### PR TITLE
feat(dynamodb)!: replace putEntity with createEntity (#293)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -146,7 +146,6 @@
     "node_modules/@algolia/client-search": {
       "version": "5.49.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.49.2",
         "@algolia/requester-browser-xhr": "5.49.2",
@@ -281,7 +280,6 @@
         "semver"
       ],
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "jsonschema": "~1.4.1",
         "semver": "^7.7.3"
@@ -530,7 +528,6 @@
     "node_modules/@aws-sdk/client-dynamodb": {
       "version": "3.1014.0",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -1521,7 +1518,6 @@
     "node_modules/@babel/core": {
       "version": "7.29.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1901,7 +1897,7 @@
     },
     "node_modules/@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -1912,7 +1908,7 @@
     },
     "node_modules/@babel/plugin-syntax-bigint": {
       "version": "7.8.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -1923,7 +1919,7 @@
     },
     "node_modules/@babel/plugin-syntax-class-properties": {
       "version": "7.12.13",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
@@ -1934,7 +1930,7 @@
     },
     "node_modules/@babel/plugin-syntax-class-static-block": {
       "version": "7.14.5",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -1984,7 +1980,7 @@
     },
     "node_modules/@babel/plugin-syntax-import-meta": {
       "version": "7.10.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -1995,7 +1991,7 @@
     },
     "node_modules/@babel/plugin-syntax-json-strings": {
       "version": "7.8.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -2019,7 +2015,7 @@
     },
     "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
       "version": "7.10.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -2030,7 +2026,7 @@
     },
     "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
       "version": "7.8.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -2041,7 +2037,7 @@
     },
     "node_modules/@babel/plugin-syntax-numeric-separator": {
       "version": "7.10.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -2052,7 +2048,7 @@
     },
     "node_modules/@babel/plugin-syntax-object-rest-spread": {
       "version": "7.8.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -2063,7 +2059,7 @@
     },
     "node_modules/@babel/plugin-syntax-optional-catch-binding": {
       "version": "7.8.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -2074,7 +2070,7 @@
     },
     "node_modules/@babel/plugin-syntax-optional-chaining": {
       "version": "7.8.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -2085,7 +2081,7 @@
     },
     "node_modules/@babel/plugin-syntax-private-property-in-object": {
       "version": "7.14.5",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -2099,7 +2095,7 @@
     },
     "node_modules/@babel/plugin-syntax-top-level-await": {
       "version": "7.14.5",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -3158,7 +3154,7 @@
     },
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@codegenie/serverless-express": {
@@ -3273,7 +3269,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -3294,7 +3289,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3394,7 +3388,6 @@
     "node_modules/@csstools/postcss-cascade-layers/node_modules/postcss-selector-parser": {
       "version": "7.1.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -3784,7 +3777,6 @@
     "node_modules/@csstools/postcss-is-pseudo-class/node_modules/postcss-selector-parser": {
       "version": "7.1.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -4694,7 +4686,6 @@
     "node_modules/@docusaurus/plugin-content-docs": {
       "version": "3.9.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@docusaurus/core": "3.9.2",
         "@docusaurus/logger": "3.9.2",
@@ -5562,6 +5553,7 @@
     },
     "node_modules/@eslint/config-array": {
       "version": "0.21.2",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/object-schema": "^2.1.7",
@@ -5574,6 +5566,7 @@
     },
     "node_modules/@eslint/config-helpers": {
       "version": "0.4.2",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/core": "^0.17.0"
@@ -5584,6 +5577,7 @@
     },
     "node_modules/@eslint/core": {
       "version": "0.17.0",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
@@ -5594,6 +5588,7 @@
     },
     "node_modules/@eslint/eslintrc": {
       "version": "3.3.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.14.0",
@@ -5625,6 +5620,7 @@
     },
     "node_modules/@eslint/object-schema": {
       "version": "2.1.7",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5632,6 +5628,7 @@
     },
     "node_modules/@eslint/plugin-kit": {
       "version": "0.4.1",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/core": "^0.17.0",
@@ -5700,6 +5697,7 @@
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
@@ -5707,6 +5705,7 @@
     },
     "node_modules/@humanfs/node": {
       "version": "0.16.7",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@humanfs/core": "^0.19.1",
@@ -5718,6 +5717,7 @@
     },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.22"
@@ -5729,6 +5729,7 @@
     },
     "node_modules/@humanwhocodes/retry": {
       "version": "0.4.3",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18"
@@ -5782,7 +5783,7 @@
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "camelcase": "^5.3.1",
@@ -5797,7 +5798,7 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
       "version": "1.0.10",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
@@ -5805,7 +5806,7 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
       "version": "4.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
@@ -5817,7 +5818,7 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
       "version": "3.14.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -5829,7 +5830,7 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
       "version": "5.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
@@ -5840,7 +5841,7 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
       "version": "2.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
@@ -5854,7 +5855,7 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
       "version": "4.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
@@ -5865,7 +5866,7 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
       "version": "5.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5873,7 +5874,7 @@
     },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5993,7 +5994,7 @@
     },
     "node_modules/@jest/console": {
       "version": "29.7.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -6009,7 +6010,7 @@
     },
     "node_modules/@jest/core": {
       "version": "29.7.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/console": "^29.7.0",
@@ -6055,7 +6056,7 @@
     },
     "node_modules/@jest/environment": {
       "version": "29.7.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/fake-timers": "^29.7.0",
@@ -6069,7 +6070,7 @@
     },
     "node_modules/@jest/expect": {
       "version": "29.7.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "expect": "^29.7.0",
@@ -6081,7 +6082,7 @@
     },
     "node_modules/@jest/expect-utils": {
       "version": "29.7.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "jest-get-type": "^29.6.3"
@@ -6092,7 +6093,7 @@
     },
     "node_modules/@jest/fake-timers": {
       "version": "29.7.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -6108,7 +6109,7 @@
     },
     "node_modules/@jest/globals": {
       "version": "29.7.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.7.0",
@@ -6122,7 +6123,7 @@
     },
     "node_modules/@jest/reporters": {
       "version": "29.7.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
@@ -6174,7 +6175,7 @@
     },
     "node_modules/@jest/source-map": {
       "version": "29.6.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.18",
@@ -6187,7 +6188,7 @@
     },
     "node_modules/@jest/test-result": {
       "version": "29.7.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/console": "^29.7.0",
@@ -6201,7 +6202,7 @@
     },
     "node_modules/@jest/test-sequencer": {
       "version": "29.7.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/test-result": "^29.7.0",
@@ -6215,7 +6216,7 @@
     },
     "node_modules/@jest/transform": {
       "version": "29.7.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -6719,7 +6720,6 @@
     "node_modules/@mdx-js/react": {
       "version": "3.1.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdx": "^2.0.0"
       },
@@ -6883,7 +6883,6 @@
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.27.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -8134,7 +8133,7 @@
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@rushstack/node-core-library": {
@@ -8162,7 +8161,6 @@
     "node_modules/@rushstack/node-core-library/node_modules/ajv": {
       "version": "8.18.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -8315,7 +8313,7 @@
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "type-detect": "4.0.8"
@@ -8323,7 +8321,7 @@
     },
     "node_modules/@sinonjs/fake-timers": {
       "version": "10.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
@@ -9108,7 +9106,6 @@
     "node_modules/@svgr/core": {
       "version": "8.1.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -9252,7 +9249,7 @@
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.20.7",
@@ -9264,7 +9261,7 @@
     },
     "node_modules/@types/babel__generator": {
       "version": "7.27.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.0.0"
@@ -9272,7 +9269,7 @@
     },
     "node_modules/@types/babel__template": {
       "version": "7.4.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.1.0",
@@ -9281,7 +9278,7 @@
     },
     "node_modules/@types/babel__traverse": {
       "version": "7.28.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.2"
@@ -9304,7 +9301,7 @@
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/deep-eql": "*",
@@ -9348,7 +9345,7 @@
     },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/eslint": {
@@ -9416,7 +9413,7 @@
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -9480,7 +9477,7 @@
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/mdast": {
@@ -9534,7 +9531,6 @@
     "node_modules/@types/react": {
       "version": "19.2.14",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -9628,7 +9624,7 @@
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/superagent": {
@@ -9727,7 +9723,6 @@
     "node_modules/@typescript-eslint/parser": {
       "version": "8.57.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.1",
         "@typescript-eslint/types": "8.57.1",
@@ -9970,7 +9965,7 @@
     },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
@@ -9985,7 +9980,7 @@
     },
     "node_modules/@vitest/mocker": {
       "version": "3.2.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/spy": "3.2.4",
@@ -10010,7 +10005,7 @@
     },
     "node_modules/@vitest/mocker/node_modules/estree-walker": {
       "version": "3.0.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
@@ -10018,7 +10013,7 @@
     },
     "node_modules/@vitest/pretty-format": {
       "version": "3.2.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tinyrainbow": "^2.0.0"
@@ -10029,7 +10024,7 @@
     },
     "node_modules/@vitest/runner": {
       "version": "3.2.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/utils": "3.2.4",
@@ -10042,7 +10037,7 @@
     },
     "node_modules/@vitest/snapshot": {
       "version": "3.2.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/pretty-format": "3.2.4",
@@ -10055,7 +10050,7 @@
     },
     "node_modules/@vitest/spy": {
       "version": "3.2.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tinyspy": "^4.0.3"
@@ -10066,7 +10061,7 @@
     },
     "node_modules/@vitest/utils": {
       "version": "3.2.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/pretty-format": "3.2.4",
@@ -10338,7 +10333,6 @@
     "node_modules/acorn": {
       "version": "8.16.0",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -10402,7 +10396,6 @@
     "node_modules/ajv": {
       "version": "6.14.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -10457,7 +10450,6 @@
     "node_modules/algoliasearch": {
       "version": "5.49.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/abtesting": "1.15.2",
         "@algolia/client-abtesting": "5.49.2",
@@ -10586,7 +10578,7 @@
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -10605,7 +10597,7 @@
     },
     "node_modules/array-includes": {
       "version": "3.1.9",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -10652,7 +10644,7 @@
     },
     "node_modules/array.prototype.findlastindex": {
       "version": "1.2.6",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -10672,7 +10664,7 @@
     },
     "node_modules/array.prototype.flat": {
       "version": "1.3.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -10689,7 +10681,7 @@
     },
     "node_modules/array.prototype.flatmap": {
       "version": "1.3.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -10721,7 +10713,7 @@
     },
     "node_modules/arraybuffer.prototype.slice": {
       "version": "1.0.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "array-buffer-byte-length": "^1.0.1",
@@ -10758,7 +10750,7 @@
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -10778,7 +10770,7 @@
     },
     "node_modules/async-function": {
       "version": "1.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10831,7 +10823,7 @@
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
@@ -10871,7 +10863,6 @@
         "mime-types"
       ],
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "2.2.263",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
@@ -11273,7 +11264,7 @@
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/transform": "^29.7.0",
@@ -11315,7 +11306,7 @@
     },
     "node_modules/babel-plugin-istanbul": {
       "version": "6.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -11330,7 +11321,7 @@
     },
     "node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
       "version": "5.2.1",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/core": "^7.12.3",
@@ -11345,7 +11336,7 @@
     },
     "node_modules/babel-plugin-istanbul/node_modules/semver": {
       "version": "6.3.1",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -11353,7 +11344,7 @@
     },
     "node_modules/babel-plugin-jest-hoist": {
       "version": "29.6.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.3.3",
@@ -11407,7 +11398,7 @@
     },
     "node_modules/babel-preset-current-node-syntax": {
       "version": "1.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-syntax-async-generators": "^7.8.4",
@@ -11432,7 +11423,7 @@
     },
     "node_modules/babel-preset-jest": {
       "version": "29.6.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "babel-plugin-jest-hoist": "^29.6.3",
@@ -11732,7 +11723,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -11749,7 +11739,7 @@
     },
     "node_modules/bser": {
       "version": "2.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
@@ -11817,7 +11807,7 @@
     },
     "node_modules/cac": {
       "version": "6.7.14",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11904,7 +11894,7 @@
     },
     "node_modules/camelcase": {
       "version": "5.3.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -11959,7 +11949,7 @@
     },
     "node_modules/chai": {
       "version": "5.3.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "assertion-error": "^2.0.1",
@@ -12027,7 +12017,7 @@
     },
     "node_modules/check-error": {
       "version": "2.1.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 16"
@@ -12121,7 +12111,7 @@
     },
     "node_modules/cjs-module-lexer": {
       "version": "1.4.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/clean-css": {
@@ -12170,7 +12160,7 @@
     },
     "node_modules/cliui": {
       "version": "8.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -12212,7 +12202,7 @@
     },
     "node_modules/co": {
       "version": "4.6.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">= 1.0.0",
@@ -12229,7 +12219,7 @@
     },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/color-convert": {
@@ -12425,8 +12415,7 @@
     },
     "node_modules/constructs": {
       "version": "10.5.1",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -12598,7 +12587,7 @@
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -12743,7 +12732,6 @@
     "node_modules/css-has-pseudo/node_modules/postcss-selector-parser": {
       "version": "7.1.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -13041,7 +13029,7 @@
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -13057,7 +13045,7 @@
     },
     "node_modules/data-view-byte-length": {
       "version": "1.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -13073,7 +13061,7 @@
     },
     "node_modules/data-view-byte-offset": {
       "version": "1.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -13176,7 +13164,7 @@
     },
     "node_modules/dedent": {
       "version": "1.7.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "babel-plugin-macros": "^3.1.0"
@@ -13189,7 +13177,7 @@
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -13204,6 +13192,7 @@
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/deepmerge": {
@@ -13330,7 +13319,7 @@
     },
     "node_modules/detect-newline": {
       "version": "3.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -13418,7 +13407,7 @@
     },
     "node_modules/doctrine": {
       "version": "2.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "esutils": "^2.0.2"
@@ -13567,7 +13556,7 @@
     },
     "node_modules/emittery": {
       "version": "0.13.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -13652,7 +13641,6 @@
     "node_modules/env-cmd/node_modules/commander": {
       "version": "13.1.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13666,7 +13654,7 @@
     },
     "node_modules/es-abstract": {
       "version": "1.24.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "array-buffer-byte-length": "^1.0.2",
@@ -13774,7 +13762,7 @@
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
@@ -13802,7 +13790,7 @@
     },
     "node_modules/es-shim-unscopables": {
       "version": "1.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -13813,7 +13801,7 @@
     },
     "node_modules/es-to-primitive": {
       "version": "1.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.2.7",
@@ -13927,6 +13915,7 @@
     },
     "node_modules/eslint": {
       "version": "9.39.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
@@ -14088,9 +14077,8 @@
     },
     "node_modules/eslint-import-resolver-node": {
       "version": "0.3.9",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^3.2.7",
         "is-core-module": "^2.13.0",
@@ -14099,7 +14087,7 @@
     },
     "node_modules/eslint-import-resolver-node/node_modules/debug": {
       "version": "3.2.7",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
@@ -14139,7 +14127,7 @@
     },
     "node_modules/eslint-module-utils": {
       "version": "2.12.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^3.2.7"
@@ -14155,7 +14143,7 @@
     },
     "node_modules/eslint-module-utils/node_modules/debug": {
       "version": "3.2.7",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
@@ -14163,9 +14151,8 @@
     },
     "node_modules/eslint-plugin-import": {
       "version": "2.32.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -14197,7 +14184,6 @@
     "node_modules/eslint-plugin-import-x": {
       "version": "4.16.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@package-json/types": "^0.0.12",
         "@typescript-eslint/types": "^8.56.0",
@@ -14262,7 +14248,7 @@
     },
     "node_modules/eslint-plugin-import/node_modules/debug": {
       "version": "3.2.7",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
@@ -14270,7 +14256,7 @@
     },
     "node_modules/eslint-plugin-import/node_modules/semver": {
       "version": "6.3.1",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -14639,6 +14625,7 @@
     },
     "node_modules/eslint-scope": {
       "version": "8.4.0",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -14653,6 +14640,7 @@
     },
     "node_modules/eslint-visitor-keys": {
       "version": "4.2.1",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -14663,6 +14651,7 @@
     },
     "node_modules/espree": {
       "version": "10.4.0",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.15.0",
@@ -14689,6 +14678,7 @@
     },
     "node_modules/esquery": {
       "version": "1.7.0",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -14897,14 +14887,14 @@
     },
     "node_modules/exit": {
       "version": "0.1.2",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">= 0.8.0"
       }
     },
     "node_modules/expect": {
       "version": "29.7.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/expect-utils": "^29.7.0",
@@ -14919,7 +14909,7 @@
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
@@ -14928,7 +14918,6 @@
     "node_modules/express": {
       "version": "4.22.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -15071,6 +15060,7 @@
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-safe-stringify": {
@@ -15153,7 +15143,7 @@
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
@@ -15228,6 +15218,7 @@
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flat-cache": "^4.0.0"
@@ -15406,6 +15397,7 @@
     },
     "node_modules/find-up": {
       "version": "5.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
@@ -15427,6 +15419,7 @@
     },
     "node_modules/flat-cache": {
       "version": "4.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flatted": "^3.2.9",
@@ -15442,6 +15435,7 @@
     },
     "node_modules/flatted": {
       "version": "3.4.2",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
@@ -15464,7 +15458,7 @@
     },
     "node_modules/for-each": {
       "version": "0.3.5",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.2.7"
@@ -15569,7 +15563,7 @@
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
@@ -15592,7 +15586,7 @@
     },
     "node_modules/function.prototype.name": {
       "version": "1.1.8",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -15611,7 +15605,7 @@
     },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -15645,7 +15639,7 @@
     },
     "node_modules/generator-function": {
       "version": "2.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -15660,7 +15654,7 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -15694,7 +15688,7 @@
     },
     "node_modules/get-package-type": {
       "version": "0.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
@@ -15723,7 +15717,7 @@
     },
     "node_modules/get-symbol-description": {
       "version": "1.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -15760,7 +15754,7 @@
     },
     "node_modules/glob": {
       "version": "7.2.3",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -15820,6 +15814,7 @@
     },
     "node_modules/globals": {
       "version": "14.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -15830,7 +15825,7 @@
     },
     "node_modules/globalthis": {
       "version": "1.0.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-properties": "^1.2.1",
@@ -15982,7 +15977,7 @@
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -16010,7 +16005,7 @@
     },
     "node_modules/has-proto": {
       "version": "1.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.0"
@@ -16257,7 +16252,6 @@
     "node_modules/hono": {
       "version": "4.12.8",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -16595,7 +16589,7 @@
     },
     "node_modules/import-local": {
       "version": "3.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pkg-dir": "^4.2.0",
@@ -16634,7 +16628,7 @@
     },
     "node_modules/inflight": {
       "version": "1.0.6",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -16658,7 +16652,7 @@
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -16712,7 +16706,7 @@
     },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -16732,7 +16726,7 @@
     },
     "node_modules/is-async-function": {
       "version": "2.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "async-function": "^1.0.0",
@@ -16750,7 +16744,7 @@
     },
     "node_modules/is-bigint": {
       "version": "1.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-bigints": "^1.0.2"
@@ -16774,7 +16768,7 @@
     },
     "node_modules/is-boolean-object": {
       "version": "1.2.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -16796,7 +16790,7 @@
     },
     "node_modules/is-callable": {
       "version": "1.2.7",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -16830,7 +16824,7 @@
     },
     "node_modules/is-data-view": {
       "version": "1.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -16846,7 +16840,7 @@
     },
     "node_modules/is-date-object": {
       "version": "1.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -16896,7 +16890,7 @@
     },
     "node_modules/is-finalizationregistry": {
       "version": "1.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3"
@@ -16917,7 +16911,7 @@
     },
     "node_modules/is-generator-fn": {
       "version": "2.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -16925,7 +16919,7 @@
     },
     "node_modules/is-generator-function": {
       "version": "1.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.4",
@@ -17004,7 +16998,7 @@
     },
     "node_modules/is-map": {
       "version": "2.0.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -17020,7 +17014,7 @@
     },
     "node_modules/is-negative-zero": {
       "version": "2.0.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -17058,7 +17052,7 @@
     },
     "node_modules/is-number-object": {
       "version": "1.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -17117,7 +17111,7 @@
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -17141,7 +17135,7 @@
     },
     "node_modules/is-set": {
       "version": "2.0.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -17152,7 +17146,7 @@
     },
     "node_modules/is-shared-array-buffer": {
       "version": "1.0.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3"
@@ -17176,7 +17170,7 @@
     },
     "node_modules/is-string": {
       "version": "1.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -17191,7 +17185,7 @@
     },
     "node_modules/is-symbol": {
       "version": "1.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -17207,7 +17201,7 @@
     },
     "node_modules/is-typed-array": {
       "version": "1.1.15",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "which-typed-array": "^1.1.16"
@@ -17225,7 +17219,7 @@
     },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -17236,7 +17230,7 @@
     },
     "node_modules/is-weakref": {
       "version": "1.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3"
@@ -17250,7 +17244,7 @@
     },
     "node_modules/is-weakset": {
       "version": "2.0.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -17282,7 +17276,7 @@
     },
     "node_modules/isarray": {
       "version": "2.0.5",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -17298,7 +17292,7 @@
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=8"
@@ -17306,7 +17300,7 @@
     },
     "node_modules/istanbul-lib-instrument": {
       "version": "6.0.3",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/core": "^7.23.9",
@@ -17321,7 +17315,7 @@
     },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "istanbul-lib-coverage": "^3.0.0",
@@ -17334,7 +17328,7 @@
     },
     "node_modules/istanbul-lib-source-maps": {
       "version": "4.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "debug": "^4.1.1",
@@ -17347,7 +17341,7 @@
     },
     "node_modules/istanbul-reports": {
       "version": "3.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "html-escaper": "^2.0.0",
@@ -17379,9 +17373,8 @@
     },
     "node_modules/jest": {
       "version": "29.7.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -17405,7 +17398,7 @@
     },
     "node_modules/jest-changed-files": {
       "version": "29.7.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "execa": "^5.0.0",
@@ -17418,7 +17411,7 @@
     },
     "node_modules/jest-circus": {
       "version": "29.7.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.7.0",
@@ -17448,7 +17441,7 @@
     },
     "node_modules/jest-cli": {
       "version": "29.7.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/core": "^29.7.0",
@@ -17480,7 +17473,7 @@
     },
     "node_modules/jest-config": {
       "version": "29.7.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -17537,7 +17530,7 @@
     },
     "node_modules/jest-docblock": {
       "version": "29.7.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "detect-newline": "^3.0.0"
@@ -17548,7 +17541,7 @@
     },
     "node_modules/jest-each": {
       "version": "29.7.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -17563,7 +17556,7 @@
     },
     "node_modules/jest-environment-node": {
       "version": "29.7.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.7.0",
@@ -17605,7 +17598,7 @@
     },
     "node_modules/jest-haste-map": {
       "version": "29.7.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -17741,7 +17734,7 @@
     },
     "node_modules/jest-leak-detector": {
       "version": "29.7.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "jest-get-type": "^29.6.3",
@@ -17753,7 +17746,7 @@
     },
     "node_modules/jest-matcher-utils": {
       "version": "29.7.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
@@ -17767,7 +17760,7 @@
     },
     "node_modules/jest-message-util": {
       "version": "29.7.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
@@ -17786,7 +17779,7 @@
     },
     "node_modules/jest-mock": {
       "version": "29.7.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -17799,7 +17792,7 @@
     },
     "node_modules/jest-pnp-resolver": {
       "version": "1.2.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -17815,7 +17808,7 @@
     },
     "node_modules/jest-regex-util": {
       "version": "29.6.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -17823,7 +17816,7 @@
     },
     "node_modules/jest-resolve": {
       "version": "29.7.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
@@ -17842,7 +17835,7 @@
     },
     "node_modules/jest-resolve-dependencies": {
       "version": "29.7.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "jest-regex-util": "^29.6.3",
@@ -17854,7 +17847,7 @@
     },
     "node_modules/jest-runner": {
       "version": "29.7.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/console": "^29.7.0",
@@ -17885,7 +17878,7 @@
     },
     "node_modules/jest-runtime": {
       "version": "29.7.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.7.0",
@@ -17917,7 +17910,7 @@
     },
     "node_modules/jest-snapshot": {
       "version": "29.7.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -17972,7 +17965,7 @@
     },
     "node_modules/jest-validate": {
       "version": "29.7.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -17988,7 +17981,7 @@
     },
     "node_modules/jest-validate/node_modules/camelcase": {
       "version": "6.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -17999,7 +17992,7 @@
     },
     "node_modules/jest-watcher": {
       "version": "29.7.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/test-result": "^29.7.0",
@@ -18137,6 +18130,7 @@
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json5": {
@@ -18272,6 +18266,7 @@
     },
     "node_modules/levn": {
       "version": "0.4.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1",
@@ -18370,6 +18365,7 @@
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
@@ -18403,6 +18399,7 @@
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.uniq": {
@@ -18434,7 +18431,7 @@
     },
     "node_modules/loupe": {
       "version": "3.2.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lower-case": {
@@ -18477,7 +18474,7 @@
     },
     "node_modules/make-dir": {
       "version": "4.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^7.5.3"
@@ -18491,7 +18488,7 @@
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tmpl": "1.0.5"
@@ -20855,7 +20852,6 @@
     "node_modules/next": {
       "version": "16.2.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "16.2.1",
         "@swc/helpers": "0.5.15",
@@ -21013,7 +21009,7 @@
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-releases": {
@@ -21179,7 +21175,7 @@
     },
     "node_modules/object.fromentries": {
       "version": "2.0.8",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -21196,7 +21192,7 @@
     },
     "node_modules/object.groupby": {
       "version": "1.0.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -21209,7 +21205,7 @@
     },
     "node_modules/object.values": {
       "version": "1.2.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -21315,6 +21311,7 @@
     },
     "node_modules/optionator": {
       "version": "0.9.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "deep-is": "^0.1.3",
@@ -21330,7 +21327,7 @@
     },
     "node_modules/own-keys": {
       "version": "1.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.2.6",
@@ -21360,6 +21357,7 @@
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -21373,6 +21371,7 @@
     },
     "node_modules/p-locate": {
       "version": "5.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
@@ -21440,7 +21439,7 @@
     },
     "node_modules/p-try": {
       "version": "2.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -21582,6 +21581,7 @@
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -21602,7 +21602,7 @@
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -21661,12 +21661,12 @@
     },
     "node_modules/pathe": {
       "version": "2.0.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/pathval": {
       "version": "2.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.16"
@@ -21710,7 +21710,7 @@
     },
     "node_modules/pirates": {
       "version": "4.0.7",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -21725,7 +21725,7 @@
     },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "find-up": "^4.0.0"
@@ -21736,7 +21736,7 @@
     },
     "node_modules/pkg-dir/node_modules/find-up": {
       "version": "4.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
@@ -21748,7 +21748,7 @@
     },
     "node_modules/pkg-dir/node_modules/locate-path": {
       "version": "5.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
@@ -21759,7 +21759,7 @@
     },
     "node_modules/pkg-dir/node_modules/p-limit": {
       "version": "2.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
@@ -21773,7 +21773,7 @@
     },
     "node_modules/pkg-dir/node_modules/p-locate": {
       "version": "4.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
@@ -21819,7 +21819,7 @@
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -21842,7 +21842,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -22650,7 +22649,6 @@
     "node_modules/postcss-nesting/node_modules/postcss-selector-parser": {
       "version": "7.1.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -23136,6 +23134,7 @@
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
@@ -23144,7 +23143,6 @@
     "node_modules/prettier": {
       "version": "3.8.1",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -23320,7 +23318,7 @@
     },
     "node_modules/pure-rand": {
       "version": "6.1.0",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -23471,7 +23469,6 @@
     "node_modules/react": {
       "version": "18.3.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -23482,7 +23479,6 @@
     "node_modules/react-dom": {
       "version": "18.3.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -23529,7 +23525,6 @@
       "name": "@docusaurus/react-loadable",
       "version": "6.0.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/react": "*"
       },
@@ -23554,7 +23549,6 @@
     "node_modules/react-router": {
       "version": "5.3.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -23722,7 +23716,7 @@
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -23757,7 +23751,7 @@
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -24066,7 +24060,7 @@
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -24113,7 +24107,7 @@
     },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve-from": "^5.0.0"
@@ -24124,7 +24118,7 @@
     },
     "node_modules/resolve-cwd/node_modules/resolve-from": {
       "version": "5.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -24150,7 +24144,7 @@
     },
     "node_modules/resolve.exports": {
       "version": "2.0.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -24248,9 +24242,8 @@
     },
     "node_modules/rollup": {
       "version": "4.59.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -24472,7 +24465,7 @@
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -24508,7 +24501,7 @@
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -24523,7 +24516,7 @@
     },
     "node_modules/safe-regex-test": {
       "version": "1.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -24584,7 +24577,6 @@
     "node_modules/schema-utils/node_modules/ajv": {
       "version": "8.18.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -24624,11 +24616,6 @@
     "node_modules/schema-utils/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "license": "MIT"
-    },
-    "node_modules/search-insights": {
-      "version": "2.17.3",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/section-matter": {
       "version": "1.0.0",
@@ -24873,7 +24860,7 @@
     },
     "node_modules/set-function-name": {
       "version": "2.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -24887,7 +24874,7 @@
     },
     "node_modules/set-proto": {
       "version": "1.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -25057,7 +25044,7 @@
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/signal-exit": {
@@ -25198,7 +25185,7 @@
     },
     "node_modules/source-map-support": {
       "version": "0.5.13",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -25303,7 +25290,7 @@
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^2.0.0"
@@ -25314,7 +25301,7 @@
     },
     "node_modules/stack-utils/node_modules/escape-string-regexp": {
       "version": "2.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -25322,7 +25309,7 @@
     },
     "node_modules/stackback": {
       "version": "0.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/statuses": {
@@ -25338,7 +25325,7 @@
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -25364,7 +25351,7 @@
     },
     "node_modules/string-length": {
       "version": "4.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "char-regex": "^1.0.2",
@@ -25436,7 +25423,7 @@
     },
     "node_modules/string.prototype.trim": {
       "version": "1.2.10",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -25456,7 +25443,7 @@
     },
     "node_modules/string.prototype.trimend": {
       "version": "1.0.9",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -25473,7 +25460,7 @@
     },
     "node_modules/string.prototype.trimstart": {
       "version": "1.0.8",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -25523,7 +25510,7 @@
     },
     "node_modules/strip-bom": {
       "version": "4.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -25555,7 +25542,7 @@
     },
     "node_modules/strip-literal": {
       "version": "3.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^9.0.1"
@@ -25566,7 +25553,7 @@
     },
     "node_modules/strip-literal/node_modules/js-tokens": {
       "version": "9.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/strnum": {
@@ -25835,7 +25822,7 @@
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "@istanbuljs/schema": "^0.1.2",
@@ -25874,12 +25861,12 @@
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyexec": {
       "version": "0.3.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
@@ -25905,7 +25892,7 @@
     },
     "node_modules/tinyrainbow": {
       "version": "2.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -25913,7 +25900,7 @@
     },
     "node_modules/tinyspy": {
       "version": "4.0.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -25921,7 +25908,7 @@
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/to-regex-range": {
@@ -26006,7 +25993,7 @@
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/json5": "^0.0.29",
@@ -26017,7 +26004,7 @@
     },
     "node_modules/tsconfig-paths/node_modules/json5": {
       "version": "1.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.0"
@@ -26028,7 +26015,7 @@
     },
     "node_modules/tsconfig-paths/node_modules/strip-bom": {
       "version": "3.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -26036,8 +26023,7 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -26072,6 +26058,7 @@
     },
     "node_modules/type-check": {
       "version": "0.4.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1"
@@ -26082,7 +26069,7 @@
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -26111,7 +26098,7 @@
     },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -26124,7 +26111,7 @@
     },
     "node_modules/typed-array-byte-length": {
       "version": "1.0.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -26142,7 +26129,7 @@
     },
     "node_modules/typed-array-byte-offset": {
       "version": "1.0.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
@@ -26162,7 +26149,7 @@
     },
     "node_modules/typed-array-length": {
       "version": "1.0.7",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -26188,6 +26175,7 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -26225,7 +26213,7 @@
     },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -26689,7 +26677,7 @@
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.12",
@@ -26765,9 +26753,8 @@
     },
     "node_modules/vite": {
       "version": "7.3.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -26839,7 +26826,7 @@
     },
     "node_modules/vite-node": {
       "version": "3.2.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
@@ -26885,9 +26872,8 @@
     },
     "node_modules/vitest": {
       "version": "3.2.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -26962,7 +26948,7 @@
     },
     "node_modules/walker": {
       "version": "1.0.8",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
@@ -27013,7 +26999,6 @@
     "node_modules/webpack": {
       "version": "5.105.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -27217,7 +27202,6 @@
     "node_modules/webpack-dev-server/node_modules/@types/express": {
       "version": "4.17.25",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -27458,7 +27442,7 @@
     },
     "node_modules/which-boxed-primitive": {
       "version": "1.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-bigint": "^1.1.0",
@@ -27476,7 +27460,7 @@
     },
     "node_modules/which-builtin-type": {
       "version": "1.2.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -27502,7 +27486,7 @@
     },
     "node_modules/which-collection": {
       "version": "1.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-map": "^2.0.3",
@@ -27519,7 +27503,7 @@
     },
     "node_modules/which-typed-array": {
       "version": "1.1.20",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
@@ -27539,7 +27523,7 @@
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "siginfo": "^2.0.0",
@@ -27613,6 +27597,7 @@
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -27639,7 +27624,7 @@
     },
     "node_modules/write-file-atomic": {
       "version": "4.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4",
@@ -27716,7 +27701,7 @@
     },
     "node_modules/y18n": {
       "version": "5.0.8",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -27728,7 +27713,7 @@
     },
     "node_modules/yargs": {
       "version": "17.7.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -27745,7 +27730,7 @@
     },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -27753,6 +27738,7 @@
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -27790,7 +27776,6 @@
     "node_modules/zod": {
       "version": "4.3.6",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -27964,7 +27949,7 @@
     },
     "packages/dynamodb": {
       "name": "@jaypie/dynamodb",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.726.1",
@@ -28106,7 +28091,7 @@
     },
     "packages/fabric": {
       "name": "@jaypie/fabric",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*"
@@ -28699,7 +28684,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.30",
+      "version": "0.8.31",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.4",
@@ -28767,7 +28752,7 @@
     },
     "packages/mcp/node_modules/accepts": {
       "version": "2.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-types": "^3.0.0",
@@ -28779,7 +28764,7 @@
     },
     "packages/mcp/node_modules/body-parser": {
       "version": "2.2.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
@@ -28803,14 +28788,13 @@
     "packages/mcp/node_modules/commander": {
       "version": "14.0.3",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20"
       }
     },
     "packages/mcp/node_modules/content-disposition": {
       "version": "1.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -28822,9 +28806,8 @@
     },
     "packages/mcp/node_modules/express": {
       "version": "5.2.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -28865,7 +28848,7 @@
     },
     "packages/mcp/node_modules/finalhandler": {
       "version": "2.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -28885,7 +28868,7 @@
     },
     "packages/mcp/node_modules/fresh": {
       "version": "2.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -28893,7 +28876,7 @@
     },
     "packages/mcp/node_modules/iconv-lite": {
       "version": "0.7.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -28908,7 +28891,7 @@
     },
     "packages/mcp/node_modules/media-typer": {
       "version": "1.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -28916,7 +28899,7 @@
     },
     "packages/mcp/node_modules/merge-descriptors": {
       "version": "2.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -28927,7 +28910,7 @@
     },
     "packages/mcp/node_modules/mime-db": {
       "version": "1.54.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -28935,7 +28918,7 @@
     },
     "packages/mcp/node_modules/mime-types": {
       "version": "3.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
@@ -28950,7 +28933,7 @@
     },
     "packages/mcp/node_modules/negotiator": {
       "version": "1.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -28958,7 +28941,7 @@
     },
     "packages/mcp/node_modules/send": {
       "version": "1.2.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.3",
@@ -28983,7 +28966,7 @@
     },
     "packages/mcp/node_modules/serve-static": {
       "version": "2.2.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "encodeurl": "^2.0.0",
@@ -29001,7 +28984,7 @@
     },
     "packages/mcp/node_modules/type-is": {
       "version": "2.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "content-type": "^1.0.5",
@@ -29106,7 +29089,7 @@
     },
     "packages/testkit": {
       "name": "@jaypie/testkit",
-      "version": "1.2.32",
+      "version": "1.2.33",
       "license": "MIT",
       "dependencies": {
         "jest-extended": "^4.0.2",
@@ -29150,29 +29133,6 @@
           "optional": true
         },
         "@jaypie/logger": {
-          "optional": true
-        }
-      }
-    },
-    "packages/testkit/node_modules/@jaypie/dynamodb": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@jaypie/dynamodb/-/dynamodb-0.4.4.tgz",
-      "integrity": "sha512-P7i4EdYywbF5+N3bNIxmuhZ4BZ8DIM84EfI/Jro//XyrJbIe7vj6iPxIKl5LwT8d5//7TrJsOfcdp3PxMFTwuA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@aws-sdk/client-dynamodb": "^3.726.1",
-        "@aws-sdk/lib-dynamodb": "^3.726.1",
-        "@jaypie/fabric": "*"
-      },
-      "peerDependencies": {
-        "@jaypie/errors": "*",
-        "@jaypie/kit": "*",
-        "@jaypie/logger": "*",
-        "@modelcontextprotocol/sdk": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@modelcontextprotocol/sdk": {
           "optional": true
         }
       }
@@ -29349,6 +29309,28 @@
         "node": ">=22.0"
       }
     },
+    "workspaces/garden-api/node_modules/@jaypie/dynamodb": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@jaypie/dynamodb/-/dynamodb-0.5.0.tgz",
+      "integrity": "sha512-Y/uqA0hQw8hL6GUTJwTOgPVR96wx84/SPfL4a5UW1+bPRhCXRM/6P8qb3ZNXNruRyKwwc3fWc1KlSrCtZMT2qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@aws-sdk/client-dynamodb": "^3.726.1",
+        "@aws-sdk/lib-dynamodb": "^3.726.1",
+        "@jaypie/fabric": "*"
+      },
+      "peerDependencies": {
+        "@jaypie/errors": "*",
+        "@jaypie/kit": "*",
+        "@jaypie/logger": "*",
+        "@modelcontextprotocol/sdk": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
     "workspaces/garden-migrations": {
       "name": "@jaypie/garden-migrations",
       "version": "0.1.0",
@@ -29368,6 +29350,28 @@
         "node": ">=22.0"
       }
     },
+    "workspaces/garden-migrations/node_modules/@jaypie/dynamodb": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@jaypie/dynamodb/-/dynamodb-0.5.0.tgz",
+      "integrity": "sha512-Y/uqA0hQw8hL6GUTJwTOgPVR96wx84/SPfL4a5UW1+bPRhCXRM/6P8qb3ZNXNruRyKwwc3fWc1KlSrCtZMT2qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@aws-sdk/client-dynamodb": "^3.726.1",
+        "@aws-sdk/lib-dynamodb": "^3.726.1",
+        "@jaypie/fabric": "*"
+      },
+      "peerDependencies": {
+        "@jaypie/errors": "*",
+        "@jaypie/kit": "*",
+        "@jaypie/logger": "*",
+        "@modelcontextprotocol/sdk": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
     "workspaces/garden-models": {
       "name": "@jaypie/garden-models",
       "version": "0.1.0",
@@ -29385,6 +29389,28 @@
       },
       "engines": {
         "node": ">=22.0"
+      }
+    },
+    "workspaces/garden-models/node_modules/@jaypie/dynamodb": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@jaypie/dynamodb/-/dynamodb-0.5.0.tgz",
+      "integrity": "sha512-Y/uqA0hQw8hL6GUTJwTOgPVR96wx84/SPfL4a5UW1+bPRhCXRM/6P8qb3ZNXNruRyKwwc3fWc1KlSrCtZMT2qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@aws-sdk/client-dynamodb": "^3.726.1",
+        "@aws-sdk/lib-dynamodb": "^3.726.1",
+        "@jaypie/fabric": "*"
+      },
+      "peerDependencies": {
+        "@jaypie/errors": "*",
+        "@jaypie/kit": "*",
+        "@jaypie/logger": "*",
+        "@modelcontextprotocol/sdk": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
       }
     },
     "workspaces/garden-ui": {
@@ -29437,6 +29463,28 @@
         "@jaypie/logger": "*"
       }
     },
+    "workspaces/garden-ui/node_modules/@jaypie/dynamodb": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@jaypie/dynamodb/-/dynamodb-0.5.0.tgz",
+      "integrity": "sha512-Y/uqA0hQw8hL6GUTJwTOgPVR96wx84/SPfL4a5UW1+bPRhCXRM/6P8qb3ZNXNruRyKwwc3fWc1KlSrCtZMT2qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@aws-sdk/client-dynamodb": "^3.726.1",
+        "@aws-sdk/lib-dynamodb": "^3.726.1",
+        "@jaypie/fabric": "*"
+      },
+      "peerDependencies": {
+        "@jaypie/errors": "*",
+        "@jaypie/kit": "*",
+        "@jaypie/logger": "*",
+        "@modelcontextprotocol/sdk": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
     "workspaces/garden-ui/node_modules/@types/node": {
       "version": "22.19.15",
       "dev": true,
@@ -29448,7 +29496,6 @@
     "workspaces/garden-ui/node_modules/react": {
       "version": "19.2.4",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6750,6 +6750,7 @@
     },
     "node_modules/@microsoft/api-extractor": {
       "version": "7.57.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@microsoft/api-extractor-model": "7.33.4",
@@ -6782,6 +6783,7 @@
     },
     "node_modules/@microsoft/api-extractor/node_modules/balanced-match": {
       "version": "4.0.4",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
@@ -6789,6 +6791,7 @@
     },
     "node_modules/@microsoft/api-extractor/node_modules/brace-expansion": {
       "version": "5.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -6799,6 +6802,7 @@
     },
     "node_modules/@microsoft/api-extractor/node_modules/lru-cache": {
       "version": "6.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -6809,6 +6813,7 @@
     },
     "node_modules/@microsoft/api-extractor/node_modules/minimatch": {
       "version": "10.2.3",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.2"
@@ -6822,6 +6827,7 @@
     },
     "node_modules/@microsoft/api-extractor/node_modules/semver": {
       "version": "7.5.4",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -6835,6 +6841,7 @@
     },
     "node_modules/@microsoft/api-extractor/node_modules/typescript": {
       "version": "5.8.2",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -6846,6 +6853,7 @@
     },
     "node_modules/@microsoft/api-extractor/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/@microsoft/tsdoc": {
@@ -8229,6 +8237,7 @@
     },
     "node_modules/@rushstack/rig-package": {
       "version": "0.7.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve": "~1.22.1",
@@ -13366,6 +13375,7 @@
     },
     "node_modules/diff": {
       "version": "8.0.3",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -29291,7 +29301,7 @@
       "license": "MIT",
       "dependencies": {
         "@codegenie/serverless-express": "^4.17.1",
-        "@jaypie/dynamodb": "^0.5.0",
+        "@jaypie/dynamodb": "^0.6.0",
         "@jaypie/errors": "^1.2.1",
         "@jaypie/garden-models": "^0.1.0",
         "@jaypie/tildeskill": "^0.3.0",
@@ -29309,34 +29319,12 @@
         "node": ">=22.0"
       }
     },
-    "workspaces/garden-api/node_modules/@jaypie/dynamodb": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@jaypie/dynamodb/-/dynamodb-0.5.0.tgz",
-      "integrity": "sha512-Y/uqA0hQw8hL6GUTJwTOgPVR96wx84/SPfL4a5UW1+bPRhCXRM/6P8qb3ZNXNruRyKwwc3fWc1KlSrCtZMT2qw==",
-      "license": "MIT",
-      "dependencies": {
-        "@aws-sdk/client-dynamodb": "^3.726.1",
-        "@aws-sdk/lib-dynamodb": "^3.726.1",
-        "@jaypie/fabric": "*"
-      },
-      "peerDependencies": {
-        "@jaypie/errors": "*",
-        "@jaypie/kit": "*",
-        "@jaypie/logger": "*",
-        "@modelcontextprotocol/sdk": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@modelcontextprotocol/sdk": {
-          "optional": true
-        }
-      }
-    },
     "workspaces/garden-migrations": {
       "name": "@jaypie/garden-migrations",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@jaypie/dynamodb": "^0.5.0",
+        "@jaypie/dynamodb": "^0.6.0",
         "@jaypie/fabric": "^0.3.0",
         "@jaypie/logger": "^1.2.5",
         "jaypie": "^1.2.3"
@@ -29350,34 +29338,12 @@
         "node": ">=22.0"
       }
     },
-    "workspaces/garden-migrations/node_modules/@jaypie/dynamodb": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@jaypie/dynamodb/-/dynamodb-0.5.0.tgz",
-      "integrity": "sha512-Y/uqA0hQw8hL6GUTJwTOgPVR96wx84/SPfL4a5UW1+bPRhCXRM/6P8qb3ZNXNruRyKwwc3fWc1KlSrCtZMT2qw==",
-      "license": "MIT",
-      "dependencies": {
-        "@aws-sdk/client-dynamodb": "^3.726.1",
-        "@aws-sdk/lib-dynamodb": "^3.726.1",
-        "@jaypie/fabric": "*"
-      },
-      "peerDependencies": {
-        "@jaypie/errors": "*",
-        "@jaypie/kit": "*",
-        "@jaypie/logger": "*",
-        "@modelcontextprotocol/sdk": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@modelcontextprotocol/sdk": {
-          "optional": true
-        }
-      }
-    },
     "workspaces/garden-models": {
       "name": "@jaypie/garden-models",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@jaypie/dynamodb": "^0.5.0",
+        "@jaypie/dynamodb": "^0.6.0",
         "@jaypie/errors": "*",
         "@jaypie/fabric": "^0.3.0",
         "@jaypie/kit": "*",
@@ -29391,28 +29357,6 @@
         "node": ">=22.0"
       }
     },
-    "workspaces/garden-models/node_modules/@jaypie/dynamodb": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@jaypie/dynamodb/-/dynamodb-0.5.0.tgz",
-      "integrity": "sha512-Y/uqA0hQw8hL6GUTJwTOgPVR96wx84/SPfL4a5UW1+bPRhCXRM/6P8qb3ZNXNruRyKwwc3fWc1KlSrCtZMT2qw==",
-      "license": "MIT",
-      "dependencies": {
-        "@aws-sdk/client-dynamodb": "^3.726.1",
-        "@aws-sdk/lib-dynamodb": "^3.726.1",
-        "@jaypie/fabric": "*"
-      },
-      "peerDependencies": {
-        "@jaypie/errors": "*",
-        "@jaypie/kit": "*",
-        "@jaypie/logger": "*",
-        "@modelcontextprotocol/sdk": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@modelcontextprotocol/sdk": {
-          "optional": true
-        }
-      }
-    },
     "workspaces/garden-ui": {
       "name": "@jaypie/garden-ui",
       "version": "0.1.0",
@@ -29420,7 +29364,7 @@
       "dependencies": {
         "@auth0/nextjs-auth0": "^4.16.0",
         "@jaypie/aws": "^1.2.6",
-        "@jaypie/dynamodb": "^0.5.0",
+        "@jaypie/dynamodb": "^0.6.0",
         "@jaypie/errors": "^1.2.1",
         "@jaypie/garden-models": "^0.1.0",
         "@jaypie/kit": "^1.2.5",
@@ -29461,28 +29405,6 @@
         "@jaypie/errors": "*",
         "@jaypie/kit": "*",
         "@jaypie/logger": "*"
-      }
-    },
-    "workspaces/garden-ui/node_modules/@jaypie/dynamodb": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@jaypie/dynamodb/-/dynamodb-0.5.0.tgz",
-      "integrity": "sha512-Y/uqA0hQw8hL6GUTJwTOgPVR96wx84/SPfL4a5UW1+bPRhCXRM/6P8qb3ZNXNruRyKwwc3fWc1KlSrCtZMT2qw==",
-      "license": "MIT",
-      "dependencies": {
-        "@aws-sdk/client-dynamodb": "^3.726.1",
-        "@aws-sdk/lib-dynamodb": "^3.726.1",
-        "@jaypie/fabric": "*"
-      },
-      "peerDependencies": {
-        "@jaypie/errors": "*",
-        "@jaypie/kit": "*",
-        "@jaypie/logger": "*",
-        "@modelcontextprotocol/sdk": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@modelcontextprotocol/sdk": {
-          "optional": true
-        }
       }
     },
     "workspaces/garden-ui/node_modules/@types/node": {

--- a/packages/dynamodb/CLAUDE.md
+++ b/packages/dynamodb/CLAUDE.md
@@ -53,8 +53,8 @@ src/
 | Export | Description |
 |--------|-------------|
 | `getEntity({ id })` | Get a single entity by primary key (id only) |
-| `putEntity({ entity })` | Create or replace entity (auto-indexes, auto-timestamps) |
-| `updateEntity({ entity })` | Update entity (auto-indexes, auto-timestamps) |
+| `createEntity({ entity })` | Create entity; returns `null` if `id` already exists (conditional write on `attribute_not_exists(id)`) |
+| `updateEntity({ entity })` | Create or replace entity (auto-indexes, auto-timestamps) |
 | `deleteEntity({ id })` | Soft delete (sets `deletedAt`, re-indexes with `#deleted` suffix) |
 | `archiveEntity({ id })` | Archive (sets `archivedAt`, re-indexes with `#archived` suffix) |
 | `destroyEntity({ id })` | Hard delete (permanently removes) |
@@ -258,10 +258,10 @@ const { items } = await queryByScope({ model: "record", scope: APEX });
 ### Create Entity
 
 ```typescript
-import { APEX, putEntity } from "@jaypie/dynamodb";
+import { APEX, createEntity } from "@jaypie/dynamodb";
 
 // indexEntity auto-populates: createdAt, updatedAt, and all GSI keys
-const record = await putEntity({
+const record = await createEntity({
   entity: {
     model: "record",
     id: crypto.randomUUID(),
@@ -282,12 +282,12 @@ const record = await putEntity({
 ### Hierarchical Entities
 
 ```typescript
-import { calculateScope, putEntity, queryByScope } from "@jaypie/dynamodb";
+import { calculateScope, createEntity, queryByScope } from "@jaypie/dynamodb";
 
 const chat = { model: "chat", id: "abc-123" };
 const messageScope = calculateScope(chat); // "chat#abc-123"
 
-const message = await putEntity({
+const message = await createEntity({
   entity: {
     model: "message",
     id: crypto.randomUUID(),
@@ -421,7 +421,7 @@ import {
   exportEntities,
   exportEntitiesToJson,
   indexEntity,
-  putEntity,
+  createEntity,
   queryByScope,
   seedEntities,
   seedEntityIfNotExists,

--- a/packages/dynamodb/package.json
+++ b/packages/dynamodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/dynamodb",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"

--- a/packages/dynamodb/src/__tests__/entities.spec.ts
+++ b/packages/dynamodb/src/__tests__/entities.spec.ts
@@ -15,7 +15,7 @@ import {
   deleteEntity,
   destroyEntity,
   getEntity,
-  putEntity,
+  createEntity,
   updateEntity,
 } from "../entities.js";
 import type { StorableEntity } from "../types.js";
@@ -81,25 +81,48 @@ describe("Entity Operations", () => {
     });
   });
 
-  describe("putEntity", () => {
+  describe("createEntity", () => {
     it("returns the indexed entity with indexModel populated", async () => {
       const entity = createTestEntity();
-      const result = (await putEntity({ entity })) as StorableEntity & {
+      const result = (await createEntity({ entity })) as StorableEntity & {
         indexModel?: string;
       };
       expect(result.indexModel).toBe("record");
     });
 
+    it("issues PutCommand with attribute_not_exists(id) condition", async () => {
+      await createEntity({ entity: createTestEntity() });
+      const cmd = mockSend.mock.calls[0][0];
+      expect(cmd.input.ConditionExpression).toBe("attribute_not_exists(id)");
+    });
+
+    it("returns null when ConditionalCheckFailedException is thrown", async () => {
+      const err = Object.assign(new Error("conditional check failed"), {
+        name: "ConditionalCheckFailedException",
+      });
+      mockSend.mockRejectedValueOnce(err);
+      const result = await createEntity({ entity: createTestEntity() });
+      expect(result).toBeNull();
+    });
+
+    it("re-throws non-ConditionalCheckFailedException errors", async () => {
+      const err = Object.assign(new Error("boom"), { name: "OtherError" });
+      mockSend.mockRejectedValueOnce(err);
+      await expect(createEntity({ entity: createTestEntity() })).rejects.toThrow(
+        "boom",
+      );
+    });
+
     it("auto-bumps updatedAt and backfills createdAt", async () => {
       const entity = createTestEntity();
-      const result = await putEntity({ entity });
+      const result = await createEntity({ entity });
       expect(result.updatedAt).toBeDefined();
       expect(result.createdAt).toBeDefined();
     });
 
     it("writes via PutCommand", async () => {
       const entity = createTestEntity();
-      await putEntity({ entity });
+      await createEntity({ entity });
       const cmd = mockSend.mock.calls[0][0];
       expect(cmd.input.TableName).toBe("test-table");
       expect(cmd.input.Item.id).toBe(entity.id);
@@ -108,7 +131,7 @@ describe("Entity Operations", () => {
 
     it("auto-populates optional GSI attributes when fields present", async () => {
       const entity = { ...createTestEntity(), alias: "my-alias" };
-      const result = (await putEntity({ entity })) as StorableEntity & {
+      const result = (await createEntity({ entity })) as StorableEntity & {
         indexModel?: string;
         indexModelAlias?: string;
       };
@@ -251,7 +274,7 @@ describe("Entity Operations", () => {
         ...createTestEntity(),
         state: { active: true },
       };
-      const result = await putEntity({ entity });
+      const result = await createEntity({ entity });
       expect(result.state).toEqual({ active: true });
     });
 
@@ -260,7 +283,7 @@ describe("Entity Operations", () => {
         ...createTestEntity(),
         customField: "custom-value",
       };
-      const result = await putEntity({ entity });
+      const result = await createEntity({ entity });
       expect(result.customField).toBe("custom-value");
     });
   });

--- a/packages/dynamodb/src/__tests__/index.spec.ts
+++ b/packages/dynamodb/src/__tests__/index.spec.ts
@@ -40,8 +40,8 @@ describe("@jaypie/dynamodb exports", () => {
       expect(dynamodb.getEntity).toBeFunction();
     });
 
-    it("exports putEntity", () => {
-      expect(dynamodb.putEntity).toBeFunction();
+    it("exports createEntity", () => {
+      expect(dynamodb.createEntity).toBeFunction();
     });
 
     it("exports updateEntity", () => {

--- a/packages/dynamodb/src/__tests__/seedExport.spec.ts
+++ b/packages/dynamodb/src/__tests__/seedExport.spec.ts
@@ -15,7 +15,8 @@ vi.mock("../entities.js", async () => {
   const actual = await vi.importActual("../entities.js");
   return {
     ...actual,
-    putEntity: vi.fn(),
+    createEntity: vi.fn(),
+    updateEntity: vi.fn(),
   };
 });
 
@@ -86,12 +87,12 @@ describe("Seed and Export Utilities", () => {
         scope: "@",
       });
       expect(result).toBe(false);
-      expect(entitiesModule.putEntity).not.toHaveBeenCalled();
+      expect(entitiesModule.createEntity).not.toHaveBeenCalled();
     });
 
     it("creates entity when it does not exist", async () => {
       vi.mocked(queriesModule.queryByAlias).mockResolvedValueOnce(null);
-      vi.mocked(entitiesModule.putEntity).mockResolvedValueOnce(
+      vi.mocked(entitiesModule.createEntity).mockResolvedValueOnce(
         createTestEntity(),
       );
 
@@ -102,12 +103,12 @@ describe("Seed and Export Utilities", () => {
       });
 
       expect(result).toBe(true);
-      expect(entitiesModule.putEntity).toHaveBeenCalledTimes(1);
+      expect(entitiesModule.createEntity).toHaveBeenCalledTimes(1);
     });
 
     it("auto-generates id when missing", async () => {
       vi.mocked(queriesModule.queryByAlias).mockResolvedValueOnce(null);
-      vi.mocked(entitiesModule.putEntity).mockResolvedValueOnce(
+      vi.mocked(entitiesModule.createEntity).mockResolvedValueOnce(
         createTestEntity(),
       );
 
@@ -117,16 +118,16 @@ describe("Seed and Export Utilities", () => {
         scope: "@",
       });
 
-      const callArg = vi.mocked(entitiesModule.putEntity).mock.calls[0][0];
+      const callArg = vi.mocked(entitiesModule.createEntity).mock.calls[0][0];
       expect(callArg.entity.id).toBeDefined();
       expect(callArg.entity.id.length).toBeGreaterThan(0);
     });
 
-    it("delegates timestamp management to putEntity (no manual createdAt)", async () => {
-      // createdAt/updatedAt are now managed by indexEntity inside putEntity —
+    it("delegates timestamp management to createEntity (no manual createdAt)", async () => {
+      // createdAt/updatedAt are now managed by indexEntity inside createEntity —
       // seedEntityIfNotExists no longer sets them.
       vi.mocked(queriesModule.queryByAlias).mockResolvedValueOnce(null);
-      vi.mocked(entitiesModule.putEntity).mockResolvedValueOnce(
+      vi.mocked(entitiesModule.createEntity).mockResolvedValueOnce(
         createTestEntity(),
       );
 
@@ -136,13 +137,13 @@ describe("Seed and Export Utilities", () => {
         scope: "@",
       });
 
-      const callArg = vi.mocked(entitiesModule.putEntity).mock.calls[0][0];
+      const callArg = vi.mocked(entitiesModule.createEntity).mock.calls[0][0];
       expect(callArg.entity.createdAt).toBeUndefined();
     });
 
     it("uses name from alias when name is missing", async () => {
       vi.mocked(queriesModule.queryByAlias).mockResolvedValueOnce(null);
-      vi.mocked(entitiesModule.putEntity).mockResolvedValueOnce(
+      vi.mocked(entitiesModule.createEntity).mockResolvedValueOnce(
         createTestEntity(),
       );
 
@@ -152,7 +153,7 @@ describe("Seed and Export Utilities", () => {
         scope: "@",
       });
 
-      const callArg = vi.mocked(entitiesModule.putEntity).mock.calls[0][0];
+      const callArg = vi.mocked(entitiesModule.createEntity).mock.calls[0][0];
       expect(callArg.entity.name).toBe("my-alias");
     });
   });
@@ -173,7 +174,7 @@ describe("Seed and Export Utilities", () => {
 
     it("creates entities that do not exist", async () => {
       vi.mocked(queriesModule.queryByAlias).mockResolvedValue(null);
-      vi.mocked(entitiesModule.putEntity).mockResolvedValue(createTestEntity());
+      vi.mocked(entitiesModule.createEntity).mockResolvedValue(createTestEntity());
 
       const result = await seedEntities([
         { alias: "entity-1", model: "record", scope: "@" },
@@ -183,14 +184,14 @@ describe("Seed and Export Utilities", () => {
       expect(result.created).toEqual(["entity-1", "entity-2"]);
       expect(result.skipped).toEqual([]);
       expect(result.errors).toEqual([]);
-      expect(entitiesModule.putEntity).toHaveBeenCalledTimes(2);
+      expect(entitiesModule.createEntity).toHaveBeenCalledTimes(2);
     });
 
     it("skips entities that already exist", async () => {
       vi.mocked(queriesModule.queryByAlias)
         .mockResolvedValueOnce(createTestEntity()) // First exists
         .mockResolvedValueOnce(null); // Second doesn't exist
-      vi.mocked(entitiesModule.putEntity).mockResolvedValue(createTestEntity());
+      vi.mocked(entitiesModule.createEntity).mockResolvedValue(createTestEntity());
 
       const result = await seedEntities([
         { alias: "existing", model: "record", scope: "@" },
@@ -199,7 +200,7 @@ describe("Seed and Export Utilities", () => {
 
       expect(result.created).toEqual(["new-one"]);
       expect(result.skipped).toEqual(["existing"]);
-      expect(entitiesModule.putEntity).toHaveBeenCalledTimes(1);
+      expect(entitiesModule.createEntity).toHaveBeenCalledTimes(1);
     });
 
     it("replaces entities when replace option is true", async () => {
@@ -207,7 +208,9 @@ describe("Seed and Export Utilities", () => {
       vi.mocked(queriesModule.queryByAlias).mockResolvedValueOnce(
         existingEntity,
       );
-      vi.mocked(entitiesModule.putEntity).mockResolvedValue(createTestEntity());
+      vi.mocked(entitiesModule.updateEntity).mockResolvedValue(
+        createTestEntity(),
+      );
 
       const result = await seedEntities(
         [{ alias: "existing", model: "record", scope: "@" }],
@@ -216,10 +219,11 @@ describe("Seed and Export Utilities", () => {
 
       expect(result.created).toEqual(["existing"]);
       expect(result.skipped).toEqual([]);
-      expect(entitiesModule.putEntity).toHaveBeenCalledTimes(1);
+      expect(entitiesModule.updateEntity).toHaveBeenCalledTimes(1);
+      expect(entitiesModule.createEntity).not.toHaveBeenCalled();
 
       // Should use the existing ID
-      const callArg = vi.mocked(entitiesModule.putEntity).mock.calls[0][0];
+      const callArg = vi.mocked(entitiesModule.updateEntity).mock.calls[0][0];
       expect(callArg.entity.id).toBe("existing-id");
     });
 
@@ -235,7 +239,7 @@ describe("Seed and Export Utilities", () => {
       );
 
       expect(result.created).toEqual(["entity-1", "entity-2"]);
-      expect(entitiesModule.putEntity).not.toHaveBeenCalled();
+      expect(entitiesModule.createEntity).not.toHaveBeenCalled();
     });
 
     it("records errors for entities missing required fields", async () => {
@@ -251,7 +255,7 @@ describe("Seed and Export Utilities", () => {
 
     it("uses name as alias identifier when alias is missing", async () => {
       vi.mocked(queriesModule.queryByAlias).mockResolvedValue(null);
-      vi.mocked(entitiesModule.putEntity).mockResolvedValue(createTestEntity());
+      vi.mocked(entitiesModule.createEntity).mockResolvedValue(createTestEntity());
 
       const result = await seedEntities([
         { model: "record", name: "Named Entity", scope: "@" },

--- a/packages/dynamodb/src/entities.ts
+++ b/packages/dynamodb/src/entities.ts
@@ -57,25 +57,34 @@ export const getEntity = fabricService({
 });
 
 /**
- * Put (create or replace) an entity.
+ * Create an entity. Fails the conditional write if `id` already exists,
+ * returning `null` instead of throwing. Use `updateEntity` to overwrite.
  * `indexEntity` auto-bumps `updatedAt` and backfills `createdAt`.
  */
-export async function putEntity({
+export async function createEntity({
   entity,
 }: {
   entity: StorableEntity;
-}): Promise<StorableEntity> {
+}): Promise<StorableEntity | null> {
   const docClient = getDocClient();
   const tableName = getTableName();
 
   const indexedEntity = indexEntity(entity);
 
   const command = new PutCommand({
+    ConditionExpression: "attribute_not_exists(id)",
     Item: indexedEntity,
     TableName: tableName,
   });
 
-  await docClient.send(command);
+  try {
+    await docClient.send(command);
+  } catch (error) {
+    if ((error as { name?: string })?.name === "ConditionalCheckFailedException") {
+      return null;
+    }
+    throw error;
+  }
   return indexedEntity;
 }
 

--- a/packages/dynamodb/src/index.ts
+++ b/packages/dynamodb/src/index.ts
@@ -18,10 +18,10 @@ export {
 // Entity operations
 export {
   archiveEntity,
+  createEntity,
   deleteEntity,
   destroyEntity,
   getEntity,
-  putEntity,
   transactWriteEntities,
   updateEntity,
 } from "./entities.js";

--- a/packages/dynamodb/src/keyBuilders.ts
+++ b/packages/dynamodb/src/keyBuilders.ts
@@ -49,7 +49,7 @@ export function calculateScope(parent?: ParentReference): string {
  * - Populates GSI attributes (pk composite and sk composite when applicable)
  *   using the indexes registered for the entity's model.
  *
- * Callers (putEntity, updateEntity, deleteEntity, archiveEntity,
+ * Callers (createEntity, updateEntity, deleteEntity, archiveEntity,
  * transactWriteEntities) go through this one function so `updatedAt` is
  * always fresh and never forgotten.
  *

--- a/packages/dynamodb/src/mcp/index.ts
+++ b/packages/dynamodb/src/mcp/index.ts
@@ -4,10 +4,10 @@ import { fabricService, type Service } from "@jaypie/fabric";
 
 import {
   archiveEntity,
+  createEntity,
   deleteEntity,
   destroyEntity,
   getEntity,
-  putEntity,
   queryByAlias,
   queryByCategory,
   queryByScope,
@@ -58,13 +58,13 @@ function wrapWithInit(handler: Service<any, any, any>): Service {
 // Note: These wrap the regular async functions to make them work with fabricMcp
 
 /**
- * MCP wrapper for putEntity
+ * MCP wrapper for createEntity
  * Accepts entity JSON directly from LLM
  */
-const mcpPutEntity = fabricService({
-  alias: "dynamodb_put",
+const mcpCreateEntity = fabricService({
+  alias: "dynamodb_create",
   description:
-    "Create or replace an entity in DynamoDB (auto-indexes GSI keys)",
+    "Create an entity in DynamoDB (auto-indexes GSI keys; returns null if id exists)",
   input: {
     // Required entity fields
     id: { type: String, description: "Entity ID (sort key)" },
@@ -100,7 +100,7 @@ const mcpPutEntity = fabricService({
       updatedAt: now,
       xid: input.xid as string | undefined,
     };
-    return putEntity({ entity });
+    return createEntity({ entity });
   },
 });
 
@@ -317,11 +317,11 @@ export function registerDynamoDbTools(
   tools.push("dynamodb_get");
 
   fabricMcp({
-    service: wrapWithInit(mcpPutEntity),
-    name: "dynamodb_put",
+    service: wrapWithInit(mcpCreateEntity),
+    name: "dynamodb_create",
     server,
   });
-  tools.push("dynamodb_put");
+  tools.push("dynamodb_create");
 
   fabricMcp({
     service: wrapWithInit(mcpUpdateEntity),

--- a/packages/dynamodb/src/seedExport.ts
+++ b/packages/dynamodb/src/seedExport.ts
@@ -1,4 +1,4 @@
-import { putEntity } from "./entities.js";
+import { createEntity, updateEntity } from "./entities.js";
 import { queryByAlias, queryByScope } from "./queries.js";
 import type { StorableEntity } from "./types.js";
 
@@ -69,7 +69,7 @@ export async function seedEntityIfNotExists<T extends Partial<StorableEntity>>(
     ...entity,
   } as StorableEntity;
 
-  await putEntity({ entity: completeEntity });
+  await createEntity({ entity: completeEntity });
   return true;
 }
 
@@ -105,6 +105,7 @@ export async function seedEntities<T extends Partial<StorableEntity>>(
       }
 
       // For entities with alias, check existence
+      let isReplace = false;
       if (entity.alias) {
         const existing = await queryByAlias({
           alias: entity.alias,
@@ -120,6 +121,7 @@ export async function seedEntities<T extends Partial<StorableEntity>>(
         // If replacing, use existing ID to update rather than create new
         if (existing && replace) {
           entity.id = existing.id;
+          isReplace = true;
         }
       }
 
@@ -137,7 +139,11 @@ export async function seedEntities<T extends Partial<StorableEntity>>(
         ...entity,
       } as StorableEntity;
 
-      await putEntity({ entity: completeEntity });
+      if (isReplace) {
+        await updateEntity({ entity: completeEntity });
+      } else {
+        await createEntity({ entity: completeEntity });
+      }
       result.created.push(alias);
     } catch (error) {
       const errorMessage =

--- a/packages/fabric/CLAUDE.md
+++ b/packages/fabric/CLAUDE.md
@@ -317,7 +317,7 @@ const server = new FabricHttpServer({
 
 | Operation | HTTP Method | Route | DynamoDB Function |
 |-----------|-------------|-------|-------------------|
-| create | POST | `/{model}` | `putEntity` |
+| create | POST | `/{model}` | `createEntity` |
 | list | GET | `/{model}` | `queryByScope` |
 | read | GET | `/{model}/:id` | `getEntity` |
 | update | POST | `/{model}/:id` | `updateEntity` |

--- a/packages/fabric/README.md
+++ b/packages/fabric/README.md
@@ -380,7 +380,7 @@ export const handler = server.handler;
 
 | Operation | HTTP Method | Route | DynamoDB Function |
 |-----------|-------------|-------|-------------------|
-| create | POST | `/{model}` | `putEntity` |
+| create | POST | `/{model}` | `createEntity` |
 | list | GET | `/{model}` | `queryByScope` |
 | read | GET | `/{model}/:id` | `getEntity` |
 | update | POST | `/{model}/:id` | `updateEntity` |
@@ -465,14 +465,14 @@ const services = FabricData({
       alias: "duplicate",
       description: "Create a copy of a record",
       service: async (entity) => {
-        const { putEntity } = await import("@jaypie/dynamodb");
+        const { createEntity } = await import("@jaypie/dynamodb");
         const duplicate = {
           ...entity,
           id: crypto.randomUUID(),
           name: `${entity.name} (Copy)`,
         };
         delete duplicate.alias;
-        return putEntity({ entity: duplicate });
+        return createEntity({ entity: duplicate });
       },
     },
   ],

--- a/packages/fabric/package.json
+++ b/packages/fabric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/fabric",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Jaypie modeling framework with type conversion, service handlers, and adapters",
   "repository": {
     "type": "git",

--- a/packages/fabric/src/__tests__/data.spec.ts
+++ b/packages/fabric/src/__tests__/data.spec.ts
@@ -29,7 +29,7 @@ vi.mock("@jaypie/dynamodb", () => ({
   archiveEntity: vi.fn().mockResolvedValue(true),
   deleteEntity: vi.fn().mockResolvedValue(true),
   getEntity: vi.fn().mockResolvedValue(null),
-  putEntity: vi.fn().mockImplementation(async ({ entity }) => ({
+  createEntity: vi.fn().mockImplementation(async ({ entity }) => ({
     ...entity,
     indexScope: "@#record",
   })),

--- a/packages/fabric/src/data/services/create.ts
+++ b/packages/fabric/src/data/services/create.ts
@@ -38,7 +38,7 @@ export function createCreateService<T extends FabricModel = FabricModel>(
       context?: CreateServiceContext,
     ) => {
       // Dynamically import DynamoDB utilities
-      const { putEntity } = await import("@jaypie/dynamodb");
+      const { createEntity } = await import("@jaypie/dynamodb");
 
       // Calculate scope
       const scopeConfig = globalConfig.scope as
@@ -74,7 +74,7 @@ export function createCreateService<T extends FabricModel = FabricModel>(
       };
 
       // indexEntity on the dynamodb side fills createdAt/updatedAt/GSI attrs.
-      const created = await putEntity({ entity });
+      const created = await createEntity({ entity });
       return created;
     },
   }) as unknown as FabricHttpService;

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.30",
+  "version": "0.8.31",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/dynamodb/0.6.0.md
+++ b/packages/mcp/release-notes/dynamodb/0.6.0.md
@@ -1,0 +1,42 @@
+---
+version: 0.6.0
+date: 2026-04-13
+summary: Replace `putEntity` with `createEntity` (conditional `attribute_not_exists(id)`) to remove the silent-clobber footgun
+---
+
+## Breaking changes
+
+- **Removed `putEntity`.** The unconditional `PutCommand` it issued was a
+  silent-clobber footgun: callers using it as "ensure exists" overwrote
+  embedded fields (e.g., `messages: []`) on every call. `putEntity` was also
+  semantically identical to `updateEntity`, so it was dead weight as well as
+  a trap. Migrate based on intent:
+  - "I want this row to exist, do nothing if it already does" → `createEntity`
+  - "I want this row to be exactly these values, replacing any prior state" → `updateEntity`
+
+## New
+
+- **`createEntity({ entity })`**: writes with
+  `ConditionExpression: "attribute_not_exists(id)"`. On
+  `ConditionalCheckFailedException`, returns `null` instead of throwing.
+  Other errors propagate normally. Return type is `StorableEntity | null`.
+
+## MCP
+
+- The `dynamodb_put` tool is renamed to `dynamodb_create` and now wraps
+  `createEntity`.
+
+## Migration
+
+```ts
+// Before
+await putEntity({ entity });          // silently overwrote on second call
+
+// After — pick the verb that matches intent
+await createEntity({ entity });       // ensure exists; null if id taken
+await updateEntity({ entity });       // overwrite (was putEntity's actual behavior)
+```
+
+Internal callers in `seedExport` (`seedEntityIfNotExists`, `seedEntities`)
+were migrated: the create paths use `createEntity`; the `replace: true`
+path uses `updateEntity`.

--- a/packages/mcp/release-notes/fabric/0.3.1.md
+++ b/packages/mcp/release-notes/fabric/0.3.1.md
@@ -1,0 +1,14 @@
+---
+version: 0.3.1
+date: 2026-04-13
+summary: FabricData create service uses `createEntity` (was `putEntity`) from `@jaypie/dynamodb` 0.6.0
+---
+
+## Changes
+
+- `createCreateService` (the POST `/{model}` handler in FabricData) now
+  imports `createEntity` instead of `putEntity`. Behavior is unchanged in
+  practice: the create service generates a fresh UUID for `id`, so the new
+  conditional write never collides; if a caller supplies a colliding `id`
+  via a custom transform, the service now returns `null` instead of
+  silently overwriting.

--- a/packages/mcp/release-notes/mcp/0.8.31.md
+++ b/packages/mcp/release-notes/mcp/0.8.31.md
@@ -1,0 +1,12 @@
+---
+version: 0.8.31
+date: 2026-04-13
+summary: Update dynamodb skill docs and pull `@jaypie/dynamodb` 0.6.0 (`createEntity` replaces `putEntity`)
+---
+
+## Changes
+
+- `dynamodb` skill updated: `putEntity` examples and table entry replaced
+  with `createEntity`.
+- Pulls `@jaypie/dynamodb` 0.6.0 with renamed MCP tool `dynamodb_create`
+  (was `dynamodb_put`).

--- a/packages/mcp/release-notes/testkit/1.2.33.md
+++ b/packages/mcp/release-notes/testkit/1.2.33.md
@@ -1,0 +1,11 @@
+---
+version: 1.2.33
+date: 2026-04-13
+summary: Replace `putEntity` mock with `createEntity` to match `@jaypie/dynamodb` 0.6.0
+---
+
+## Changes
+
+- Removed `putEntity` mock; added `createEntity` mock that returns the
+  indexed entity (or `null` to simulate `ConditionalCheckFailedException`,
+  via `mockResolvedValueOnce(null)`).

--- a/packages/mcp/skills/dynamodb.md
+++ b/packages/mcp/skills/dynamodb.md
@@ -33,7 +33,7 @@ The runtime package provides entity operations, GSI-based queries, key builders,
 import {
   APEX,
   initClient,
-  putEntity,
+  createEntity,
   getEntity,
   deleteEntity,
   queryByScope,
@@ -44,7 +44,7 @@ import {
 Or through the main package:
 
 ```typescript
-import { APEX, initClient, putEntity, queryByScope } from "jaypie";
+import { APEX, initClient, createEntity, queryByScope } from "jaypie";
 ```
 
 ### Client Initialization
@@ -121,10 +121,10 @@ interface StorableEntity {
 ### Entity Operations
 
 ```typescript
-import { APEX, putEntity, getEntity, updateEntity, deleteEntity, archiveEntity, destroyEntity } from "@jaypie/dynamodb";
+import { APEX, createEntity, getEntity, updateEntity, deleteEntity, archiveEntity, destroyEntity } from "@jaypie/dynamodb";
 
 // Create entity — indexEntity auto-populates GSI keys, createdAt, updatedAt
-const record = await putEntity({
+const record = await createEntity({
   entity: {
     model: "record",
     id: crypto.randomUUID(),
@@ -157,7 +157,7 @@ await destroyEntity({ id: "abc-123" });
 
 | Function | Description |
 |----------|-------------|
-| `putEntity({ entity })` | Create or replace (auto-indexes GSI keys, auto-timestamps) |
+| `createEntity({ entity })` | Create entity; returns `null` if `id` exists (conditional `attribute_not_exists(id)`) |
 | `getEntity({ id })` | Get by primary key (id only) |
 | `updateEntity({ entity })` | Update (sets `updatedAt`, re-indexes) |
 | `deleteEntity({ id })` | Soft delete (`deletedAt`, `#deleted` suffix on GSI pk) |
@@ -169,16 +169,16 @@ await destroyEntity({ id: "abc-123" });
 The `scope` field enables parent-child relationships:
 
 ```typescript
-import { APEX, calculateScope, putEntity, queryByScope } from "@jaypie/dynamodb";
+import { APEX, calculateScope, createEntity, queryByScope } from "@jaypie/dynamodb";
 
 // Root-level entity: scope = APEX ("@")
-await putEntity({ entity: { model: "chat", scope: APEX, ... } });
+await createEntity({ entity: { model: "chat", scope: APEX, ... } });
 
 // Child entity: scope = "{parent.model}#{parent.id}"
 const chat = { model: "chat", id: "abc-123" };
 const messageScope = calculateScope(chat); // "chat#abc-123"
 
-await putEntity({
+await createEntity({
   entity: { model: "message", scope: messageScope, ... },
 });
 
@@ -394,7 +394,7 @@ Mock `@jaypie/dynamodb` via testkit. Key builders and `indexEntity` work correct
 import {
   APEX,
   indexEntity,
-  putEntity,
+  createEntity,
   queryByScope,
   seedEntities,
 } from "@jaypie/testkit/mock";

--- a/packages/testkit/package.json
+++ b/packages/testkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/testkit",
-  "version": "1.2.32",
+  "version": "1.2.33",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"

--- a/packages/testkit/src/mock/dynamodb.ts
+++ b/packages/testkit/src/mock/dynamodb.ts
@@ -65,8 +65,8 @@ export const getEntity = createMockFunction<
   (params: { id: string }) => Promise<StorableEntity | null>
 >(async () => null);
 
-export const putEntity = createMockFunction<
-  (params: { entity: StorableEntity }) => Promise<StorableEntity>
+export const createEntity = createMockFunction<
+  (params: { entity: StorableEntity }) => Promise<StorableEntity | null>
 >(async (params: { entity: StorableEntity }) =>
   original.indexEntity(params.entity),
 );

--- a/workspaces/documentation/docs/experimental/dynamodb.md
+++ b/workspaces/documentation/docs/experimental/dynamodb.md
@@ -25,7 +25,7 @@ npm install @jaypie/dynamodb
 
 | Function | Purpose |
 |----------|---------|
-| `putEntity` | Create new entity |
+| `createEntity` | Create new entity (returns `null` if `id` exists) |
 | `getEntity` | Read entity by ID |
 | `updateEntity` | Update entity fields |
 | `deleteEntity` | Soft delete (mark deleted) |
@@ -102,10 +102,10 @@ GSIs are defined using `fabricIndex()` from `@jaypie/fabric`. All GSIs use a com
 ### Create Entity
 
 ```typescript
-import { APEX, putEntity } from "@jaypie/dynamodb";
+import { APEX, createEntity } from "@jaypie/dynamodb";
 
 // indexEntity auto-populates GSI keys, createdAt, updatedAt
-const user = await putEntity({
+const user = await createEntity({
   entity: {
     model: "user",
     id: crypto.randomUUID(),

--- a/workspaces/garden-api/package.json
+++ b/workspaces/garden-api/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@codegenie/serverless-express": "^4.17.1",
-    "@jaypie/dynamodb": "^0.5.0",
+    "@jaypie/dynamodb": "^0.6.0",
     "@jaypie/errors": "^1.2.1",
     "@jaypie/garden-models": "^0.1.0",
     "@jaypie/tildeskill": "^0.3.0",

--- a/workspaces/garden-api/src/routes/mcp.route.ts
+++ b/workspaces/garden-api/src/routes/mcp.route.ts
@@ -1,10 +1,10 @@
 import { loadEnvSecrets } from "@jaypie/aws";
 import {
   calculateScope,
+  createEntity,
   deleteEntity,
   getEntity,
   initClient,
-  putEntity,
   queryByCategory,
   queryByScope,
   queryByXid,
@@ -202,7 +202,7 @@ async function handleSkillNote({
     updatedAt: now,
     xid,
   };
-  await putEntity({ entity });
+  await createEntity({ entity });
   log.trace("Skill note created", { alias, id });
   return { created: id };
 }
@@ -332,7 +332,7 @@ async function handleJournalRequest(params: {
         scope,
         updatedAt: now,
       };
-      await putEntity({ entity });
+      await createEntity({ entity });
       log.trace("Journal entry created", { category, id: entryId });
       return { category, created: entryId, name: entity.name };
     }

--- a/workspaces/garden-migrations/package.json
+++ b/workspaces/garden-migrations/package.json
@@ -16,7 +16,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@jaypie/dynamodb": "^0.5.0",
+    "@jaypie/dynamodb": "^0.6.0",
     "@jaypie/fabric": "^0.3.0",
     "@jaypie/logger": "^1.2.5",
     "jaypie": "^1.2.3"

--- a/workspaces/garden-models/package.json
+++ b/workspaces/garden-models/package.json
@@ -19,7 +19,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@jaypie/dynamodb": "^0.5.0",
+    "@jaypie/dynamodb": "^0.6.0",
     "@jaypie/errors": "*",
     "@jaypie/fabric": "^0.3.0",
     "@jaypie/kit": "*",

--- a/workspaces/garden-ui/package.json
+++ b/workspaces/garden-ui/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@auth0/nextjs-auth0": "^4.16.0",
     "@jaypie/aws": "^1.2.6",
-    "@jaypie/dynamodb": "^0.5.0",
+    "@jaypie/dynamodb": "^0.6.0",
     "@jaypie/errors": "^1.2.1",
     "@jaypie/garden-models": "^0.1.0",
     "@jaypie/kit": "^1.2.5",

--- a/workspaces/garden-ui/src/app/api/apikeys/route.ts
+++ b/workspaces/garden-ui/src/app/api/apikeys/route.ts
@@ -1,4 +1,4 @@
-import { APEX, deleteEntity, initClient, putEntity, queryByScope, queryByXid } from "@jaypie/dynamodb";
+import { APEX, createEntity, deleteEntity, initClient, queryByScope, queryByXid } from "@jaypie/dynamodb";
 import { GARDEN_MODEL } from "@jaypie/garden-models";
 import "@jaypie/garden-models"; // Side-effect: registers all models
 import { generateJaypieKey, hashJaypieKey } from "@jaypie/kit";
@@ -93,7 +93,7 @@ export async function POST(request: Request): Promise<Response> {
     const hash = hashJaypieKey(key);
     const now = new Date().toISOString();
 
-    await putEntity({
+    await createEntity({
       entity: {
         alias: hash,
         createdAt: now,

--- a/workspaces/garden-ui/src/app/api/gardens/route.ts
+++ b/workspaces/garden-ui/src/app/api/gardens/route.ts
@@ -1,7 +1,7 @@
 import {
   APEX,
+  createEntity,
   initClient,
-  putEntity,
   queryByScope,
   type StorableEntity,
 } from "@jaypie/dynamodb";
@@ -71,7 +71,7 @@ export async function POST(request: Request): Promise<Response> {
       xid: auth.sub,
     } as GardenEntity;
 
-    await putEntity({ entity: entity as unknown as StorableEntity });
+    await createEntity({ entity: entity as unknown as StorableEntity });
 
     log.debug("Garden created", { name: gardenName });
 

--- a/workspaces/garden-ui/src/lib/session.ts
+++ b/workspaces/garden-ui/src/lib/session.ts
@@ -2,7 +2,7 @@ import { createHash, createHmac, randomUUID } from "node:crypto";
 
 import {
   APEX,
-  putEntity,
+  createEntity,
   queryByAlias,
   updateEntity,
 } from "@jaypie/dynamodb";
@@ -48,7 +48,7 @@ async function createSession(): Promise<string> {
     updatedAt: now,
   } as SessionEntity;
 
-  await putEntity({ entity });
+  await createEntity({ entity });
   log.debug("Session created", { hint: token.slice(-4) });
   return token;
 }

--- a/workspaces/garden-ui/src/lib/user/upsert.ts
+++ b/workspaces/garden-ui/src/lib/user/upsert.ts
@@ -1,6 +1,6 @@
 import {
   APEX,
-  putEntity,
+  createEntity,
   queryByXid,
   updateEntity,
   type StorableEntity,
@@ -69,7 +69,7 @@ async function upsertUser({
     xid: sub,
   } as UserEntity;
 
-  await putEntity({ entity });
+  await createEntity({ entity });
   log.debug("User created", { email, sub });
   return entity;
 }


### PR DESCRIPTION
Closes #293.

## Summary
- Replace `@jaypie/dynamodb`'s `putEntity` with `createEntity({ entity })`, which writes with `ConditionExpression: "attribute_not_exists(id)"` and returns `null` on `ConditionalCheckFailedException` instead of clobbering.
- `putEntity` was functionally identical to `updateEntity` and the silent-clobber behavior (documented in the Slack-thread incident in #293) was a footgun. Migrate by intent: create-only → `createEntity`, overwrite → `updateEntity`.
- Update internal seed paths, MCP tool (`dynamodb_put` → `dynamodb_create`), `@jaypie/fabric` FabricData create service, `@jaypie/testkit` mock, garden-ui/garden-api callsites, and all documentation.

## Versions
- `@jaypie/dynamodb` 0.5.0 → **0.6.0** (minor, breaking)
- `@jaypie/testkit` 1.2.32 → 1.2.33
- `@jaypie/mcp` 0.8.30 → 0.8.31
- `@jaypie/fabric` 0.3.0 → 0.3.1

## Test plan
- [x] `npm run test -w packages/dynamodb` (168 passed, including new `createEntity` cases: condition expression, null on CCFE, re-throws other errors)
- [x] `npm run test -w packages/testkit -w packages/fabric -w packages/mcp` all green
- [x] `npm run typecheck -w workspaces/garden-ui -w workspaces/garden-api` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)