### PR TITLE
fix: update jaypie subpackage dependency versions

### DIFF
--- a/.claude/skills/prepare/SKILL.md
+++ b/.claude/skills/prepare/SKILL.md
@@ -9,6 +9,8 @@ description: Prepare a release by committing, versioning, updating docs and skil
 
 2. **Version** edited packages. Patch any edited subpackages without version changes. If a `jaypie` dependency is versioned, bump `jaypie` too. If `@jaypie/mcp` skills or release-notes change, patch `@jaypie/mcp`.
 
+   ⚠️ **CRITICAL: Update `packages/jaypie/package.json` dependency versions** — When bumping any `@jaypie/*` subpackage, update the corresponding version range in `packages/jaypie/package.json` dependencies to match the new version (e.g., `"^1.2.1"` → `"^1.2.4"`). Failure to do this means consumers of `jaypie` won't pull the latest subpackage versions.
+
 3. **Documentation and Skills** -- update anything impacted:
    - README.md (top-level)
    - CLAUDE.md (top- and package-level)

--- a/package-lock.json
+++ b/package-lock.json
@@ -33423,17 +33423,17 @@
       }
     },
     "packages/jaypie": {
-      "version": "1.2.20",
+      "version": "1.2.21",
       "license": "MIT",
       "dependencies": {
-        "@jaypie/aws": "^1.2.4",
+        "@jaypie/aws": "^1.2.5",
         "@jaypie/core": "^1.2.1",
         "@jaypie/datadog": "^1.2.2",
         "@jaypie/errors": "^1.2.1",
-        "@jaypie/express": "^1.2.11",
-        "@jaypie/kit": "^1.2.1",
-        "@jaypie/lambda": "^1.2.3",
-        "@jaypie/logger": "^1.2.1"
+        "@jaypie/express": "^1.2.15",
+        "@jaypie/kit": "^1.2.4",
+        "@jaypie/lambda": "^1.2.4",
+        "@jaypie/logger": "^1.2.5"
       },
       "devDependencies": {
         "@jaypie/types": "^0.1.7",
@@ -33687,7 +33687,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.7.36",
+      "version": "0.7.37",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "*",

--- a/packages/jaypie/package.json
+++ b/packages/jaypie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jaypie",
-  "version": "1.2.20",
+  "version": "1.2.21",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"
@@ -32,14 +32,14 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@jaypie/aws": "^1.2.4",
+    "@jaypie/aws": "^1.2.5",
     "@jaypie/core": "^1.2.1",
     "@jaypie/datadog": "^1.2.2",
     "@jaypie/errors": "^1.2.1",
-    "@jaypie/express": "^1.2.11",
-    "@jaypie/kit": "^1.2.1",
-    "@jaypie/lambda": "^1.2.3",
-    "@jaypie/logger": "^1.2.1"
+    "@jaypie/express": "^1.2.15",
+    "@jaypie/kit": "^1.2.4",
+    "@jaypie/lambda": "^1.2.4",
+    "@jaypie/logger": "^1.2.5"
   },
   "devDependencies": {
     "@jaypie/types": "^0.1.7",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.7.36",
+  "version": "0.7.37",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/jaypie/1.2.21.md
+++ b/packages/mcp/release-notes/jaypie/1.2.21.md
@@ -1,0 +1,15 @@
+---
+version: 1.2.21
+date: 2026-03-13
+summary: Update internal dependency versions to latest published subpackages
+---
+
+## Changes
+
+- Updated dependency version ranges to match latest published subpackages:
+  - `@jaypie/aws` ^1.2.4 → ^1.2.5
+  - `@jaypie/express` ^1.2.11 → ^1.2.15
+  - `@jaypie/kit` ^1.2.1 → ^1.2.4
+  - `@jaypie/lambda` ^1.2.3 → ^1.2.4
+  - `@jaypie/logger` ^1.2.1 → ^1.2.5
+- Ensures consumers get latest subpackage features (e.g., `generateJaypieKey` seed support)

--- a/packages/mcp/release-notes/mcp/0.7.37.md
+++ b/packages/mcp/release-notes/mcp/0.7.37.md
@@ -1,0 +1,10 @@
+---
+version: 0.7.37
+date: 2026-03-13
+summary: Add critical reminder to prepare skill about updating jaypie dependency versions
+---
+
+## Changes
+
+- Updated prepare skill to emphasize updating `packages/jaypie/package.json` dependency versions when bumping subpackages
+- Added release notes for jaypie 1.2.21


### PR DESCRIPTION
## Summary
- Updated `packages/jaypie/package.json` dependency ranges to match latest published subpackage versions (aws, express, kit, lambda, logger)
- Consumers were not pulling latest subpackages (e.g., `@jaypie/kit` 1.2.4 with `generateJaypieKey` seed support)
- Added critical reminder to `/prepare` skill to prevent recurrence

## Test plan
- [x] CI passes (lint, typecheck, unit tests on Node 22/24/25)

🤖 Generated with [Claude Code](https://claude.com/claude-code)