### PR TITLE
fix: pin @jaypie/* deps in mcp package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33687,12 +33687,12 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.7.40",
+      "version": "0.7.41",
       "license": "MIT",
       "dependencies": {
-        "@jaypie/fabric": "*",
-        "@jaypie/llm": "*",
-        "@jaypie/tildeskill": "*",
+        "@jaypie/fabric": "^0.2.2",
+        "@jaypie/llm": "^1.2.18",
+        "@jaypie/tildeskill": "^0.2.0",
         "@modelcontextprotocol/sdk": "^1.17.0",
         "commander": "^14.0.0",
         "gray-matter": "^4.0.3",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.7.40",
+  "version": "0.7.41",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",
@@ -39,9 +39,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@jaypie/fabric": "*",
-    "@jaypie/llm": "*",
-    "@jaypie/tildeskill": "*",
+    "@jaypie/fabric": "^0.2.2",
+    "@jaypie/llm": "^1.2.18",
+    "@jaypie/tildeskill": "^0.2.0",
     "@modelcontextprotocol/sdk": "^1.17.0",
     "commander": "^14.0.0",
     "gray-matter": "^4.0.3",

--- a/packages/mcp/release-notes/mcp/0.7.41.md
+++ b/packages/mcp/release-notes/mcp/0.7.41.md
@@ -1,0 +1,10 @@
+---
+version: 0.7.41
+date: 2026-03-18
+summary: Pin @jaypie/* dependency versions to prevent stale resolution with npx
+---
+
+## Changes
+
+- Pin `@jaypie/fabric`, `@jaypie/llm`, and `@jaypie/tildeskill` dependencies from `*` to `^current` version ranges
+- Fixes MCP server startup crash when `npx -y @jaypie/mcp` resolves an older cached `@jaypie/llm` missing newer provider constants


### PR DESCRIPTION
## Summary

- Pin `@jaypie/fabric`, `@jaypie/llm`, `@jaypie/tildeskill` from `*` to `^version` ranges
- Fixes MCP server startup crash when `npx -y @jaypie/mcp` resolves stale cached `@jaypie/llm` missing newer provider constants (e.g., `LLM.PROVIDER.XAI.MODEL.SMALL`)

## Test plan

- [x] MCP tests pass (74 tests)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)