### PR TITLE
feat/TS-updates-itay: Updated types

### DIFF
--- a/packages/cdk/src/index.d.ts
+++ b/packages/cdk/src/index.d.ts
@@ -51,6 +51,7 @@ declare module "@jaypie/cdk" {
     BUILD: {
       CONFIG: CDKBuildConfig;
       PERSONAL: string;
+      STATIC: string;
     };
     CREATION: {
       CDK: string;
@@ -145,10 +146,7 @@ declare module "@jaypie/cdk" {
   export function cfnOutput(params: CfnOutputParams): boolean;
   export function isValidHostname(hostname: string): boolean;
   export function isValidSubdomain(subdomain: string): boolean;
-  export function mergeDomain(params: {
-    subdomain: string;
-    domain: string;
-  }): string;
+  export function mergeDomain(subdomain: string, domain: string): string;
   export function projectTagger(params: {
     cdk?: typeof import("aws-cdk-lib");
     stack?: import("aws-cdk-lib").Stack;

--- a/packages/express/index.d.ts
+++ b/packages/express/index.d.ts
@@ -10,7 +10,7 @@ export const EXPRESS: {
 };
 
 export interface CorsConfig {
-  origins?: string | string[];
+  origin?: string | string[];
   overrides?: Record<string, unknown>;
 }
 


### PR DESCRIPTION
- Updated the CORS origin array from `origins` to `origin` as [expected by the code](https://github.com/finlaysonstudio/jaypie/blob/main/packages/express/src/cors.helper.js#L85)
- Updated the type definition of the `mergeDomain` function since [it takes two params](https://github.com/finlaysonstudio/jaypie/blob/main/packages/cdk/src/mergeDomain.function.js#L4) instead of an object
- Added the missing `STATIC` type to the `CDK.BUILD` object