### PR TITLE
docs(llm): document explain mode for tool calling transparency

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/skills/llm.md
+++ b/packages/mcp/skills/llm.md
@@ -142,6 +142,27 @@ const greetTool = fabricLlmTool(greetService);
 const toolkit = new Toolkit([greetTool]);
 ```
 
+### Explain Mode
+
+Explain mode adds transparency to tool calling by requiring the LLM to state its reasoning when invoking tools.
+
+```typescript
+// Enable via Toolkit constructor
+const toolkit = new Toolkit([myTool], { explain: true });
+
+// Or via operate options
+const response = await Llm.operate("What's the weather?", {
+  model: "gpt-5.1",
+  tools: myTools,
+  explain: true,
+});
+```
+
+When enabled:
+- Each tool receives an `__Explanation` parameter requiring the model to state why it's calling the tool
+- The explanation is stripped before the tool executes (tools receive clean arguments)
+- Useful for debugging and understanding LLM decision-making
+
 ## Structured Output
 
 ### Natural Schema

--- a/stacks/documentation/docs/packages/llm.md
+++ b/stacks/documentation/docs/packages/llm.md
@@ -191,6 +191,27 @@ const toolkit = new Toolkit([
 ]);
 ```
 
+### Explain Mode
+
+Explain mode adds transparency to tool calling by requiring the LLM to state its reasoning when invoking tools.
+
+```typescript
+// Enable via Toolkit constructor
+const toolkit = new Toolkit([myTool], { explain: true });
+
+// Or via operate options
+const response = await Llm.operate("What's the weather?", {
+  model: "gpt-5.1",
+  tools: myTools,
+  explain: true,
+});
+```
+
+When enabled:
+- Each tool receives an `__Explanation` parameter requiring the model to state why it's calling the tool
+- The explanation is stripped before the tool executes (tools receive clean arguments)
+- Useful for debugging and understanding LLM decision-making
+
 ## Structured Output
 
 ### JSON Schema


### PR DESCRIPTION
## Summary

- Add documentation for the `explain` mode feature in `@jaypie/llm` Toolkit
- Document how explain mode adds an `__Explanation` parameter to tool calls
- Show how to enable via Toolkit constructor or operate options
- Explain behavior (explanation stripped before tool execution)

## Changes

- `packages/mcp/skills/llm.md` - Add "Explain Mode" section under Tool Calling
- `stacks/documentation/docs/packages/llm.md` - Add "Explain Mode" section under Toolkit
- `packages/mcp/package.json` - Bump version 0.6.3 → 0.6.4

## Test plan

- [x] `npm run typecheck -w packages/mcp` passes
- [x] `npm run build -w packages/mcp` passes
- [x] `npm test -w packages/mcp` passes (68 tests)
- [x] `npm run format packages/mcp` passes
- [x] NPM Check CI workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)