### PR TITLE
fix: remove always-auth from setup-node@v6 in npm-deploy

### DIFF
--- a/.github/workflows/npm-deploy.yml
+++ b/.github/workflows/npm-deploy.yml
@@ -27,7 +27,6 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          always-auth: false
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci


### PR DESCRIPTION
## Summary

- Remove deprecated `always-auth` input from `actions/setup-node@v6` in npm-deploy workflow
- This was causing the NPM Deploy to fail on publish step after merging PR #234

## Test plan

- [x] NPM Check CI passing
- [ ] Re-run NPM Deploy after merge to verify publish succeeds


🤖 Generated with [Claude Code](https://claude.com/claude-code)