### PR TITLE
fix: add missing security headers to JaypieDistribution (#193)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30803,7 +30803,7 @@
     },
     "packages/constructs": {
       "name": "@jaypie/constructs",
-      "version": "1.2.30",
+      "version": "1.2.31",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*",
@@ -31704,7 +31704,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.7.22",
+      "version": "0.7.23",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "*",

--- a/packages/constructs/CLAUDE.md
+++ b/packages/constructs/CLAUDE.md
@@ -171,7 +171,7 @@ new JaypieDistribution(this, "Distribution", {
 
 `JaypieDistribution` ships with default security response headers (analogous to `helmet` for Express). Headers are applied via a `ResponseHeadersPolicy` attached to the auto-generated default behavior.
 
-**Default headers**: HSTS, X-Content-Type-Options (nosniff), X-Frame-Options (DENY), Referrer-Policy, Content-Security-Policy, Permissions-Policy, Cross-Origin-Opener-Policy, Cross-Origin-Resource-Policy, Server removal.
+**Default headers**: Cache-Control, HSTS, X-Content-Type-Options (nosniff), X-Frame-Options (DENY), Referrer-Policy, Content-Security-Policy, Permissions-Policy, Cross-Origin-Embedder-Policy, Cross-Origin-Opener-Policy, Cross-Origin-Resource-Policy, Server removal.
 
 ```typescript
 // Defaults enabled (no config needed)

--- a/packages/constructs/package.json
+++ b/packages/constructs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/constructs",
-  "version": "1.2.30",
+  "version": "1.2.31",
   "description": "CDK constructs for Jaypie applications",
   "repository": {
     "type": "git",

--- a/packages/constructs/src/JaypieDistribution.ts
+++ b/packages/constructs/src/JaypieDistribution.ts
@@ -269,6 +269,16 @@ export class JaypieDistribution
           customHeadersBehavior: {
             customHeaders: [
               {
+                header: "Cache-Control",
+                override: true,
+                value: "no-store, no-cache, must-revalidate, proxy-revalidate",
+              },
+              {
+                header: "Cross-Origin-Embedder-Policy",
+                override: true,
+                value: "unsafe-none",
+              },
+              {
                 header: "Cross-Origin-Opener-Policy",
                 override: true,
                 value: "same-origin",

--- a/packages/constructs/src/__tests__/JaypieDistribution.spec.ts
+++ b/packages/constructs/src/__tests__/JaypieDistribution.spec.ts
@@ -1047,6 +1047,56 @@ describe("JaypieDistribution", () => {
       });
     });
 
+    it("sets Cache-Control custom header", () => {
+      const stack = new Stack();
+      const bucket = new s3.Bucket(stack, "TestBucket");
+      const origin = origins.S3BucketOrigin.withOriginAccessControl(bucket);
+
+      new JaypieDistribution(stack, "TestDistribution", {
+        handler: origin,
+      });
+      const template = Template.fromStack(stack);
+
+      template.hasResourceProperties("AWS::CloudFront::ResponseHeadersPolicy", {
+        ResponseHeadersPolicyConfig: {
+          CustomHeadersConfig: {
+            Items: Match.arrayWith([
+              Match.objectLike({
+                Header: "Cache-Control",
+                Override: true,
+                Value: "no-store, no-cache, must-revalidate, proxy-revalidate",
+              }),
+            ]),
+          },
+        },
+      });
+    });
+
+    it("sets Cross-Origin-Embedder-Policy custom header", () => {
+      const stack = new Stack();
+      const bucket = new s3.Bucket(stack, "TestBucket");
+      const origin = origins.S3BucketOrigin.withOriginAccessControl(bucket);
+
+      new JaypieDistribution(stack, "TestDistribution", {
+        handler: origin,
+      });
+      const template = Template.fromStack(stack);
+
+      template.hasResourceProperties("AWS::CloudFront::ResponseHeadersPolicy", {
+        ResponseHeadersPolicyConfig: {
+          CustomHeadersConfig: {
+            Items: Match.arrayWith([
+              Match.objectLike({
+                Header: "Cross-Origin-Embedder-Policy",
+                Override: true,
+                Value: "unsafe-none",
+              }),
+            ]),
+          },
+        },
+      });
+    });
+
     it("sets Cross-Origin-Opener-Policy custom header", () => {
       const stack = new Stack();
       const bucket = new s3.Bucket(stack, "TestBucket");

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.7.22",
+  "version": "0.7.23",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/constructs/1.2.31.md
+++ b/packages/mcp/release-notes/constructs/1.2.31.md
@@ -1,0 +1,11 @@
+---
+version: 1.2.31
+date: 2026-02-18
+summary: Add Cache-Control and Cross-Origin-Embedder-Policy security headers to JaypieDistribution
+---
+
+# @jaypie/constructs 1.2.31
+
+## Fixes
+
+- **JaypieDistribution**: Added `Cache-Control` (`no-store, no-cache, must-revalidate, proxy-revalidate`) and `Cross-Origin-Embedder-Policy` (`unsafe-none`) to the default security response headers, resolving ZAP baseline scan warnings [90004], [10015], and [10049].

--- a/packages/mcp/skills/cdk.md
+++ b/packages/mcp/skills/cdk.md
@@ -173,12 +173,14 @@ new JaypieNextJs(this, "App", {
 
 `JaypieDistribution` ships with default security response headers via a `ResponseHeadersPolicy` (analogous to `helmet` for Express):
 
+- Cache-Control (no-store, no-cache, must-revalidate, proxy-revalidate)
 - HSTS (2-year max-age, includeSubDomains, preload)
 - X-Content-Type-Options (nosniff)
 - X-Frame-Options (DENY)
 - Referrer-Policy (strict-origin-when-cross-origin)
 - Content-Security-Policy (conservative defaults)
 - Permissions-Policy (camera, microphone, geolocation, payment disabled)
+- Cross-Origin-Embedder-Policy (unsafe-none)
 - Cross-Origin-Opener-Policy (same-origin)
 - Cross-Origin-Resource-Policy (same-origin)
 - Server header removed


### PR DESCRIPTION
## Summary
- Adds `Cache-Control` and `Cross-Origin-Embedder-Policy` to `JaypieDistribution` default security response headers
- Resolves ZAP baseline scan warnings [90004], [10015], and [10049]
- Bumps `@jaypie/constructs` to 1.2.31, `@jaypie/mcp` to 0.7.23

## Test plan
- [x] Typecheck passes
- [x] All 417 tests pass (62 in JaypieDistribution, including 2 new)
- [x] Build succeeds
- [ ] CI passes

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)