### PR TITLE
fix: count unhandled handler errors in log.report; include HTTP method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28070,7 +28070,7 @@
     },
     "packages/express": {
       "name": "@jaypie/express",
-      "version": "1.2.20",
+      "version": "1.2.21",
       "license": "MIT",
       "dependencies": {
         "@jaypie/datadog": "*",
@@ -28442,17 +28442,17 @@
       "license": "MIT"
     },
     "packages/jaypie": {
-      "version": "1.2.35",
+      "version": "1.2.36",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "^1.2.7",
         "@jaypie/core": "^1.2.1",
         "@jaypie/datadog": "^1.2.2",
         "@jaypie/errors": "^1.2.1",
-        "@jaypie/express": "^1.2.20",
-        "@jaypie/kit": "^1.2.6",
+        "@jaypie/express": "^1.2.21",
+        "@jaypie/kit": "^1.2.7",
         "@jaypie/lambda": "^1.2.5",
-        "@jaypie/logger": "^1.2.14"
+        "@jaypie/logger": "^1.2.15"
       },
       "devDependencies": {
         "@jaypie/types": "^0.1.7",
@@ -28494,7 +28494,7 @@
     },
     "packages/kit": {
       "name": "@jaypie/kit",
-      "version": "1.2.6",
+      "version": "1.2.7",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*",
@@ -28634,7 +28634,7 @@
     },
     "packages/logger": {
       "name": "@jaypie/logger",
-      "version": "1.2.14",
+      "version": "1.2.15",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-typescript": "^12.1.2",
@@ -28699,7 +28699,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.29",
+      "version": "0.8.30",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.4",

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/express",
-  "version": "1.2.20",
+  "version": "1.2.21",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"

--- a/packages/express/src/expressHandler.ts
+++ b/packages/express/src/expressHandler.ts
@@ -653,7 +653,11 @@ function expressHandler<T>(
     );
 
     // Add request data to session report
-    logger.report({ path, status: String(res.statusCode) });
+    logger.report({
+      method: req.method,
+      path,
+      status: String(res.statusCode),
+    });
 
     // Submit metric if Datadog is configured
     if (hasDatadogEnv()) {

--- a/packages/express/src/expressStreamHandler.ts
+++ b/packages/express/src/expressStreamHandler.ts
@@ -428,7 +428,11 @@ function expressStreamHandler(
       );
 
       // Add request data to session report
-      logger.report({ path, status: String(res.statusCode) });
+      logger.report({
+        method: req.method,
+        path,
+        status: String(res.statusCode),
+      });
 
       // Submit metric if Datadog is configured
       if (hasDatadogEnv()) {

--- a/packages/jaypie/package.json
+++ b/packages/jaypie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jaypie",
-  "version": "1.2.35",
+  "version": "1.2.36",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"
@@ -36,10 +36,10 @@
     "@jaypie/core": "^1.2.1",
     "@jaypie/datadog": "^1.2.2",
     "@jaypie/errors": "^1.2.1",
-    "@jaypie/express": "^1.2.20",
-    "@jaypie/kit": "^1.2.6",
+    "@jaypie/express": "^1.2.21",
+    "@jaypie/kit": "^1.2.7",
     "@jaypie/lambda": "^1.2.5",
-    "@jaypie/logger": "^1.2.14"
+    "@jaypie/logger": "^1.2.15"
   },
   "devDependencies": {
     "@jaypie/types": "^0.1.7",

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/kit",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Utility functions for Jaypie applications",
   "repository": {
     "type": "git",

--- a/packages/kit/src/jaypieHandler.module.ts
+++ b/packages/kit/src/jaypieHandler.module.ts
@@ -124,8 +124,8 @@ const jaypieHandler = (
       } else {
         // otherwise, respond as unhandled
         const err = error as Error;
-        log.fatal("[handler] Caught unhandled error");
-        log.error(`[${err.name}] ${err.message}`);
+        publicLogger.fatal("[handler] Caught unhandled error");
+        publicLogger.error(`[${err.name}] ${err.message}`);
         log.var({
           unhandedError: {
             name: err.name,
@@ -165,8 +165,8 @@ const jaypieHandler = (
       } else {
         // otherwise, respond as unhandled
         const err = error as Error;
-        log.fatal("[handler] Caught unhandled error");
-        log.error(`[${err.name}] ${err.message}`);
+        publicLogger.fatal("[handler] Caught unhandled error");
+        publicLogger.error(`[${err.name}] ${err.message}`);
         log.var({
           unhandedError: {
             name: err.name,

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/logger",
-  "version": "1.2.14",
+  "version": "1.2.15",
   "description": "Logger utilities for Jaypie applications",
   "repository": {
     "type": "git",

--- a/packages/logger/src/JaypieLogger.ts
+++ b/packages/logger/src/JaypieLogger.ts
@@ -79,10 +79,14 @@ class JaypieLogger {
       this._logger.error.var(messageObject, messageValue);
     };
 
-    this.fatal = ((...args: any[]) =>
-      this._logger.fatal(...args)) as Logger["fatal"];
-    this.fatal.var = (messageObject: unknown, messageValue?: unknown) =>
+    this.fatal = ((...args: any[]) => {
+      if (this._sessionActive) this._errorCount++;
+      this._logger.fatal(...args);
+    }) as Logger["fatal"];
+    this.fatal.var = (messageObject: unknown, messageValue?: unknown) => {
+      if (this._sessionActive) this._errorCount++;
       this._logger.fatal.var(messageObject, messageValue);
+    };
 
     this.info = ((...args: any[]) =>
       this._logger.info(...args)) as Logger["info"];
@@ -149,6 +153,15 @@ class JaypieLogger {
         this.error.var = (messageObject: unknown, messageValue?: unknown) => {
           if (this._sessionActive) this._errorCount++;
           this._logger.error.var(messageObject, messageValue);
+        };
+      } else if (lvl === "fatal") {
+        this.fatal = ((...args: any[]) => {
+          if (this._sessionActive) this._errorCount++;
+          this._logger.fatal(...args);
+        }) as any;
+        this.fatal.var = (messageObject: unknown, messageValue?: unknown) => {
+          if (this._sessionActive) this._errorCount++;
+          this._logger.fatal.var(messageObject, messageValue);
         };
       } else if (lvl === "warn") {
         this.warn = ((...args: any[]) => {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.29",
+  "version": "0.8.30",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/express/1.2.21.md
+++ b/packages/mcp/release-notes/express/1.2.21.md
@@ -1,0 +1,9 @@
+---
+version: 1.2.21
+date: 2026-04-12
+summary: Include HTTP method in express session report
+---
+
+## Changes
+
+- `expressHandler` and `expressStreamHandler` now include `method` (e.g. `GET`, `POST`) alongside `path` and `status` in the `log.report` payload emitted at teardown.

--- a/packages/mcp/release-notes/jaypie/1.2.36.md
+++ b/packages/mcp/release-notes/jaypie/1.2.36.md
@@ -1,0 +1,5 @@
+---
+version: 1.2.36
+date: 2026-04-12
+summary: Pulls in kit 1.2.7, logger 1.2.15, express 1.2.21 (log.report unhandled-error fix; report includes HTTP method)
+---

--- a/packages/mcp/release-notes/kit/1.2.7.md
+++ b/packages/mcp/release-notes/kit/1.2.7.md
@@ -1,0 +1,9 @@
+---
+version: 1.2.7
+date: 2026-04-12
+summary: jaypieHandler logs unhandled errors on the root logger so log.report counts them
+---
+
+## Changes
+
+- `jaypieHandler` now logs unhandled-error `fatal`/`error` calls via the root `publicLogger` instead of a `.with()`-derived child. Child loggers maintain their own `_errorCount`, so errors logged there were invisible to `log.report` on the root. The report now reflects unhandled errors correctly.

--- a/packages/mcp/release-notes/logger/1.2.15.md
+++ b/packages/mcp/release-notes/logger/1.2.15.md
@@ -1,0 +1,9 @@
+---
+version: 1.2.15
+date: 2026-04-12
+summary: Count log.fatal toward session errorCount in log.report
+---
+
+## Changes
+
+- `log.fatal` and `log.fatal.var` now increment the session error count, matching the severity of fatal vs error. Previously only `log.error` incremented the counter, so unhandled error paths that logged `fatal` would underreport.

--- a/packages/mcp/release-notes/mcp/0.8.30.md
+++ b/packages/mcp/release-notes/mcp/0.8.30.md
@@ -1,0 +1,5 @@
+---
+version: 0.8.30
+date: 2026-04-12
+summary: Release notes for logger 1.2.15, kit 1.2.7, express 1.2.21
+---


### PR DESCRIPTION
## Summary
- `jaypieHandler` now logs unhandled `fatal`/`error` on the root logger so `log.report` sees them (child loggers from `.with()` have their own counters)
- `log.fatal` now increments session `errorCount`
- Express `log.report` payload now includes `method` alongside `path` and `status`

## Versions
- kit 1.2.6 → 1.2.7
- logger 1.2.14 → 1.2.15
- express 1.2.20 → 1.2.21
- jaypie 1.2.35 → 1.2.36
- mcp 0.8.29 → 0.8.30

## Test plan
- [x] Typecheck logger/kit/express
- [x] Unit tests logger/kit/express pass
- [x] NPM Check green

🤖 Generated with [Claude Code](https://claude.com/claude-code)