### PR TITLE
feat(tildeskill): createSkillService factory for reusable skill lookup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6750,7 +6750,6 @@
     },
     "node_modules/@microsoft/api-extractor": {
       "version": "7.57.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@microsoft/api-extractor-model": "7.33.4",
@@ -6783,7 +6782,6 @@
     },
     "node_modules/@microsoft/api-extractor/node_modules/balanced-match": {
       "version": "4.0.4",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
@@ -6791,7 +6789,6 @@
     },
     "node_modules/@microsoft/api-extractor/node_modules/brace-expansion": {
       "version": "5.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -6802,7 +6799,6 @@
     },
     "node_modules/@microsoft/api-extractor/node_modules/lru-cache": {
       "version": "6.0.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -6813,7 +6809,6 @@
     },
     "node_modules/@microsoft/api-extractor/node_modules/minimatch": {
       "version": "10.2.3",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.2"
@@ -6827,7 +6822,6 @@
     },
     "node_modules/@microsoft/api-extractor/node_modules/semver": {
       "version": "7.5.4",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -6841,7 +6835,6 @@
     },
     "node_modules/@microsoft/api-extractor/node_modules/typescript": {
       "version": "5.8.2",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -6853,7 +6846,6 @@
     },
     "node_modules/@microsoft/api-extractor/node_modules/yallist": {
       "version": "4.0.0",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/@microsoft/tsdoc": {
@@ -8239,7 +8231,6 @@
     },
     "node_modules/@rushstack/rig-package": {
       "version": "0.7.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve": "~1.22.1",
@@ -12291,9 +12282,8 @@
     },
     "node_modules/commander": {
       "version": "12.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13387,7 +13377,6 @@
     },
     "node_modules/diff": {
       "version": "8.0.3",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -28710,11 +28699,11 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.28",
+      "version": "0.8.29",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.4",
-        "@jaypie/tildeskill": "^0.3.0",
+        "@jaypie/tildeskill": "^0.3.1",
         "@modelcontextprotocol/sdk": "^1.17.0",
         "commander": "^14.0.0",
         "gray-matter": "^4.0.3",
@@ -29117,7 +29106,7 @@
     },
     "packages/testkit": {
       "name": "@jaypie/testkit",
-      "version": "1.2.31",
+      "version": "1.2.32",
       "license": "MIT",
       "dependencies": {
         "jest-extended": "^4.0.2",
@@ -29226,10 +29215,11 @@
     },
     "packages/tildeskill": {
       "name": "@jaypie/tildeskill",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*",
+        "@jaypie/fabric": "*",
         "gray-matter": "^4.0.3"
       },
       "devDependencies": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.28",
+  "version": "0.8.29",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@jaypie/fabric": "^0.2.4",
-    "@jaypie/tildeskill": "^0.3.0",
+    "@jaypie/tildeskill": "^0.3.1",
     "@modelcontextprotocol/sdk": "^1.17.0",
     "commander": "^14.0.0",
     "gray-matter": "^4.0.3",

--- a/packages/mcp/release-notes/mcp/0.8.29.md
+++ b/packages/mcp/release-notes/mcp/0.8.29.md
@@ -1,0 +1,13 @@
+---
+version: 0.8.29
+date: 2026-04-12
+summary: Delegate skill service to @jaypie/tildeskill createSkillService
+---
+
+## Changes
+
+- Replace inline `skillService` with `createSkillService(skillStore)` from `@jaypie/tildeskill`
+- Skill lookups now automatically expand includes
+- Plural/singular fallback annotates with `<!-- resolved: -->` HTML comment instead of injecting frontmatter
+- Remove raw file reading, `addAliasToFrontmatter`, `formatSkillListItem`, and `skillLayerPaths` from MCP
+- Bump `@jaypie/tildeskill` dependency to `^0.3.1`

--- a/packages/mcp/release-notes/testkit/1.2.32.md
+++ b/packages/mcp/release-notes/testkit/1.2.32.md
@@ -1,0 +1,9 @@
+---
+version: 1.2.32
+date: 2026-04-12
+summary: Add createSkillService mock for tildeskill parity
+---
+
+## Changes
+
+- Add `createSkillService` mock to tildeskill mock module

--- a/packages/mcp/release-notes/tildeskill/0.3.1.md
+++ b/packages/mcp/release-notes/tildeskill/0.3.1.md
@@ -1,0 +1,12 @@
+---
+version: 0.3.1
+date: 2026-04-12
+summary: Add createSkillService factory for reusable skill lookup as a fabricService
+---
+
+## Changes
+
+- Add `createSkillService(store)` factory that returns a `fabricService` wrapping any `SkillStore`
+- The service handles index listing, alias validation, `find()` with plural/singular fallback, and automatic `expandIncludes`
+- Compatible with `fabricTool()` for `Llm.operate` toolkits and `suite.register()` for MCP servers
+- Add `@jaypie/fabric` as a dependency (lightweight; only requires `@jaypie/errors`)

--- a/packages/mcp/skills/tildeskill.md
+++ b/packages/mcp/skills/tildeskill.md
@@ -87,6 +87,27 @@ const store = createMemoryStore([
 const skill = await store.get("test");
 ```
 
+## Skill Service Factory
+
+```typescript
+import { createSkillService, createMemoryStore } from "@jaypie/tildeskill";
+
+const store = createMemoryStore([
+  { alias: "aws", content: "# AWS docs", description: "AWS guide" },
+]);
+
+// Returns a fabricService — works with MCP, Llm.operate, or direct calls
+const skillService = createSkillService(store);
+
+await skillService({ alias: "aws" }); // → skill content (with expandIncludes)
+await skillService({ alias: "index" }); // → formatted listing
+await skillService(); // → same as "index"
+
+// Use with fabricTool for Llm.operate toolkits
+import { fabricTool } from "@jaypie/fabric/llm";
+const { tool } = fabricTool({ service: skillService });
+```
+
 ## Include Expansion
 
 ```typescript

--- a/packages/mcp/src/suites/docs/index.ts
+++ b/packages/mcp/src/suites/docs/index.ts
@@ -5,10 +5,8 @@ import { fabricService } from "@jaypie/fabric";
 import {
   createLayeredStore,
   createMarkdownStore,
-  isValidAlias,
+  createSkillService,
   type LayeredStoreLayer,
-  normalizeAlias,
-  type SkillRecord,
 } from "@jaypie/tildeskill";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
@@ -45,21 +43,18 @@ const LAYER_SEPARATOR = ":";
 // the built-in Jaypie skill pack so `skill("aws")` prefers the client's copy
 // while still exposing bundled Jaypie docs under the `jaypie:` namespace.
 const skillLayers: LayeredStoreLayer[] = [];
-const skillLayerPaths = new Map<string, string>();
 
 if (process.env.MCP_SKILLS_PATH) {
   skillLayers.push({
     namespace: LOCAL_SKILLS_NAMESPACE,
     store: createMarkdownStore({ path: process.env.MCP_SKILLS_PATH }),
   });
-  skillLayerPaths.set(LOCAL_SKILLS_NAMESPACE, process.env.MCP_SKILLS_PATH);
 }
 
 skillLayers.push({
   namespace: JAYPIE_SKILLS_NAMESPACE,
   store: createMarkdownStore({ path: BUILTIN_SKILLS_PATH }),
 });
-skillLayerPaths.set(JAYPIE_SKILLS_NAMESPACE, BUILTIN_SKILLS_PATH);
 
 const skillStore = createLayeredStore({
   layers: skillLayers,
@@ -122,14 +117,6 @@ function formatReleaseNoteListItem(note: {
   }
 
   return parts.join(" ");
-}
-
-function formatSkillListItem(skill: SkillRecord): string {
-  const { alias, description } = skill;
-  if (description) {
-    return `* ${alias} - ${description}`;
-  }
-  return `* ${alias}`;
 }
 
 async function getPackageReleaseNotes(packageName: string): Promise<
@@ -196,92 +183,7 @@ function filterReleaseNotesSince(
 // SKILL SERVICE
 // =============================================================================
 
-/**
- * Add alias to frontmatter indicating the canonical skill name
- */
-function addAliasToFrontmatter(content: string, matchedAlias: string): string {
-  if (content.startsWith("---")) {
-    // Find the end of frontmatter
-    const endIndex = content.indexOf("---", 3);
-    if (endIndex !== -1) {
-      // Insert alias before the closing ---
-      const beforeClose = content.slice(0, endIndex);
-      const afterClose = content.slice(endIndex);
-      return `${beforeClose}alias: ${matchedAlias}\n${afterClose}`;
-    }
-  }
-  // No frontmatter exists, create one
-  return `---\nalias: ${matchedAlias}\n---\n\n${content}`;
-}
-
-export const skillService = fabricService({
-  alias: "skill",
-  description:
-    "Access Jaypie development documentation. Pass a skill alias (e.g., 'aws', 'tests', 'errors') to get that documentation. Pass 'index' or no argument to list all available skills.",
-  input: {
-    alias: {
-      description:
-        "Skill alias (e.g., 'aws', 'tests'). Omit or use 'index' to list all skills.",
-      required: false,
-      type: String,
-    },
-  },
-  service: async ({ alias: inputAlias }: { alias?: string }) => {
-    const alias = normalizeAlias(inputAlias || "index");
-
-    if (!isValidAlias(alias)) {
-      throw new Error(
-        `Invalid skill alias "${alias}". Use alphanumeric characters, hyphens, and underscores only.`,
-      );
-    }
-
-    if (alias === "index") {
-      const allSkills = await skillStore.list();
-      // Index entries from every layer hide per-layer "index" records.
-      const skills = allSkills.filter(
-        (s: { alias: string }) =>
-          s.alias !== "index" && !s.alias.endsWith(`${LAYER_SEPARATOR}index`),
-      );
-      const skillList = skills.map(formatSkillListItem).join("\n");
-
-      return `# Index of Skills\n\n${skillList}`;
-    }
-
-    const skill = await skillStore.find(alias);
-
-    if (!skill) {
-      throw new Error(
-        `Skill "${alias}" not found. Use skill("index") to list available skills.`,
-      );
-    }
-
-    // Split the namespaced alias the layered store returned (e.g., "local:aws")
-    // so we can read the raw markdown file from the correct layer directory.
-    const separatorIdx = skill.alias.indexOf(LAYER_SEPARATOR);
-    const layerNamespace =
-      separatorIdx === -1 ? "" : skill.alias.slice(0, separatorIdx);
-    const innerAlias =
-      separatorIdx === -1 ? skill.alias : skill.alias.slice(separatorIdx + 1);
-    const layerPath = skillLayerPaths.get(layerNamespace);
-    if (!layerPath) {
-      // Defensive: layered store returned a layer we don't know the path for.
-      return skill.content;
-    }
-
-    const skillPath = path.join(layerPath, `${innerAlias}.md`);
-    let content = await fs.readFile(skillPath, "utf-8");
-
-    // Detect plural/singular fallback so we can annotate the canonical alias.
-    const inputSeparatorIdx = alias.indexOf(LAYER_SEPARATOR);
-    const inputInnerAlias =
-      inputSeparatorIdx === -1 ? alias : alias.slice(inputSeparatorIdx + 1);
-    if (innerAlias !== inputInnerAlias) {
-      content = addAliasToFrontmatter(content, skill.alias);
-    }
-
-    return content;
-  },
-});
+export const skillService = createSkillService(skillStore);
 
 // =============================================================================
 // VERSION SERVICE

--- a/packages/testkit/package.json
+++ b/packages/testkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/testkit",
-  "version": "1.2.31",
+  "version": "1.2.32",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"

--- a/packages/testkit/src/mock/tildeskill.ts
+++ b/packages/testkit/src/mock/tildeskill.ts
@@ -53,10 +53,10 @@ function createMockStore(): SkillStore {
 export const createLayeredStore = createMockFunction(() => createMockStore());
 export const createSkillService = createMockFunction(() => {
   const service = createMockResolvedFunction("# Mock Skill Content");
-  (service as Record<string, unknown>).$fabric = "mock";
-  (service as Record<string, unknown>).alias = "skill";
-  (service as Record<string, unknown>).description = "Mock skill service";
-  (service as Record<string, unknown>).input = {
+  (service as unknown as Record<string, unknown>).$fabric = "mock";
+  (service as unknown as Record<string, unknown>).alias = "skill";
+  (service as unknown as Record<string, unknown>).description = "Mock skill service";
+  (service as unknown as Record<string, unknown>).input = {
     alias: { description: "Skill alias", required: false, type: String },
   };
   return service;

--- a/packages/testkit/src/mock/tildeskill.ts
+++ b/packages/testkit/src/mock/tildeskill.ts
@@ -51,6 +51,16 @@ function createMockStore(): SkillStore {
 }
 
 export const createLayeredStore = createMockFunction(() => createMockStore());
+export const createSkillService = createMockFunction(() => {
+  const service = createMockResolvedFunction("# Mock Skill Content");
+  (service as Record<string, unknown>).$fabric = "mock";
+  (service as Record<string, unknown>).alias = "skill";
+  (service as Record<string, unknown>).description = "Mock skill service";
+  (service as Record<string, unknown>).input = {
+    alias: { description: "Skill alias", required: false, type: String },
+  };
+  return service;
+});
 export const createMarkdownStore = createMockFunction(() => createMockStore());
 export const createMemoryStore = createMockFunction(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/tildeskill/CLAUDE.md
+++ b/packages/tildeskill/CLAUDE.md
@@ -35,6 +35,7 @@ packages/tildeskill/
 │   ├── stores/              # Storage backends
 │   │   ├── markdown.ts      # createMarkdownStore
 │   │   └── memory.ts        # createMemoryStore
+│   ├── service.ts           # createSkillService factory
 │   ├── types.ts             # TypeScript interfaces
 │   └── index.ts             # Main exports
 └── dist/                    # Built output
@@ -101,6 +102,36 @@ const layered = createLayeredStore({
   ],
 });
 ```
+
+### Skill Service Factory
+
+```typescript
+import { createSkillService, createMemoryStore } from "@jaypie/tildeskill";
+
+const store = createMemoryStore([
+  { alias: "aws", content: "# AWS\n\nAWS docs", description: "AWS guide" },
+]);
+
+// Returns a fabricService compatible with MCP and Llm.operate toolkits
+const skillService = createSkillService(store);
+
+// Get skill content
+const content = await skillService({ alias: "aws" });
+
+// List all skills
+const index = await skillService({ alias: "index" });
+// or: await skillService()
+
+// Use with fabricTool for Llm.operate
+import { fabricTool } from "@jaypie/fabric/llm";
+const { tool } = fabricTool({ service: skillService });
+```
+
+Features:
+- Automatic `expandIncludes` on every lookup
+- Plural/singular fallback via `find()` with `<!-- resolved: -->` annotation
+- Index listing filters out `"index"` entries
+- Works with any `SkillStore` (memory, markdown, layered)
 
 ### Include Expansion
 

--- a/packages/tildeskill/package.json
+++ b/packages/tildeskill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/tildeskill",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Skill/vocabulary management with pluggable storage backends",
   "repository": {
     "type": "git",
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "@jaypie/errors": "*",
+    "@jaypie/fabric": "*",
     "gray-matter": "^4.0.3"
   },
   "devDependencies": {

--- a/packages/tildeskill/src/__tests__/index.spec.ts
+++ b/packages/tildeskill/src/__tests__/index.spec.ts
@@ -4,6 +4,7 @@ import {
   createLayeredStore,
   createMarkdownStore,
   createMemoryStore,
+  createSkillService,
   getAlternativeSpellings,
   isValidAlias,
   normalizeAlias,
@@ -49,6 +50,14 @@ describe("@jaypie/tildeskill exports", () => {
   it("exports getAlternativeSpellings", () => {
     expect(typeof getAlternativeSpellings).toBe("function");
     expect(getAlternativeSpellings("skills")).toEqual(["skill"]);
+  });
+
+  it("exports createSkillService", () => {
+    expect(typeof createSkillService).toBe("function");
+    const store = createMemoryStore();
+    const service = createSkillService(store);
+    expect(service).toHaveProperty("$fabric");
+    expect(service.alias).toBe("skill");
   });
 
   it("exports createLayeredStore", () => {

--- a/packages/tildeskill/src/__tests__/service.spec.ts
+++ b/packages/tildeskill/src/__tests__/service.spec.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest";
+
+import { createSkillService } from "../service";
+import { createLayeredStore } from "../stores/layered";
+import { createMemoryStore } from "../stores/memory";
+
+describe("createSkillService", () => {
+  describe("returns a fabricService", () => {
+    it("has $fabric property", () => {
+      const store = createMemoryStore();
+      const service = createSkillService(store);
+      expect(service).toHaveProperty("$fabric");
+    });
+
+    it("has alias 'skill'", () => {
+      const store = createMemoryStore();
+      const service = createSkillService(store);
+      expect(service.alias).toBe("skill");
+    });
+
+    it("has description and input", () => {
+      const store = createMemoryStore();
+      const service = createSkillService(store);
+      expect(service.description).toBeDefined();
+      expect(service.input).toBeDefined();
+    });
+  });
+
+  describe("index listing", () => {
+    it("returns index when called with no alias", async () => {
+      const store = createMemoryStore([
+        { alias: "aws", content: "# AWS", description: "AWS docs" },
+        { alias: "tests", content: "# Tests", description: "Testing guide" },
+      ]);
+      const service = createSkillService(store);
+      const result = await service();
+      expect(result).toContain("# Index of Skills");
+      expect(result).toContain("aws - AWS docs");
+      expect(result).toContain("tests - Testing guide");
+    });
+
+    it("returns index when alias is 'index'", async () => {
+      const store = createMemoryStore([
+        { alias: "aws", content: "# AWS", description: "AWS docs" },
+      ]);
+      const service = createSkillService(store);
+      const result = await service({ alias: "index" });
+      expect(result).toContain("# Index of Skills");
+      expect(result).toContain("aws");
+    });
+
+    it("filters out bare 'index' entry", async () => {
+      const store = createMemoryStore([
+        { alias: "index", content: "# Index", description: "Index" },
+        { alias: "aws", content: "# AWS", description: "AWS docs" },
+      ]);
+      const service = createSkillService(store);
+      const result = await service({ alias: "index" });
+      expect(result).toContain("aws");
+      expect(result).not.toContain("* index");
+    });
+
+    it("filters out namespaced ':index' entries", async () => {
+      const local = createMemoryStore([
+        { alias: "index", content: "# Local Index" },
+        { alias: "aws", content: "# AWS", description: "AWS docs" },
+      ]);
+      const jaypie = createMemoryStore([
+        { alias: "index", content: "# Jaypie Index" },
+        { alias: "tests", content: "# Tests", description: "Testing" },
+      ]);
+      const layered = createLayeredStore({
+        layers: [
+          { namespace: "local", store: local },
+          { namespace: "jaypie", store: jaypie },
+        ],
+      });
+      const service = createSkillService(layered);
+      const result = await service({ alias: "index" });
+      expect(result).toContain("local:aws");
+      expect(result).toContain("jaypie:tests");
+      expect(result).not.toContain(":index");
+    });
+
+    it("lists skills without descriptions", async () => {
+      const store = createMemoryStore([{ alias: "aws", content: "# AWS" }]);
+      const service = createSkillService(store);
+      const result = await service({ alias: "index" });
+      expect(result).toContain("* aws");
+    });
+  });
+
+  describe("get skill", () => {
+    it("returns skill content by alias", async () => {
+      const store = createMemoryStore([
+        { alias: "aws", content: "# AWS\n\nAWS documentation content" },
+      ]);
+      const service = createSkillService(store);
+      const result = await service({ alias: "aws" });
+      expect(result).toBe("# AWS\n\nAWS documentation content");
+    });
+
+    it("throws when skill not found", async () => {
+      const store = createMemoryStore();
+      const service = createSkillService(store);
+      await expect(service({ alias: "missing" })).rejects.toThrow(/not found/);
+    });
+
+    it("throws on invalid alias", async () => {
+      const store = createMemoryStore();
+      const service = createSkillService(store);
+      await expect(service({ alias: "../../etc" })).rejects.toThrow(/invalid/i);
+    });
+  });
+
+  describe("expandIncludes", () => {
+    it("expands includes in returned content", async () => {
+      const store = createMemoryStore([
+        { alias: "base", content: "Base content" },
+        { alias: "main", content: "Main content", includes: ["base"] },
+      ]);
+      const service = createSkillService(store);
+      const result = await service({ alias: "main" });
+      expect(result).toContain("Base content");
+      expect(result).toContain("Main content");
+    });
+  });
+
+  describe("plural/singular fallback", () => {
+    it("annotates when fallback resolved a different alias", async () => {
+      const store = createMemoryStore([
+        { alias: "skill", content: "# Skill content" },
+      ]);
+      const service = createSkillService(store);
+      const result = await service({ alias: "skills" });
+      expect(result).toContain("<!-- resolved: skill -->");
+      expect(result).toContain("# Skill content");
+    });
+
+    it("does not annotate on exact match", async () => {
+      const store = createMemoryStore([
+        { alias: "skill", content: "# Skill content" },
+      ]);
+      const service = createSkillService(store);
+      const result = await service({ alias: "skill" });
+      expect(result).not.toContain("<!-- resolved:");
+      expect(result).toBe("# Skill content");
+    });
+  });
+
+  describe("layered store integration", () => {
+    it("resolves skills from layered store", async () => {
+      const local = createMemoryStore([
+        { alias: "aws", content: "# Local AWS" },
+      ]);
+      const jaypie = createMemoryStore([
+        { alias: "tests", content: "# Jaypie Tests" },
+      ]);
+      const layered = createLayeredStore({
+        layers: [
+          { namespace: "local", store: local },
+          { namespace: "jaypie", store: jaypie },
+        ],
+      });
+      const service = createSkillService(layered);
+
+      const aws = await service({ alias: "aws" });
+      expect(aws).toBe("# Local AWS");
+
+      const tests = await service({ alias: "tests" });
+      expect(tests).toBe("# Jaypie Tests");
+    });
+
+    it("resolves namespaced alias directly", async () => {
+      const local = createMemoryStore([
+        { alias: "aws", content: "# Local AWS" },
+      ]);
+      const jaypie = createMemoryStore([
+        { alias: "aws", content: "# Jaypie AWS" },
+      ]);
+      const layered = createLayeredStore({
+        layers: [
+          { namespace: "local", store: local },
+          { namespace: "jaypie", store: jaypie },
+        ],
+      });
+      const service = createSkillService(layered);
+
+      const result = await service({ alias: "jaypie:aws" });
+      expect(result).toBe("# Jaypie AWS");
+    });
+  });
+});

--- a/packages/tildeskill/src/index.ts
+++ b/packages/tildeskill/src/index.ts
@@ -9,6 +9,9 @@ export type {
   SkillStore,
 } from "./types";
 
+// Service factory
+export { createSkillService } from "./service";
+
 // Core utilities
 export { expandIncludes } from "./core/expandIncludes";
 export { normalizeAlias, parseList } from "./core/normalize";

--- a/packages/tildeskill/src/service.ts
+++ b/packages/tildeskill/src/service.ts
@@ -1,0 +1,85 @@
+import { fabricService } from "@jaypie/fabric";
+
+import { expandIncludes } from "./core/expandIncludes";
+import { normalizeAlias } from "./core/normalize";
+import { isValidAlias } from "./core/validate";
+import type { SkillRecord, SkillStore } from "./types";
+
+function formatSkillListItem(skill: SkillRecord): string {
+  if (skill.description) {
+    return `* ${skill.alias} - ${skill.description}`;
+  }
+  return `* ${skill.alias}`;
+}
+
+/**
+ * Create a fabric service that looks up skills from a SkillStore.
+ *
+ * The returned service accepts `{ alias }` input:
+ * - `"index"` or omitted → formatted listing of all skills
+ * - Any other alias → skill content via `find()` with plural/singular fallback
+ *   and automatic `expandIncludes`
+ *
+ * Compatible with `fabricTool()` for Llm.operate toolkits and
+ * `suite.register()` for MCP servers.
+ */
+export function createSkillService(store: SkillStore) {
+  return fabricService({
+    alias: "skill",
+    description:
+      "Access development documentation. Pass a skill alias to get that documentation. Pass 'index' or no argument to list all available skills.",
+    input: {
+      alias: {
+        description:
+          "Skill alias (e.g., 'aws', 'tests'). Omit or use 'index' to list all skills.",
+        required: false,
+        type: String,
+      },
+    },
+    service: async ({ alias: inputAlias }: { alias?: string }) => {
+      const alias = normalizeAlias(inputAlias || "index");
+
+      if (!isValidAlias(alias)) {
+        throw new Error(
+          `Invalid skill alias "${alias}". Use alphanumeric characters, hyphens, and underscores only.`,
+        );
+      }
+
+      if (alias === "index") {
+        const allSkills = await store.list();
+        // Filter out index entries from every layer
+        const skills = allSkills.filter(
+          (s: SkillRecord) =>
+            s.alias !== "index" && !s.alias.endsWith(":index"),
+        );
+        const skillList = skills.map(formatSkillListItem).join("\n");
+        return `# Index of Skills\n\n${skillList}`;
+      }
+
+      const skill = await store.find(alias);
+
+      if (!skill) {
+        throw new Error(
+          `Skill "${alias}" not found. Use skill("index") to list available skills.`,
+        );
+      }
+
+      // Expand includes (no-op when skill has no includes)
+      const content = await expandIncludes(store, skill);
+
+      // Detect plural/singular fallback by comparing inner aliases
+      const separatorIdx = alias.indexOf(":");
+      const inputInnerAlias =
+        separatorIdx === -1 ? alias : alias.slice(separatorIdx + 1);
+      const skillSepIdx = skill.alias.indexOf(":");
+      const skillInnerAlias =
+        skillSepIdx === -1 ? skill.alias : skill.alias.slice(skillSepIdx + 1);
+
+      if (skillInnerAlias !== inputInnerAlias) {
+        return `<!-- resolved: ${skill.alias} -->\n\n${content}`;
+      }
+
+      return content;
+    },
+  });
+}

--- a/workspaces/documentation/docs/experimental/tildeskill.md
+++ b/workspaces/documentation/docs/experimental/tildeskill.md
@@ -24,6 +24,8 @@ npm install @jaypie/tildeskill
 
 | Export | Purpose |
 |--------|---------|
+| `createSkillService` | Fabric service factory for skill lookup |
+| `createLayeredStore` | Compose multiple stores with namespace prefixes |
 | `createMarkdownStore` | File-based store (reads .md files) |
 | `createMemoryStore` | In-memory store (for testing) |
 | `expandIncludes` | Expand included skills into content |
@@ -36,8 +38,10 @@ npm install @jaypie/tildeskill
 | Type | Description |
 |------|-------------|
 | `SkillRecord` | Skill document with alias, content, description, includes, name, nicknames, related, tags |
-| `SkillStore` | Store interface with get, getByNickname, list, put, search methods |
+| `SkillStore` | Store interface with find, get, getByNickname, list, put, search methods |
 | `ListFilter` | Filter options for list (namespace, tag) |
+| `LayeredStoreLayer` | Layer definition with namespace and store |
+| `LayeredStoreOptions` | Options for createLayeredStore |
 
 ## Store Factories
 
@@ -245,51 +249,46 @@ try {
 }
 ```
 
-## Use Cases
+## Skill Service Factory
 
-### MCP Skill Server
-
-The primary use case is serving skill documentation via MCP:
+`createSkillService` wraps a `SkillStore` as a `fabricService`, compatible with MCP servers and `Llm.operate` toolkits:
 
 ```typescript
-import { createMarkdownStore } from "@jaypie/tildeskill";
-import { fabricService } from "@jaypie/fabric";
+import { createSkillService, createMarkdownStore } from "@jaypie/tildeskill";
 
 const store = createMarkdownStore({ path: "./skills" });
+const skillService = createSkillService(store);
 
-const skillService = fabricService({
-  alias: "skill",
-  description: "Get skill documentation",
-  input: {
-    alias: { type: String, required: false },
-  },
-  service: async ({ alias }) => {
-    if (!alias) {
-      const skills = await store.list();
-      return skills.map(s => `${s.alias}: ${s.description}`).join("\n");
-    }
-    const skill = await store.get(alias);
-    return skill?.content ?? `Skill "${alias}" not found`;
-  },
-});
+// Get skill content (with automatic expandIncludes)
+const content = await skillService({ alias: "aws" });
+
+// List all skills
+const index = await skillService({ alias: "index" });
+// or: await skillService()
+
+// Use with fabricTool for Llm.operate
+import { fabricTool } from "@jaypie/fabric/llm";
+const { tool } = fabricTool({ service: skillService });
 ```
 
-### Documentation System
+## Layered Stores
 
-Build a searchable documentation system:
+Compose multiple stores with namespace prefixes. Earlier layers win for single-result lookups:
 
 ```typescript
-import { createMarkdownStore } from "@jaypie/tildeskill";
+import { createLayeredStore, createMarkdownStore } from "@jaypie/tildeskill";
 
-const store = createMarkdownStore({ path: "./docs" });
+const layered = createLayeredStore({
+  layers: [
+    { namespace: "local", store: createMarkdownStore({ path: "./my-skills" }) },
+    { namespace: "jaypie", store: createMarkdownStore({ path: "./jaypie-skills" }) },
+  ],
+});
 
-async function searchDocs(query: string) {
-  const docs = await store.list();
-  return docs.filter(d =>
-    d.content.toLowerCase().includes(query.toLowerCase()) ||
-    d.description?.toLowerCase().includes(query.toLowerCase())
-  );
-}
+await layered.get("aws");          // first layer wins → { alias: "local:aws", ... }
+await layered.get("jaypie:aws");   // targets specific layer
+await layered.find("skills");      // per-layer plural/singular fallback
+await layered.list();              // all layers, prefixed aliases
 ```
 
 ## Related


### PR DESCRIPTION
## Summary

- Add `createSkillService(store)` factory in `@jaypie/tildeskill` that wraps a `SkillStore` as a `fabricService`
- Replace inline `skillService` in `@jaypie/mcp` with the new factory
- Enable skill lookup as a tool in `Llm.operate` toolkits via `fabricTool()`

## Version bumps

- `@jaypie/tildeskill` 0.3.0 → 0.3.1 (new factory, adds `@jaypie/fabric` dep)
- `@jaypie/mcp` 0.8.28 → 0.8.29 (delegates to tildeskill)
- `@jaypie/testkit` 1.2.31 → 1.2.32 (mock parity)

## Test plan

- [x] `npm run test -w packages/tildeskill` (156 passing, +16 new)
- [x] `npm run test -w packages/testkit` (293 passing)
- [x] `npm run test -w packages/mcp` (41 passing)
- [x] Typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)