### PR TITLE
fix(shepherd): use merge instead of squash

### DIFF
--- a/.claude/commands/shepherd.md
+++ b/.claude/commands/shepherd.md
@@ -4,7 +4,7 @@ Guide the Jaypie merge process.
 
 1. Run a clean NPM Check workflow
 2. Create PR
-3. Merge once checks pass
+3. Merge once checks pass (use `--merge`, not `--squash`)
 4. Run a clean NPM Deploy workflow
 
 ## Clean NPM Check


### PR DESCRIPTION
## Summary

- Update shepherd workflow to use `--merge` instead of `--squash`
- Preserves micro commit history when merging PRs

## Test plan

- [x] NPM Check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)