### PR TITLE
feat(logger): redact X-Service-Key and X-Webhook-Token

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28429,7 +28429,7 @@
       "license": "MIT"
     },
     "packages/jaypie": {
-      "version": "1.2.33",
+      "version": "1.2.34",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "^1.2.7",
@@ -28439,7 +28439,7 @@
         "@jaypie/express": "^1.2.20",
         "@jaypie/kit": "^1.2.6",
         "@jaypie/lambda": "^1.2.5",
-        "@jaypie/logger": "^1.2.13"
+        "@jaypie/logger": "^1.2.14"
       },
       "devDependencies": {
         "@jaypie/types": "^0.1.7",
@@ -28617,7 +28617,7 @@
     },
     "packages/logger": {
       "name": "@jaypie/logger",
-      "version": "1.2.13",
+      "version": "1.2.14",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-typescript": "^12.1.2",
@@ -28682,7 +28682,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.24",
+      "version": "0.8.25",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.4",

--- a/packages/jaypie/package.json
+++ b/packages/jaypie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jaypie",
-  "version": "1.2.33",
+  "version": "1.2.34",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"
@@ -39,7 +39,7 @@
     "@jaypie/express": "^1.2.20",
     "@jaypie/kit": "^1.2.6",
     "@jaypie/lambda": "^1.2.5",
-    "@jaypie/logger": "^1.2.13"
+    "@jaypie/logger": "^1.2.14"
   },
   "devDependencies": {
     "@jaypie/types": "^0.1.7",

--- a/packages/kit/src/lib/http.lib.ts
+++ b/packages/kit/src/lib/http.lib.ts
@@ -80,6 +80,7 @@ const HTTP = {
       SESSION: "X-Project-Session",
       VERSION: "X-Project-Version",
     },
+    SERVICE_KEY: "X-Service-Key",
     SIGNATURE: {
       ED25519: "X-Signature-Ed25519",
       TIMESTAMP: "X-Signature-Timestamp",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/logger",
-  "version": "1.2.13",
+  "version": "1.2.14",
   "description": "Logger utilities for Jaypie applications",
   "repository": {
     "type": "git",

--- a/packages/logger/src/__tests__/sanitizeAuth.spec.ts
+++ b/packages/logger/src/__tests__/sanitizeAuth.spec.ts
@@ -99,5 +99,58 @@ describe("sanitizeAuth", () => {
       const obj = { headers: { "content-type": "application/json" } };
       expect(sanitizeAuth(obj)).toBe(obj);
     });
+
+    it("redacts top-level X-Service-Key (case-insensitive)", () => {
+      const obj = { "X-Service-Key": "sk-proj-abc1234" };
+      const result = sanitizeAuth(obj) as Record<string, unknown>;
+      expect(result["X-Service-Key"]).toBe("sk_1234");
+    });
+
+    it("redacts top-level X-Webhook-Token (case-insensitive)", () => {
+      const obj = { "x-webhook-token": "sk-proj-abc1234" };
+      const result = sanitizeAuth(obj) as Record<string, unknown>;
+      expect(result["x-webhook-token"]).toBe("sk_1234");
+    });
+
+    it("redacts nested headers X-Service-Key and X-Webhook-Token", () => {
+      const obj = {
+        headers: {
+          "X-Service-Key": "sk-proj-service1234",
+          "X-Webhook-Token": "sk-proj-webhook1234",
+          "content-type": "application/json",
+        },
+      };
+      const result = sanitizeAuth(obj) as Record<
+        string,
+        Record<string, unknown>
+      >;
+      expect(result.headers["X-Service-Key"]).toBe("sk_1234");
+      expect(result.headers["X-Webhook-Token"]).toBe("sk_1234");
+      expect(result.headers["content-type"]).toBe("application/json");
+    });
+
+    it("redacts authorization alongside service key and webhook token in headers", () => {
+      const obj = {
+        headers: {
+          Authorization: "Bearer sk-proj-auth1234",
+          "x-service-key": "Bearer sk-proj-service1234",
+          "X-Webhook-Token": "Bearer sk-proj-webhook1234",
+        },
+      };
+      const result = sanitizeAuth(obj) as Record<
+        string,
+        Record<string, unknown>
+      >;
+      expect(result.headers.Authorization).toBe("sk_1234");
+      expect(result.headers["x-service-key"]).toBe("sk_1234");
+      expect(result.headers["X-Webhook-Token"]).toBe("sk_1234");
+    });
+
+    it("does not mutate nested headers when redacting service key", () => {
+      const headers = { "X-Service-Key": "sk-proj-abc1234" };
+      const obj = { headers };
+      sanitizeAuth(obj);
+      expect(headers["X-Service-Key"]).toBe("sk-proj-abc1234");
+    });
   });
 });

--- a/packages/logger/src/sanitizeAuth.ts
+++ b/packages/logger/src/sanitizeAuth.ts
@@ -19,6 +19,12 @@ export function redactAuth(value: unknown): string {
 // Main
 //
 
+const REDACTED_KEYS = new Set([
+  "authorization",
+  "x-service-key",
+  "x-webhook-token",
+]);
+
 export function sanitizeAuth(value: unknown): unknown {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     return value;
@@ -30,7 +36,7 @@ export function sanitizeAuth(value: unknown): unknown {
   for (const key of Object.keys(obj)) {
     const lower = key.toLowerCase();
 
-    if (lower === "authorization") {
+    if (REDACTED_KEYS.has(lower)) {
       if (!clone) clone = { ...obj };
       clone[key] = redactAuth(obj[key]);
     } else if (lower === "headers") {
@@ -41,14 +47,16 @@ export function sanitizeAuth(value: unknown): unknown {
         !Array.isArray(headers)
       ) {
         const hdrs = headers as Record<string, unknown>;
+        let clonedHeaders: Record<string, unknown> | undefined;
         for (const hKey of Object.keys(hdrs)) {
-          if (hKey.toLowerCase() === "authorization") {
-            if (!clone) clone = { ...obj };
-            const clonedHeaders = { ...hdrs };
+          if (REDACTED_KEYS.has(hKey.toLowerCase())) {
+            if (!clonedHeaders) clonedHeaders = { ...hdrs };
             clonedHeaders[hKey] = redactAuth(hdrs[hKey]);
-            clone[key] = clonedHeaders;
-            break;
           }
+        }
+        if (clonedHeaders) {
+          if (!clone) clone = { ...obj };
+          clone[key] = clonedHeaders;
         }
       }
     }

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.24",
+  "version": "0.8.25",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/logger/1.2.14.md
+++ b/packages/mcp/release-notes/logger/1.2.14.md
@@ -1,0 +1,10 @@
+---
+version: 1.2.14
+date: 2026-04-10
+summary: Redact X-Service-Key and X-Webhook-Token headers in sanitizeAuth
+---
+
+## Changes
+
+- `sanitizeAuth` now also redacts `X-Service-Key` and `X-Webhook-Token` headers (case-insensitive)
+- Applies at top-level keys and inside nested `headers` objects, alongside the existing `Authorization` handling


### PR DESCRIPTION
## Summary
- `sanitizeAuth` now redacts `X-Service-Key` and `X-Webhook-Token` headers (case-insensitive) at top-level and inside nested `headers` objects, alongside the existing `Authorization` handling
- Bumps `@jaypie/logger` 1.2.14, `jaypie` 1.2.34, `@jaypie/mcp` 0.8.25
- Also includes a small `chore: config: constants` for `packages/kit/src/lib/http.lib.ts`

## Test plan
- [x] `npm run test -w packages/logger` (85 passing, 5 new sanitizeAuth tests)
- [x] `npm run typecheck` for logger / jaypie / mcp
- [x] NPM Check CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)