### PR TITLE
fix(logger): extract useful data from opaque objects in .var()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28429,7 +28429,7 @@
       "license": "MIT"
     },
     "packages/jaypie": {
-      "version": "1.2.30",
+      "version": "1.2.31",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "^1.2.7",
@@ -28439,7 +28439,7 @@
         "@jaypie/express": "^1.2.18",
         "@jaypie/kit": "^1.2.6",
         "@jaypie/lambda": "^1.2.4",
-        "@jaypie/logger": "^1.2.11"
+        "@jaypie/logger": "^1.2.12"
       },
       "devDependencies": {
         "@jaypie/types": "^0.1.7",
@@ -28617,7 +28617,7 @@
     },
     "packages/logger": {
       "name": "@jaypie/logger",
-      "version": "1.2.11",
+      "version": "1.2.12",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-typescript": "^12.1.2",
@@ -28682,7 +28682,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.19",
+      "version": "0.8.20",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.2",

--- a/packages/jaypie/package.json
+++ b/packages/jaypie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jaypie",
-  "version": "1.2.30",
+  "version": "1.2.31",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"
@@ -39,7 +39,7 @@
     "@jaypie/express": "^1.2.18",
     "@jaypie/kit": "^1.2.6",
     "@jaypie/lambda": "^1.2.4",
-    "@jaypie/logger": "^1.2.11"
+    "@jaypie/logger": "^1.2.12"
   },
   "devDependencies": {
     "@jaypie/types": "^0.1.7",

--- a/packages/logger/CLAUDE.md
+++ b/packages/logger/CLAUDE.md
@@ -83,9 +83,18 @@ log.debug.var({ userId: "123" });
 
 ### Pipelines
 
-Special handling for common objects (`src/pipelines.ts`):
-- **Axios responses**: Strips circular references, keeps data/status/headers
-- **Errors**: Extracts message, name, stack, and Jaypie error properties
+Two-tier filtering system in `src/pipelines.ts`:
+
+**Key-based pipelines** (match on var key name):
+- **Axios responses** (key: `"response"`): Strips `config`/`request`, keeps `data`/`status`/`headers`/`statusText`
+
+**Type-based filters** (run on any key, match on value shape via `filterByType`):
+- **Fetch Response**: Extracts `ok`, `status`, `statusText`, `headers`, `url`, `redirected`, `type`
+- **Errors**: Extracts `message`, `name`, `stack`, and Jaypie error properties (`isProjectError`, `title`, `detail`, `status`)
+
+**Generic opaque fallback** (catches any class instance where `JSON.stringify` returns `{}`):
+- Map-like objects (`Headers`, `URLSearchParams`, `FormData`): converted via `.entries()`
+- Other opaque objects: walks prototype chain to read getters, includes `_type` constructor name
 
 ### Tagging
 

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/logger",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "description": "Logger utilities for Jaypie applications",
   "repository": {
     "type": "git",

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -6,6 +6,7 @@ import {
   LEVEL_VALUES,
   PSEUDO_LEVELS,
 } from "./constants";
+import { filterByType, pipelines } from "./pipelines";
 import { sanitizeAuth } from "./sanitizeAuth";
 import { forceString, out, parse, parsesTo, stringify } from "./utils";
 
@@ -154,7 +155,14 @@ class Logger {
 
       if (format === FORMAT.JSON) {
         const messageKey = keys[0];
-        const messageVal = msgObj[messageKey];
+        let messageVal = msgObj[messageKey];
+
+        for (const pipeline of pipelines) {
+          if (messageKey === pipeline.key) {
+            messageVal = pipeline.filter(messageVal);
+          }
+        }
+        messageVal = filterByType(messageVal);
 
         const json: LogJson = {
           data: parse(messageVal),

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -35,9 +35,7 @@ type LogMethod = {
   var: (messageObject: unknown, messageValue?: unknown) => void;
 };
 
-function resolveLevelField(
-  value?: boolean | string,
-): false | string {
+function resolveLevelField(value?: boolean | string): false | string {
   if (value === undefined) {
     const env = process.env.LOG_LEVEL_FIELD;
     if (env === undefined || env === "") return false;

--- a/packages/logger/src/__tests__/index.spec.ts
+++ b/packages/logger/src/__tests__/index.spec.ts
@@ -235,12 +235,8 @@ describe("@jaypie/logger", () => {
         const debugSpy = vi
           .spyOn(console, "debug")
           .mockImplementation(() => {});
-        const infoSpy = vi
-          .spyOn(console, "info")
-          .mockImplementation(() => {});
-        const warnSpy = vi
-          .spyOn(console, "warn")
-          .mockImplementation(() => {});
+        const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
         const errorSpy = vi
           .spyOn(console, "error")
           .mockImplementation(() => {});

--- a/packages/logger/src/logVar.ts
+++ b/packages/logger/src/logVar.ts
@@ -1,5 +1,5 @@
 import { forceVar } from "./forceVar";
-import { pipelines } from "./pipelines";
+import { filterByType, pipelines } from "./pipelines";
 
 function keyValueToArray(keyValue: Record<string, unknown>): [string, unknown] {
   const key = Object.keys(keyValue)[0];
@@ -14,6 +14,7 @@ export function logVar(key: unknown, value?: unknown): Record<string, unknown> {
       v = pipeline.filter(v);
     }
   }
+  v = filterByType(v);
 
   return { [k]: v };
 }

--- a/packages/logger/src/pipelines.ts
+++ b/packages/logger/src/pipelines.ts
@@ -156,10 +156,7 @@ function isOpaqueObject(value: unknown): boolean {
     return false;
   }
   // Plain objects are fine
-  if (
-    value.constructor === Object ||
-    value.constructor === undefined
-  ) {
+  if (value.constructor === Object || value.constructor === undefined) {
     return false;
   }
   // If JSON.stringify produces "{}" the object has no own enumerable properties

--- a/packages/logger/src/pipelines.ts
+++ b/packages/logger/src/pipelines.ts
@@ -3,6 +3,10 @@ interface Pipeline {
   filter: (value: unknown) => unknown;
 }
 
+//
+// Key-based pipelines (match on var key name)
+//
+
 function isAxiosResponse(response: unknown): boolean {
   if (typeof response !== "object" || response === null) {
     return false;
@@ -41,25 +45,82 @@ export const axiosResponseVarPipeline: Pipeline = {
   key: "response",
 };
 
-function isError(item: unknown): boolean {
-  if (typeof item !== "object" || item === null) {
+export const pipelines = [axiosResponseVarPipeline];
+
+//
+// Type-based filters (run on any key, match on value shape)
+//
+
+interface TypeFilter {
+  detect: (value: unknown) => boolean;
+  filter: (value: unknown) => unknown;
+}
+
+// Fetch Response
+
+function isFetchResponse(value: unknown): boolean {
+  if (typeof value !== "object" || value === null) {
     return false;
   }
-  if (item instanceof Error) {
+  const r = value as Record<string, unknown>;
+  return !!(
+    typeof r.ok === "boolean" &&
+    typeof r.status === "number" &&
+    typeof r.statusText === "string" &&
+    "headers" in r &&
+    "body" in r &&
+    typeof r.url === "string" &&
+    !("config" in r) &&
+    !("request" in r)
+  );
+}
+
+function headersToObject(headers: unknown): Record<string, string> | unknown {
+  if (
+    headers &&
+    typeof headers === "object" &&
+    typeof (headers as Record<string, unknown>).entries === "function"
+  ) {
+    const result: Record<string, string> = {};
+    for (const [key, value] of (headers as Headers).entries()) {
+      result[key] = value;
+    }
+    return result;
+  }
+  return headers;
+}
+
+function filterFetchResponse(value: unknown): unknown {
+  const r = value as Record<string, unknown>;
+  return {
+    headers: headersToObject(r.headers),
+    ok: r.ok,
+    redirected: r.redirected,
+    status: r.status,
+    statusText: r.statusText,
+    type: r.type,
+    url: r.url,
+  };
+}
+
+// Error
+
+function isError(value: unknown): boolean {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  if (value instanceof Error) {
     return true;
   }
-  const i = item as Record<string, unknown>;
+  const i = value as Record<string, unknown>;
   if (i.isProjectError) {
     return true;
   }
   return false;
 }
 
-function filterErrorVar(item: unknown): unknown {
-  if (!isError(item)) {
-    return item;
-  }
-  const e = item as Error & Record<string, unknown>;
+function filterError(value: unknown): unknown {
+  const e = value as Error & Record<string, unknown>;
   const newItem: Record<string, unknown> = {
     message: e.message,
     name: e.name,
@@ -79,9 +140,138 @@ function filterErrorVar(item: unknown): unknown {
   return newItem;
 }
 
+// Type filter registry (order matters — first match wins)
+
+const typeFilters: TypeFilter[] = [
+  { detect: isFetchResponse, filter: filterFetchResponse },
+  { detect: isError, filter: filterError },
+];
+
+//
+// Opaque object detection and generic extraction
+//
+
+function isOpaqueObject(value: unknown): boolean {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  // Plain objects are fine
+  if (
+    value.constructor === Object ||
+    value.constructor === undefined
+  ) {
+    return false;
+  }
+  // If JSON.stringify produces "{}" the object has no own enumerable properties
+  // and will log as useless "[object Type]"
+  try {
+    const json = JSON.stringify(value);
+    return json === "{}" || json === "[]";
+  } catch {
+    return true;
+  }
+}
+
+function extractOpaqueObject(value: unknown): Record<string, unknown> {
+  const obj = value as object;
+  const result: Record<string, unknown> = {};
+
+  const ctorName = obj.constructor?.name;
+  if (ctorName && ctorName !== "Object") {
+    result._type = ctorName;
+  }
+
+  // If the object itself is map-like (Headers, URLSearchParams, FormData, etc.),
+  // convert its entries directly
+  const mapLike = obj as Record<string, unknown>;
+  if (
+    typeof mapLike.entries === "function" &&
+    typeof mapLike.forEach === "function"
+  ) {
+    try {
+      const entries = Object.fromEntries(
+        (mapLike as { entries: () => Iterable<[string, unknown]> }).entries(),
+      );
+      return { ...result, ...entries };
+    } catch {
+      // Fall through to generic extraction
+    }
+  }
+
+  // Collect readable non-function properties from the prototype chain
+  let proto: object | null = obj;
+  while (proto && proto !== Object.prototype) {
+    for (const key of Object.getOwnPropertyNames(proto)) {
+      if (key === "constructor" || key in result) {
+        continue;
+      }
+      try {
+        const desc = Object.getOwnPropertyDescriptor(proto, key);
+        if (!desc) continue;
+        // Read getters and value properties from the original object
+        const val = (obj as Record<string, unknown>)[key];
+        if (typeof val === "function" || typeof val === "symbol") {
+          continue;
+        }
+        // Skip streams and other non-serializable objects
+        if (
+          val &&
+          typeof val === "object" &&
+          typeof (val as Record<string, unknown>).pipe === "function"
+        ) {
+          continue;
+        }
+        // Convert iterable map-like objects (Headers, URLSearchParams, etc.)
+        if (
+          val &&
+          typeof val === "object" &&
+          typeof (val as Record<string, unknown>).entries === "function" &&
+          typeof (val as Record<string, unknown>).forEach === "function"
+        ) {
+          result[key] = Object.fromEntries(
+            (val as { entries: () => Iterable<[string, unknown]> }).entries(),
+          );
+          continue;
+        }
+        result[key] = val;
+      } catch {
+        // Property threw on access — skip
+      }
+    }
+    proto = Object.getPrototypeOf(proto);
+  }
+
+  return result;
+}
+
+//
+// Public API
+//
+
+/**
+ * Filter a value by type, regardless of var key name.
+ * Tries known type filters first, then falls back to generic
+ * opaque object extraction for anything that would log as [object Type].
+ */
+export function filterByType(value: unknown): unknown {
+  // Try known type filters
+  for (const tf of typeFilters) {
+    if (tf.detect(value)) {
+      return tf.filter(value);
+    }
+  }
+  // Generic fallback for opaque objects
+  if (isOpaqueObject(value)) {
+    return extractOpaqueObject(value);
+  }
+  return value;
+}
+
+// Legacy exports for key-based pipeline (axios only now)
 export const errorVarPipeline: Pipeline = {
-  filter: filterErrorVar,
+  filter: (item: unknown) => {
+    if (!isError(item)) return item;
+    return filterError(item);
+  },
   key: "error",
 };
-
-export const pipelines = [axiosResponseVarPipeline, errorVarPipeline];

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.19",
+  "version": "0.8.20",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/logger/1.2.12.md
+++ b/packages/mcp/release-notes/logger/1.2.12.md
@@ -1,0 +1,15 @@
+---
+version: 1.2.12
+date: 2026-04-08
+summary: Extract useful data from opaque objects (Response, Headers, etc.) in .var() logging
+---
+
+## Changes
+
+- Type-based filters now run on any var key, not just `"response"` or `"error"` — `log.var({ errorResponse: resp })` now works
+- Added fetch `Response` detection: extracts `ok`, `status`, `statusText`, `headers`, `url`, `redirected`, `type`
+- Error detection now works with any key (e.g., `{ lastError: new Error() }`)
+- Generic fallback for opaque objects (classes where `JSON.stringify` returns `{}`):
+  - Map-like objects (`Headers`, `URLSearchParams`, `FormData`) converted via `.entries()`
+  - Other opaque objects: walks prototype chain to read getters, skips functions and streams
+- Base `Logger` class now applies pipelines (previously only `JaypieLogger` did)


### PR DESCRIPTION
## Summary

- Type-based filters now run on any var key, not just `"response"`/`"error"` — e.g. `log.var({ errorResponse: resp })` works
- Added fetch `Response` detection: extracts `ok`, `status`, `statusText`, `headers`, `url`, `redirected`, `type`
- Generic fallback for opaque objects (classes where `JSON.stringify` → `{}`): walks prototype chain, converts map-like objects (`Headers`, `URLSearchParams`) via `.entries()`
- Base `Logger` class now applies pipelines (previously only `JaypieLogger` did)
- Bumps: `@jaypie/logger@1.2.12`, `jaypie@1.2.31`, `@jaypie/mcp@0.8.20`

## Test plan

- [x] All 80 logger tests pass
- [x] Verified fetch Response, Error, Headers, URLSearchParams, URL, axios response, and plain objects all produce useful output
- [x] Typecheck, build, test, format green for logger, jaypie, mcp

🤖 Generated with [Claude Code](https://claude.com/claude-code)