### PR TITLE
fix(ci): include JaypieGardenData in manual deploy workflow

### DIFF
--- a/.github/workflows/deploy-stacks.yml
+++ b/.github/workflows/deploy-stacks.yml
@@ -22,7 +22,9 @@ on:
           - JaypieDocumentation
           - JaypieGardenApi
           - JaypieGardenNextjs
+          - JaypieGardenData
           - JaypieGardenApi JaypieGardenNextjs
+          - JaypieGardenData JaypieGardenApi JaypieGardenNextjs
       custom_stacks:
         description: 'Custom stack list (overrides above if provided)'
         required: false
@@ -49,7 +51,7 @@ jobs:
           if [ -n "${{ github.event.inputs.custom_stacks }}" ]; then
             STACKS="${{ github.event.inputs.custom_stacks }}"
           elif [ "${{ github.event.inputs.stacks }}" == "all" ]; then
-            STACKS="JaypieDocumentation JaypieGardenApi JaypieGardenNextjs"
+            STACKS="JaypieDocumentation JaypieGardenData JaypieGardenApi JaypieGardenNextjs"
           else
             STACKS="${{ github.event.inputs.stacks }}"
           fi


### PR DESCRIPTION
## Summary
- Added `JaypieGardenData` to the "all" stacks list in the manual deploy workflow
- Added `JaypieGardenData` and `JaypieGardenData JaypieGardenApi JaypieGardenNextjs` as dropdown options
- Prevents fresh deploys from skipping the DynamoDB table, which broke the `/status` endpoint

## Test plan
- [x] Deployed `JaypieGardenData` to development via `custom_stacks` — table created, `/status` endpoint working

🤖 Generated with [Claude Code](https://claude.com/claude-code)