### PR TITLE
fix(logger): rename JSON log field to level

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33605,7 +33605,7 @@
     },
     "packages/logger": {
       "name": "@jaypie/logger",
-      "version": "1.2.6",
+      "version": "1.2.7",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-typescript": "^12.1.2",
@@ -33670,7 +33670,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.2",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/logger",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Logger utilities for Jaypie applications",
   "repository": {
     "type": "git",

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -23,7 +23,7 @@ interface LoggerOptions {
 interface LogJson {
   data?: unknown;
   dataType?: string;
-  log: string;
+  level: string;
   message: string;
   var?: string;
   [key: string]: unknown;
@@ -86,7 +86,7 @@ class Logger {
           const message = stringify(...sanitized);
           const parses = parsesTo(message);
           const json: LogJson = {
-            log: logLevel,
+            level: logLevel,
             message,
             ...this.tags,
           };
@@ -138,7 +138,7 @@ class Logger {
         const json: LogJson = {
           data: parse(messageVal),
           dataType: typeof messageVal,
-          log: logLevel,
+          level: logLevel,
           message: stringify(messageVal),
           var: messageKey,
           ...this.tags,

--- a/packages/logger/src/__tests__/datadogTransport.spec.ts
+++ b/packages/logger/src/__tests__/datadogTransport.spec.ts
@@ -184,11 +184,11 @@ describe("datadogTransport", () => {
       expect(body[0].message).toBe("Creating evaluation");
     });
 
-    it("excludes 'log' field from entry (level is in status)", () => {
+    it("excludes 'level' field from entry (level is in status)", () => {
       const transport = getDatadogTransport()!;
       transport.send(
         JSON.stringify({
-          log: "trace",
+          level: "trace",
           message: "Creating evaluation",
           project: "garden",
         }),
@@ -196,14 +196,14 @@ describe("datadogTransport", () => {
       );
       transport.flush();
       const body = lastWrittenBody() as any[];
-      expect(body[0]).not.toHaveProperty("log");
+      expect(body[0]).not.toHaveProperty("level");
     });
 
     it("spreads extra JSON fields as top-level attributes", () => {
       const transport = getDatadogTransport()!;
       transport.send(
         JSON.stringify({
-          log: "info",
+          level: "info",
           message: "User login",
           project: "garden",
           requestId: "abc-123",
@@ -226,7 +226,7 @@ describe("datadogTransport", () => {
 
     it("falls back to full JSON string when message field is missing", () => {
       const transport = getDatadogTransport()!;
-      const line = JSON.stringify({ log: "info", data: "some data" });
+      const line = JSON.stringify({ level: "info", data: "some data" });
       transport.send(line, "info");
       transport.flush();
       const body = lastWrittenBody() as any[];
@@ -248,7 +248,7 @@ describe("datadogTransport", () => {
 
     it("sends correct payload structure", () => {
       const transport = getDatadogTransport()!;
-      transport.send('{"log":"info","message":"hello"}', "info");
+      transport.send('{"level":"info","message":"hello"}', "info");
       transport.flush();
 
       expect(request).toHaveBeenCalledWith(

--- a/packages/logger/src/__tests__/index.spec.ts
+++ b/packages/logger/src/__tests__/index.spec.ts
@@ -129,7 +129,7 @@ describe("@jaypie/logger", () => {
         logger.trace("Handling Discord interaction", { type: 1 });
 
         expect(debugSpy).toHaveBeenCalledWith(
-          '{"log":"trace","message":"Handling Discord interaction {\\"type\\":1}"}',
+          '{"level":"trace","message":"Handling Discord interaction {\\"type\\":1}"}',
         );
       });
     });

--- a/packages/logger/src/datadogTransport.ts
+++ b/packages/logger/src/datadogTransport.ts
@@ -95,7 +95,7 @@ class DatadogLogTransport {
         if (parsed && typeof parsed === "object") {
           if (parsed.message) {
             message = parsed.message;
-            const { log: _, message: __, ...rest } = parsed;
+            const { level: _, message: __, ...rest } = parsed;
             extra = rest;
           }
         }

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/logger/1.2.7.md
+++ b/packages/mcp/release-notes/logger/1.2.7.md
@@ -1,0 +1,24 @@
+---
+version: 1.2.7
+date: 2026-03-27
+summary: Rename JSON log field from "log" to "level" to fix Datadog CloudWatch collision
+---
+
+## Changes
+
+- Renamed `"log"` field to `"level"` in JSON output to prevent Datadog Forwarder from interpreting the log level as the message content
+- Updated DatadogTransport to strip `"level"` instead of `"log"` when forwarding
+- Closes #250
+
+## Migration
+
+JSON output changes from:
+```json
+{"log":"debug","message":"hello"}
+```
+to:
+```json
+{"level":"debug","message":"hello"}
+```
+
+Any log parsing rules that match on the `"log"` field should be updated to match `"level"`.

--- a/workspaces/documentation/docs/core/logging.md
+++ b/workspaces/documentation/docs/core/logging.md
@@ -46,7 +46,7 @@ Use `log.var()` for structured key-value logging:
 log.var({ userId: "abc-123" });
 
 // Output:
-// { "log": "trace", "message": "abc-123", "var": "userId", "data": "abc-123", "dataType": "string" }
+// { "level": "trace", "message": "abc-123", "var": "userId", "data": "abc-123", "dataType": "string" }
 ```
 
 Variable logging is available at all levels:

--- a/workspaces/documentation/docs/packages/logger.md
+++ b/workspaces/documentation/docs/packages/logger.md
@@ -175,7 +175,7 @@ Outputs:
 
 ```json
 {
-  "log": "info",
+  "level": "info",
   "message": "Server started",
   "invoke": "abc-123",
   "timestamp": "2024-01-15T10:30:00.000Z"


### PR DESCRIPTION
## Summary
- Rename `"log"` field to `"level"` in JSON output to prevent Datadog Forwarder from interpreting log level as message content on the CloudWatch path
- Update DatadogTransport to strip `"level"` instead of `"log"`
- Update documentation examples

## Versions
| Package | Version |
|---------|---------|
| `@jaypie/logger` | 1.2.7 |
| `@jaypie/mcp` | 0.8.4 |

Closes #250

## Test plan
- [x] All 68 logger tests pass with updated field name
- [x] Typecheck clean
- [x] Documentation updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)