### PR TITLE
ci: remove openrouter from LLM client tests

### DIFF
--- a/.github/workflows/npm-check.yml
+++ b/.github/workflows/npm-check.yml
@@ -102,9 +102,8 @@ jobs:
         if: steps.changes.outputs.llm == 'true'
         run: LOG_LEVEL=trace npm run test:llm:all
         env:
-          APP_PROVIDER: anthropic,google,openai,openrouter,xai
+          APP_PROVIDER: anthropic,google,openai,xai
           ANTHROPIC_API_KEY: ${{ secrets.CICD_ANTHROPIC_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.CICD_GEMINI_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.CICD_OPENAI_API_KEY }}
-          OPENROUTER_API_KEY: ${{ secrets.CICD_OPENROUTER_API_KEY }}
           XAI_API_KEY: ${{ secrets.CICD_XAI_API_KEY }}


### PR DESCRIPTION
## Summary
- Remove OpenRouter from `APP_PROVIDER` in `npm-check.yml` LLM client tests
- OpenRouter frequently returns plain text instead of structured tool-call results, causing flaky CI

## Test plan
- [x] Verify `npm-deploy.yml` already excludes OpenRouter (confirmed)
- [x] Only CI config change, no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)