### PR TITLE
fix(constructs): drop @jaypie/fabric runtime dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -146,6 +146,7 @@
     "node_modules/@algolia/client-search": {
       "version": "5.49.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.49.2",
         "@algolia/requester-browser-xhr": "5.49.2",
@@ -280,6 +281,7 @@
         "semver"
       ],
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "jsonschema": "~1.4.1",
         "semver": "^7.7.3"
@@ -528,6 +530,7 @@
     "node_modules/@aws-sdk/client-dynamodb": {
       "version": "3.1014.0",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -1518,6 +1521,7 @@
     "node_modules/@babel/core": {
       "version": "7.29.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1897,7 +1901,7 @@
     },
     "node_modules/@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -1908,7 +1912,7 @@
     },
     "node_modules/@babel/plugin-syntax-bigint": {
       "version": "7.8.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -1919,7 +1923,7 @@
     },
     "node_modules/@babel/plugin-syntax-class-properties": {
       "version": "7.12.13",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
@@ -1930,7 +1934,7 @@
     },
     "node_modules/@babel/plugin-syntax-class-static-block": {
       "version": "7.14.5",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -1980,7 +1984,7 @@
     },
     "node_modules/@babel/plugin-syntax-import-meta": {
       "version": "7.10.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -1991,7 +1995,7 @@
     },
     "node_modules/@babel/plugin-syntax-json-strings": {
       "version": "7.8.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -2015,7 +2019,7 @@
     },
     "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
       "version": "7.10.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -2026,7 +2030,7 @@
     },
     "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
       "version": "7.8.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -2037,7 +2041,7 @@
     },
     "node_modules/@babel/plugin-syntax-numeric-separator": {
       "version": "7.10.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -2048,7 +2052,7 @@
     },
     "node_modules/@babel/plugin-syntax-object-rest-spread": {
       "version": "7.8.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -2059,7 +2063,7 @@
     },
     "node_modules/@babel/plugin-syntax-optional-catch-binding": {
       "version": "7.8.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -2070,7 +2074,7 @@
     },
     "node_modules/@babel/plugin-syntax-optional-chaining": {
       "version": "7.8.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -2081,7 +2085,7 @@
     },
     "node_modules/@babel/plugin-syntax-private-property-in-object": {
       "version": "7.14.5",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -2095,7 +2099,7 @@
     },
     "node_modules/@babel/plugin-syntax-top-level-await": {
       "version": "7.14.5",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -3154,7 +3158,7 @@
     },
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@codegenie/serverless-express": {
@@ -3269,6 +3273,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -3289,6 +3294,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3388,6 +3394,7 @@
     "node_modules/@csstools/postcss-cascade-layers/node_modules/postcss-selector-parser": {
       "version": "7.1.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -3777,6 +3784,7 @@
     "node_modules/@csstools/postcss-is-pseudo-class/node_modules/postcss-selector-parser": {
       "version": "7.1.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -4686,6 +4694,7 @@
     "node_modules/@docusaurus/plugin-content-docs": {
       "version": "3.9.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@docusaurus/core": "3.9.2",
         "@docusaurus/logger": "3.9.2",
@@ -5553,7 +5562,6 @@
     },
     "node_modules/@eslint/config-array": {
       "version": "0.21.2",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/object-schema": "^2.1.7",
@@ -5566,7 +5574,6 @@
     },
     "node_modules/@eslint/config-helpers": {
       "version": "0.4.2",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/core": "^0.17.0"
@@ -5577,7 +5584,6 @@
     },
     "node_modules/@eslint/core": {
       "version": "0.17.0",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
@@ -5588,7 +5594,6 @@
     },
     "node_modules/@eslint/eslintrc": {
       "version": "3.3.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.14.0",
@@ -5620,7 +5625,6 @@
     },
     "node_modules/@eslint/object-schema": {
       "version": "2.1.7",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5628,7 +5632,6 @@
     },
     "node_modules/@eslint/plugin-kit": {
       "version": "0.4.1",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/core": "^0.17.0",
@@ -5697,7 +5700,6 @@
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
@@ -5705,7 +5707,6 @@
     },
     "node_modules/@humanfs/node": {
       "version": "0.16.7",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@humanfs/core": "^0.19.1",
@@ -5717,7 +5718,6 @@
     },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.22"
@@ -5729,7 +5729,6 @@
     },
     "node_modules/@humanwhocodes/retry": {
       "version": "0.4.3",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18"
@@ -5783,7 +5782,7 @@
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "camelcase": "^5.3.1",
@@ -5798,7 +5797,7 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
       "version": "1.0.10",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
@@ -5806,7 +5805,7 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
       "version": "4.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
@@ -5818,7 +5817,7 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
       "version": "3.14.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -5830,7 +5829,7 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
       "version": "5.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
@@ -5841,7 +5840,7 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
       "version": "2.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
@@ -5855,7 +5854,7 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
       "version": "4.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
@@ -5866,7 +5865,7 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
       "version": "5.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5874,7 +5873,7 @@
     },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5994,7 +5993,7 @@
     },
     "node_modules/@jest/console": {
       "version": "29.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -6010,7 +6009,7 @@
     },
     "node_modules/@jest/core": {
       "version": "29.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/console": "^29.7.0",
@@ -6056,7 +6055,7 @@
     },
     "node_modules/@jest/environment": {
       "version": "29.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/fake-timers": "^29.7.0",
@@ -6070,7 +6069,7 @@
     },
     "node_modules/@jest/expect": {
       "version": "29.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "expect": "^29.7.0",
@@ -6082,7 +6081,7 @@
     },
     "node_modules/@jest/expect-utils": {
       "version": "29.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "jest-get-type": "^29.6.3"
@@ -6093,7 +6092,7 @@
     },
     "node_modules/@jest/fake-timers": {
       "version": "29.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -6109,7 +6108,7 @@
     },
     "node_modules/@jest/globals": {
       "version": "29.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.7.0",
@@ -6123,7 +6122,7 @@
     },
     "node_modules/@jest/reporters": {
       "version": "29.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
@@ -6175,7 +6174,7 @@
     },
     "node_modules/@jest/source-map": {
       "version": "29.6.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.18",
@@ -6188,7 +6187,7 @@
     },
     "node_modules/@jest/test-result": {
       "version": "29.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/console": "^29.7.0",
@@ -6202,7 +6201,7 @@
     },
     "node_modules/@jest/test-sequencer": {
       "version": "29.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/test-result": "^29.7.0",
@@ -6216,7 +6215,7 @@
     },
     "node_modules/@jest/transform": {
       "version": "29.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -6720,6 +6719,7 @@
     "node_modules/@mdx-js/react": {
       "version": "3.1.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/mdx": "^2.0.0"
       },
@@ -6750,7 +6750,6 @@
     },
     "node_modules/@microsoft/api-extractor": {
       "version": "7.57.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@microsoft/api-extractor-model": "7.33.4",
@@ -6783,7 +6782,6 @@
     },
     "node_modules/@microsoft/api-extractor/node_modules/balanced-match": {
       "version": "4.0.4",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
@@ -6791,7 +6789,6 @@
     },
     "node_modules/@microsoft/api-extractor/node_modules/brace-expansion": {
       "version": "5.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -6802,7 +6799,6 @@
     },
     "node_modules/@microsoft/api-extractor/node_modules/lru-cache": {
       "version": "6.0.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -6813,7 +6809,6 @@
     },
     "node_modules/@microsoft/api-extractor/node_modules/minimatch": {
       "version": "10.2.3",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.2"
@@ -6827,7 +6822,6 @@
     },
     "node_modules/@microsoft/api-extractor/node_modules/semver": {
       "version": "7.5.4",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -6841,7 +6835,6 @@
     },
     "node_modules/@microsoft/api-extractor/node_modules/typescript": {
       "version": "5.8.2",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -6853,7 +6846,6 @@
     },
     "node_modules/@microsoft/api-extractor/node_modules/yallist": {
       "version": "4.0.0",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/@microsoft/tsdoc": {
@@ -6891,6 +6883,7 @@
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.27.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -8141,7 +8134,7 @@
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@rushstack/node-core-library": {
@@ -8169,6 +8162,7 @@
     "node_modules/@rushstack/node-core-library/node_modules/ajv": {
       "version": "8.18.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -8237,7 +8231,6 @@
     },
     "node_modules/@rushstack/rig-package": {
       "version": "0.7.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve": "~1.22.1",
@@ -8322,7 +8315,7 @@
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "type-detect": "4.0.8"
@@ -8330,7 +8323,7 @@
     },
     "node_modules/@sinonjs/fake-timers": {
       "version": "10.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
@@ -9115,6 +9108,7 @@
     "node_modules/@svgr/core": {
       "version": "8.1.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -9258,7 +9252,7 @@
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.20.7",
@@ -9270,7 +9264,7 @@
     },
     "node_modules/@types/babel__generator": {
       "version": "7.27.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.0.0"
@@ -9278,7 +9272,7 @@
     },
     "node_modules/@types/babel__template": {
       "version": "7.4.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.1.0",
@@ -9287,7 +9281,7 @@
     },
     "node_modules/@types/babel__traverse": {
       "version": "7.28.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.2"
@@ -9310,7 +9304,7 @@
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/deep-eql": "*",
@@ -9354,7 +9348,7 @@
     },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/eslint": {
@@ -9422,7 +9416,7 @@
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -9486,7 +9480,7 @@
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/mdast": {
@@ -9540,6 +9534,7 @@
     "node_modules/@types/react": {
       "version": "19.2.14",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -9633,7 +9628,7 @@
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/superagent": {
@@ -9732,6 +9727,7 @@
     "node_modules/@typescript-eslint/parser": {
       "version": "8.57.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.1",
         "@typescript-eslint/types": "8.57.1",
@@ -9974,7 +9970,7 @@
     },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
@@ -9989,7 +9985,7 @@
     },
     "node_modules/@vitest/mocker": {
       "version": "3.2.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/spy": "3.2.4",
@@ -10014,7 +10010,7 @@
     },
     "node_modules/@vitest/mocker/node_modules/estree-walker": {
       "version": "3.0.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
@@ -10022,7 +10018,7 @@
     },
     "node_modules/@vitest/pretty-format": {
       "version": "3.2.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tinyrainbow": "^2.0.0"
@@ -10033,7 +10029,7 @@
     },
     "node_modules/@vitest/runner": {
       "version": "3.2.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/utils": "3.2.4",
@@ -10046,7 +10042,7 @@
     },
     "node_modules/@vitest/snapshot": {
       "version": "3.2.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/pretty-format": "3.2.4",
@@ -10059,7 +10055,7 @@
     },
     "node_modules/@vitest/spy": {
       "version": "3.2.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tinyspy": "^4.0.3"
@@ -10070,7 +10066,7 @@
     },
     "node_modules/@vitest/utils": {
       "version": "3.2.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/pretty-format": "3.2.4",
@@ -10342,6 +10338,7 @@
     "node_modules/acorn": {
       "version": "8.16.0",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -10405,6 +10402,7 @@
     "node_modules/ajv": {
       "version": "6.14.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -10459,6 +10457,7 @@
     "node_modules/algoliasearch": {
       "version": "5.49.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/abtesting": "1.15.2",
         "@algolia/client-abtesting": "5.49.2",
@@ -10587,7 +10586,7 @@
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -10606,7 +10605,7 @@
     },
     "node_modules/array-includes": {
       "version": "3.1.9",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -10653,7 +10652,7 @@
     },
     "node_modules/array.prototype.findlastindex": {
       "version": "1.2.6",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -10673,7 +10672,7 @@
     },
     "node_modules/array.prototype.flat": {
       "version": "1.3.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -10690,7 +10689,7 @@
     },
     "node_modules/array.prototype.flatmap": {
       "version": "1.3.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -10722,7 +10721,7 @@
     },
     "node_modules/arraybuffer.prototype.slice": {
       "version": "1.0.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "array-buffer-byte-length": "^1.0.1",
@@ -10759,7 +10758,7 @@
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -10779,7 +10778,7 @@
     },
     "node_modules/async-function": {
       "version": "1.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10832,7 +10831,7 @@
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
@@ -10872,6 +10871,7 @@
         "mime-types"
       ],
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "2.2.263",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
@@ -11273,7 +11273,7 @@
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/transform": "^29.7.0",
@@ -11315,7 +11315,7 @@
     },
     "node_modules/babel-plugin-istanbul": {
       "version": "6.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -11330,7 +11330,7 @@
     },
     "node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
       "version": "5.2.1",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/core": "^7.12.3",
@@ -11345,7 +11345,7 @@
     },
     "node_modules/babel-plugin-istanbul/node_modules/semver": {
       "version": "6.3.1",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -11353,7 +11353,7 @@
     },
     "node_modules/babel-plugin-jest-hoist": {
       "version": "29.6.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.3.3",
@@ -11407,7 +11407,7 @@
     },
     "node_modules/babel-preset-current-node-syntax": {
       "version": "1.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-syntax-async-generators": "^7.8.4",
@@ -11432,7 +11432,7 @@
     },
     "node_modules/babel-preset-jest": {
       "version": "29.6.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "babel-plugin-jest-hoist": "^29.6.3",
@@ -11732,6 +11732,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -11748,7 +11749,7 @@
     },
     "node_modules/bser": {
       "version": "2.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
@@ -11816,7 +11817,7 @@
     },
     "node_modules/cac": {
       "version": "6.7.14",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11903,7 +11904,7 @@
     },
     "node_modules/camelcase": {
       "version": "5.3.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -11958,7 +11959,7 @@
     },
     "node_modules/chai": {
       "version": "5.3.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "assertion-error": "^2.0.1",
@@ -12026,7 +12027,7 @@
     },
     "node_modules/check-error": {
       "version": "2.1.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 16"
@@ -12120,7 +12121,7 @@
     },
     "node_modules/cjs-module-lexer": {
       "version": "1.4.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/clean-css": {
@@ -12169,7 +12170,7 @@
     },
     "node_modules/cliui": {
       "version": "8.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -12211,7 +12212,7 @@
     },
     "node_modules/co": {
       "version": "4.6.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "iojs": ">= 1.0.0",
@@ -12228,7 +12229,7 @@
     },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/color-convert": {
@@ -12424,7 +12425,8 @@
     },
     "node_modules/constructs": {
       "version": "10.5.1",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -12596,7 +12598,7 @@
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -12741,6 +12743,7 @@
     "node_modules/css-has-pseudo/node_modules/postcss-selector-parser": {
       "version": "7.1.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -13038,7 +13041,7 @@
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -13054,7 +13057,7 @@
     },
     "node_modules/data-view-byte-length": {
       "version": "1.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -13070,7 +13073,7 @@
     },
     "node_modules/data-view-byte-offset": {
       "version": "1.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -13173,7 +13176,7 @@
     },
     "node_modules/dedent": {
       "version": "1.7.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "babel-plugin-macros": "^3.1.0"
@@ -13186,7 +13189,7 @@
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -13201,7 +13204,6 @@
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/deepmerge": {
@@ -13328,7 +13330,7 @@
     },
     "node_modules/detect-newline": {
       "version": "3.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -13375,7 +13377,6 @@
     },
     "node_modules/diff": {
       "version": "8.0.3",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -13417,7 +13418,7 @@
     },
     "node_modules/doctrine": {
       "version": "2.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "esutils": "^2.0.2"
@@ -13566,7 +13567,7 @@
     },
     "node_modules/emittery": {
       "version": "0.13.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -13651,6 +13652,7 @@
     "node_modules/env-cmd/node_modules/commander": {
       "version": "13.1.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13664,7 +13666,7 @@
     },
     "node_modules/es-abstract": {
       "version": "1.24.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "array-buffer-byte-length": "^1.0.2",
@@ -13772,7 +13774,7 @@
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
@@ -13800,7 +13802,7 @@
     },
     "node_modules/es-shim-unscopables": {
       "version": "1.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -13811,7 +13813,7 @@
     },
     "node_modules/es-to-primitive": {
       "version": "1.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.2.7",
@@ -13925,7 +13927,6 @@
     },
     "node_modules/eslint": {
       "version": "9.39.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
@@ -14087,8 +14088,9 @@
     },
     "node_modules/eslint-import-resolver-node": {
       "version": "0.3.9",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^3.2.7",
         "is-core-module": "^2.13.0",
@@ -14097,7 +14099,7 @@
     },
     "node_modules/eslint-import-resolver-node/node_modules/debug": {
       "version": "3.2.7",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
@@ -14137,7 +14139,7 @@
     },
     "node_modules/eslint-module-utils": {
       "version": "2.12.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^3.2.7"
@@ -14153,7 +14155,7 @@
     },
     "node_modules/eslint-module-utils/node_modules/debug": {
       "version": "3.2.7",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
@@ -14161,8 +14163,9 @@
     },
     "node_modules/eslint-plugin-import": {
       "version": "2.32.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -14194,6 +14197,7 @@
     "node_modules/eslint-plugin-import-x": {
       "version": "4.16.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@package-json/types": "^0.0.12",
         "@typescript-eslint/types": "^8.56.0",
@@ -14258,7 +14262,7 @@
     },
     "node_modules/eslint-plugin-import/node_modules/debug": {
       "version": "3.2.7",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
@@ -14266,7 +14270,7 @@
     },
     "node_modules/eslint-plugin-import/node_modules/semver": {
       "version": "6.3.1",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -14635,7 +14639,6 @@
     },
     "node_modules/eslint-scope": {
       "version": "8.4.0",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -14650,7 +14653,6 @@
     },
     "node_modules/eslint-visitor-keys": {
       "version": "4.2.1",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -14661,7 +14663,6 @@
     },
     "node_modules/espree": {
       "version": "10.4.0",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.15.0",
@@ -14688,7 +14689,6 @@
     },
     "node_modules/esquery": {
       "version": "1.7.0",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -14897,14 +14897,14 @@
     },
     "node_modules/exit": {
       "version": "0.1.2",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.8.0"
       }
     },
     "node_modules/expect": {
       "version": "29.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/expect-utils": "^29.7.0",
@@ -14919,7 +14919,7 @@
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
@@ -14928,6 +14928,7 @@
     "node_modules/express": {
       "version": "4.22.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -15070,7 +15071,6 @@
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-safe-stringify": {
@@ -15153,7 +15153,7 @@
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
@@ -15228,7 +15228,6 @@
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flat-cache": "^4.0.0"
@@ -15407,7 +15406,6 @@
     },
     "node_modules/find-up": {
       "version": "5.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
@@ -15429,7 +15427,6 @@
     },
     "node_modules/flat-cache": {
       "version": "4.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flatted": "^3.2.9",
@@ -15445,7 +15442,6 @@
     },
     "node_modules/flatted": {
       "version": "3.4.2",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
@@ -15468,7 +15464,7 @@
     },
     "node_modules/for-each": {
       "version": "0.3.5",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.2.7"
@@ -15573,7 +15569,7 @@
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
@@ -15596,7 +15592,7 @@
     },
     "node_modules/function.prototype.name": {
       "version": "1.1.8",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -15615,7 +15611,7 @@
     },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -15649,7 +15645,7 @@
     },
     "node_modules/generator-function": {
       "version": "2.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -15664,7 +15660,7 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -15698,7 +15694,7 @@
     },
     "node_modules/get-package-type": {
       "version": "0.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
@@ -15727,7 +15723,7 @@
     },
     "node_modules/get-symbol-description": {
       "version": "1.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -15764,7 +15760,7 @@
     },
     "node_modules/glob": {
       "version": "7.2.3",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -15824,7 +15820,6 @@
     },
     "node_modules/globals": {
       "version": "14.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -15835,7 +15830,7 @@
     },
     "node_modules/globalthis": {
       "version": "1.0.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "define-properties": "^1.2.1",
@@ -15987,7 +15982,7 @@
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -16015,7 +16010,7 @@
     },
     "node_modules/has-proto": {
       "version": "1.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.0"
@@ -16262,6 +16257,7 @@
     "node_modules/hono": {
       "version": "4.12.8",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -16599,7 +16595,7 @@
     },
     "node_modules/import-local": {
       "version": "3.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "pkg-dir": "^4.2.0",
@@ -16638,7 +16634,7 @@
     },
     "node_modules/inflight": {
       "version": "1.0.6",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -16662,7 +16658,7 @@
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -16716,7 +16712,7 @@
     },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -16736,7 +16732,7 @@
     },
     "node_modules/is-async-function": {
       "version": "2.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "async-function": "^1.0.0",
@@ -16754,7 +16750,7 @@
     },
     "node_modules/is-bigint": {
       "version": "1.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-bigints": "^1.0.2"
@@ -16778,7 +16774,7 @@
     },
     "node_modules/is-boolean-object": {
       "version": "1.2.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -16800,7 +16796,7 @@
     },
     "node_modules/is-callable": {
       "version": "1.2.7",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -16834,7 +16830,7 @@
     },
     "node_modules/is-data-view": {
       "version": "1.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -16850,7 +16846,7 @@
     },
     "node_modules/is-date-object": {
       "version": "1.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -16900,7 +16896,7 @@
     },
     "node_modules/is-finalizationregistry": {
       "version": "1.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3"
@@ -16921,7 +16917,7 @@
     },
     "node_modules/is-generator-fn": {
       "version": "2.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -16929,7 +16925,7 @@
     },
     "node_modules/is-generator-function": {
       "version": "1.1.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.4",
@@ -17008,7 +17004,7 @@
     },
     "node_modules/is-map": {
       "version": "2.0.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -17024,7 +17020,7 @@
     },
     "node_modules/is-negative-zero": {
       "version": "2.0.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -17062,7 +17058,7 @@
     },
     "node_modules/is-number-object": {
       "version": "1.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -17121,7 +17117,7 @@
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -17145,7 +17141,7 @@
     },
     "node_modules/is-set": {
       "version": "2.0.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -17156,7 +17152,7 @@
     },
     "node_modules/is-shared-array-buffer": {
       "version": "1.0.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3"
@@ -17180,7 +17176,7 @@
     },
     "node_modules/is-string": {
       "version": "1.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -17195,7 +17191,7 @@
     },
     "node_modules/is-symbol": {
       "version": "1.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -17211,7 +17207,7 @@
     },
     "node_modules/is-typed-array": {
       "version": "1.1.15",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "which-typed-array": "^1.1.16"
@@ -17229,7 +17225,7 @@
     },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -17240,7 +17236,7 @@
     },
     "node_modules/is-weakref": {
       "version": "1.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3"
@@ -17254,7 +17250,7 @@
     },
     "node_modules/is-weakset": {
       "version": "2.0.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -17286,7 +17282,7 @@
     },
     "node_modules/isarray": {
       "version": "2.0.5",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -17302,7 +17298,7 @@
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=8"
@@ -17310,7 +17306,7 @@
     },
     "node_modules/istanbul-lib-instrument": {
       "version": "6.0.3",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/core": "^7.23.9",
@@ -17325,7 +17321,7 @@
     },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "istanbul-lib-coverage": "^3.0.0",
@@ -17338,7 +17334,7 @@
     },
     "node_modules/istanbul-lib-source-maps": {
       "version": "4.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "debug": "^4.1.1",
@@ -17351,7 +17347,7 @@
     },
     "node_modules/istanbul-reports": {
       "version": "3.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "html-escaper": "^2.0.0",
@@ -17383,8 +17379,9 @@
     },
     "node_modules/jest": {
       "version": "29.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -17408,7 +17405,7 @@
     },
     "node_modules/jest-changed-files": {
       "version": "29.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "execa": "^5.0.0",
@@ -17421,7 +17418,7 @@
     },
     "node_modules/jest-circus": {
       "version": "29.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.7.0",
@@ -17451,7 +17448,7 @@
     },
     "node_modules/jest-cli": {
       "version": "29.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/core": "^29.7.0",
@@ -17483,7 +17480,7 @@
     },
     "node_modules/jest-config": {
       "version": "29.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -17540,7 +17537,7 @@
     },
     "node_modules/jest-docblock": {
       "version": "29.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "detect-newline": "^3.0.0"
@@ -17551,7 +17548,7 @@
     },
     "node_modules/jest-each": {
       "version": "29.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -17566,7 +17563,7 @@
     },
     "node_modules/jest-environment-node": {
       "version": "29.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.7.0",
@@ -17608,7 +17605,7 @@
     },
     "node_modules/jest-haste-map": {
       "version": "29.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -17744,7 +17741,7 @@
     },
     "node_modules/jest-leak-detector": {
       "version": "29.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "jest-get-type": "^29.6.3",
@@ -17756,7 +17753,7 @@
     },
     "node_modules/jest-matcher-utils": {
       "version": "29.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
@@ -17770,7 +17767,7 @@
     },
     "node_modules/jest-message-util": {
       "version": "29.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
@@ -17789,7 +17786,7 @@
     },
     "node_modules/jest-mock": {
       "version": "29.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -17802,7 +17799,7 @@
     },
     "node_modules/jest-pnp-resolver": {
       "version": "1.2.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -17818,7 +17815,7 @@
     },
     "node_modules/jest-regex-util": {
       "version": "29.6.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -17826,7 +17823,7 @@
     },
     "node_modules/jest-resolve": {
       "version": "29.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
@@ -17845,7 +17842,7 @@
     },
     "node_modules/jest-resolve-dependencies": {
       "version": "29.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "jest-regex-util": "^29.6.3",
@@ -17857,7 +17854,7 @@
     },
     "node_modules/jest-runner": {
       "version": "29.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/console": "^29.7.0",
@@ -17888,7 +17885,7 @@
     },
     "node_modules/jest-runtime": {
       "version": "29.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.7.0",
@@ -17920,7 +17917,7 @@
     },
     "node_modules/jest-snapshot": {
       "version": "29.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -17975,7 +17972,7 @@
     },
     "node_modules/jest-validate": {
       "version": "29.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -17991,7 +17988,7 @@
     },
     "node_modules/jest-validate/node_modules/camelcase": {
       "version": "6.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -18002,7 +17999,7 @@
     },
     "node_modules/jest-watcher": {
       "version": "29.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/test-result": "^29.7.0",
@@ -18140,7 +18137,6 @@
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json5": {
@@ -18276,7 +18272,6 @@
     },
     "node_modules/levn": {
       "version": "0.4.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1",
@@ -18375,7 +18370,6 @@
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
@@ -18409,7 +18403,6 @@
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.uniq": {
@@ -18441,7 +18434,7 @@
     },
     "node_modules/loupe": {
       "version": "3.2.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/lower-case": {
@@ -18484,7 +18477,7 @@
     },
     "node_modules/make-dir": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^7.5.3"
@@ -18498,7 +18491,7 @@
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tmpl": "1.0.5"
@@ -20862,6 +20855,7 @@
     "node_modules/next": {
       "version": "16.2.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "16.2.1",
         "@swc/helpers": "0.5.15",
@@ -21019,7 +21013,7 @@
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/node-releases": {
@@ -21185,7 +21179,7 @@
     },
     "node_modules/object.fromentries": {
       "version": "2.0.8",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -21202,7 +21196,7 @@
     },
     "node_modules/object.groupby": {
       "version": "1.0.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -21215,7 +21209,7 @@
     },
     "node_modules/object.values": {
       "version": "1.2.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -21321,7 +21315,6 @@
     },
     "node_modules/optionator": {
       "version": "0.9.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "deep-is": "^0.1.3",
@@ -21337,7 +21330,7 @@
     },
     "node_modules/own-keys": {
       "version": "1.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.2.6",
@@ -21367,7 +21360,6 @@
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -21381,7 +21373,6 @@
     },
     "node_modules/p-locate": {
       "version": "5.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
@@ -21449,7 +21440,7 @@
     },
     "node_modules/p-try": {
       "version": "2.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -21591,7 +21582,6 @@
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -21612,7 +21602,7 @@
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -21671,12 +21661,12 @@
     },
     "node_modules/pathe": {
       "version": "2.0.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/pathval": {
       "version": "2.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.16"
@@ -21720,7 +21710,7 @@
     },
     "node_modules/pirates": {
       "version": "4.0.7",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -21735,7 +21725,7 @@
     },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "find-up": "^4.0.0"
@@ -21746,7 +21736,7 @@
     },
     "node_modules/pkg-dir/node_modules/find-up": {
       "version": "4.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
@@ -21758,7 +21748,7 @@
     },
     "node_modules/pkg-dir/node_modules/locate-path": {
       "version": "5.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
@@ -21769,7 +21759,7 @@
     },
     "node_modules/pkg-dir/node_modules/p-limit": {
       "version": "2.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
@@ -21783,7 +21773,7 @@
     },
     "node_modules/pkg-dir/node_modules/p-locate": {
       "version": "4.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
@@ -21829,7 +21819,7 @@
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -21852,6 +21842,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -22659,6 +22650,7 @@
     "node_modules/postcss-nesting/node_modules/postcss-selector-parser": {
       "version": "7.1.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -23144,7 +23136,6 @@
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
@@ -23153,6 +23144,7 @@
     "node_modules/prettier": {
       "version": "3.8.1",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -23328,7 +23320,7 @@
     },
     "node_modules/pure-rand": {
       "version": "6.1.0",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "individual",
@@ -23479,6 +23471,7 @@
     "node_modules/react": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -23489,6 +23482,7 @@
     "node_modules/react-dom": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -23535,6 +23529,7 @@
       "name": "@docusaurus/react-loadable",
       "version": "6.0.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/react": "*"
       },
@@ -23559,6 +23554,7 @@
     "node_modules/react-router": {
       "version": "5.3.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -23726,7 +23722,7 @@
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -23761,7 +23757,7 @@
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -24070,7 +24066,7 @@
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -24117,7 +24113,7 @@
     },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "resolve-from": "^5.0.0"
@@ -24128,7 +24124,7 @@
     },
     "node_modules/resolve-cwd/node_modules/resolve-from": {
       "version": "5.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -24154,7 +24150,7 @@
     },
     "node_modules/resolve.exports": {
       "version": "2.0.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -24252,8 +24248,9 @@
     },
     "node_modules/rollup": {
       "version": "4.59.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -24475,7 +24472,7 @@
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -24511,7 +24508,7 @@
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -24526,7 +24523,7 @@
     },
     "node_modules/safe-regex-test": {
       "version": "1.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -24587,6 +24584,7 @@
     "node_modules/schema-utils/node_modules/ajv": {
       "version": "8.18.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -24870,7 +24868,7 @@
     },
     "node_modules/set-function-name": {
       "version": "2.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -24884,7 +24882,7 @@
     },
     "node_modules/set-proto": {
       "version": "1.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -25054,7 +25052,7 @@
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/signal-exit": {
@@ -25195,7 +25193,7 @@
     },
     "node_modules/source-map-support": {
       "version": "0.5.13",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -25300,7 +25298,7 @@
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^2.0.0"
@@ -25311,7 +25309,7 @@
     },
     "node_modules/stack-utils/node_modules/escape-string-regexp": {
       "version": "2.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -25319,7 +25317,7 @@
     },
     "node_modules/stackback": {
       "version": "0.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/statuses": {
@@ -25335,7 +25333,7 @@
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -25361,7 +25359,7 @@
     },
     "node_modules/string-length": {
       "version": "4.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "char-regex": "^1.0.2",
@@ -25433,7 +25431,7 @@
     },
     "node_modules/string.prototype.trim": {
       "version": "1.2.10",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -25453,7 +25451,7 @@
     },
     "node_modules/string.prototype.trimend": {
       "version": "1.0.9",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -25470,7 +25468,7 @@
     },
     "node_modules/string.prototype.trimstart": {
       "version": "1.0.8",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -25520,7 +25518,7 @@
     },
     "node_modules/strip-bom": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -25552,7 +25550,7 @@
     },
     "node_modules/strip-literal": {
       "version": "3.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^9.0.1"
@@ -25563,7 +25561,7 @@
     },
     "node_modules/strip-literal/node_modules/js-tokens": {
       "version": "9.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/strnum": {
@@ -25832,7 +25830,7 @@
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "@istanbuljs/schema": "^0.1.2",
@@ -25871,12 +25869,12 @@
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/tinyexec": {
       "version": "0.3.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
@@ -25902,7 +25900,7 @@
     },
     "node_modules/tinyrainbow": {
       "version": "2.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -25910,7 +25908,7 @@
     },
     "node_modules/tinyspy": {
       "version": "4.0.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -25918,7 +25916,7 @@
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/to-regex-range": {
@@ -26003,7 +26001,7 @@
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/json5": "^0.0.29",
@@ -26014,7 +26012,7 @@
     },
     "node_modules/tsconfig-paths/node_modules/json5": {
       "version": "1.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.0"
@@ -26025,7 +26023,7 @@
     },
     "node_modules/tsconfig-paths/node_modules/strip-bom": {
       "version": "3.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -26033,7 +26031,8 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -26068,7 +26067,6 @@
     },
     "node_modules/type-check": {
       "version": "0.4.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1"
@@ -26079,7 +26077,7 @@
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -26108,7 +26106,7 @@
     },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -26121,7 +26119,7 @@
     },
     "node_modules/typed-array-byte-length": {
       "version": "1.0.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -26139,7 +26137,7 @@
     },
     "node_modules/typed-array-byte-offset": {
       "version": "1.0.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
@@ -26159,7 +26157,7 @@
     },
     "node_modules/typed-array-length": {
       "version": "1.0.7",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -26185,7 +26183,6 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -26223,7 +26220,7 @@
     },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -26687,7 +26684,7 @@
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.12",
@@ -26763,8 +26760,9 @@
     },
     "node_modules/vite": {
       "version": "7.3.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -26836,7 +26834,7 @@
     },
     "node_modules/vite-node": {
       "version": "3.2.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
@@ -26882,8 +26880,9 @@
     },
     "node_modules/vitest": {
       "version": "3.2.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -26958,7 +26957,7 @@
     },
     "node_modules/walker": {
       "version": "1.0.8",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
@@ -27009,6 +27008,7 @@
     "node_modules/webpack": {
       "version": "5.105.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -27212,6 +27212,7 @@
     "node_modules/webpack-dev-server/node_modules/@types/express": {
       "version": "4.17.25",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -27452,7 +27453,7 @@
     },
     "node_modules/which-boxed-primitive": {
       "version": "1.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-bigint": "^1.1.0",
@@ -27470,7 +27471,7 @@
     },
     "node_modules/which-builtin-type": {
       "version": "1.2.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -27496,7 +27497,7 @@
     },
     "node_modules/which-collection": {
       "version": "1.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-map": "^2.0.3",
@@ -27513,7 +27514,7 @@
     },
     "node_modules/which-typed-array": {
       "version": "1.1.20",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
@@ -27533,7 +27534,7 @@
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "siginfo": "^2.0.0",
@@ -27607,7 +27608,6 @@
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -27634,7 +27634,7 @@
     },
     "node_modules/write-file-atomic": {
       "version": "4.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4",
@@ -27711,7 +27711,7 @@
     },
     "node_modules/y18n": {
       "version": "5.0.8",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -27723,7 +27723,7 @@
     },
     "node_modules/yargs": {
       "version": "17.7.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -27740,7 +27740,7 @@
     },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -27748,7 +27748,6 @@
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -27786,6 +27785,7 @@
     "node_modules/zod": {
       "version": "4.3.6",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -27861,11 +27861,10 @@
     },
     "packages/constructs": {
       "name": "@jaypie/constructs",
-      "version": "1.2.43",
+      "version": "1.2.44",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*",
-        "@jaypie/fabric": "*",
         "aws-cdk-lib": "^2.232.1",
         "cdk-nextjs-standalone": "^4.3.2",
         "constructs": "^10.4.3",
@@ -28694,7 +28693,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.31",
+      "version": "0.8.32",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.4",
@@ -28762,7 +28761,7 @@
     },
     "packages/mcp/node_modules/accepts": {
       "version": "2.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "mime-types": "^3.0.0",
@@ -28774,7 +28773,7 @@
     },
     "packages/mcp/node_modules/body-parser": {
       "version": "2.2.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
@@ -28798,13 +28797,14 @@
     "packages/mcp/node_modules/commander": {
       "version": "14.0.3",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20"
       }
     },
     "packages/mcp/node_modules/content-disposition": {
       "version": "1.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -28816,8 +28816,9 @@
     },
     "packages/mcp/node_modules/express": {
       "version": "5.2.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -28858,7 +28859,7 @@
     },
     "packages/mcp/node_modules/finalhandler": {
       "version": "2.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -28878,7 +28879,7 @@
     },
     "packages/mcp/node_modules/fresh": {
       "version": "2.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -28886,7 +28887,7 @@
     },
     "packages/mcp/node_modules/iconv-lite": {
       "version": "0.7.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -28901,7 +28902,7 @@
     },
     "packages/mcp/node_modules/media-typer": {
       "version": "1.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -28909,7 +28910,7 @@
     },
     "packages/mcp/node_modules/merge-descriptors": {
       "version": "2.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -28920,7 +28921,7 @@
     },
     "packages/mcp/node_modules/mime-db": {
       "version": "1.54.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -28928,7 +28929,7 @@
     },
     "packages/mcp/node_modules/mime-types": {
       "version": "3.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
@@ -28943,7 +28944,7 @@
     },
     "packages/mcp/node_modules/negotiator": {
       "version": "1.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -28951,7 +28952,7 @@
     },
     "packages/mcp/node_modules/send": {
       "version": "1.2.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.3",
@@ -28976,7 +28977,7 @@
     },
     "packages/mcp/node_modules/serve-static": {
       "version": "2.2.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "encodeurl": "^2.0.0",
@@ -28994,7 +28995,7 @@
     },
     "packages/mcp/node_modules/type-is": {
       "version": "2.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "content-type": "^1.0.5",
@@ -29418,6 +29419,7 @@
     "workspaces/garden-ui/node_modules/react": {
       "version": "19.2.4",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }

--- a/packages/constructs/CLAUDE.md
+++ b/packages/constructs/CLAUDE.md
@@ -276,7 +276,7 @@ const namedTable = new JaypieDynamoDb(this, "myApp", {
   tableName: "my-explicit-table-name",
 });
 
-// With custom indexes using IndexDefinition from @jaypie/fabric
+// With custom indexes using IndexDefinition (owned by @jaypie/constructs)
 const customTable = new JaypieDynamoDb(this, "myApp", {
   indexes: [
     { pk: ["scope", "model"], sk: ["sequence"] },           // indexScopeModel
@@ -286,7 +286,7 @@ const customTable = new JaypieDynamoDb(this, "myApp", {
 });
 ```
 
-Note: `JaypieDynamoDb` uses `IndexDefinition` from `@jaypie/fabric` for GSI configuration, enabling consistent index definitions across CDK and runtime code. Table names default to CDK-generated names for proper namespacing across environments; use the `tableName` prop only when an explicit name is required.
+Note: `JaypieDynamoDb` uses its own `IndexDefinition` type for GSI configuration. The shape matches `@jaypie/fabric`'s `IndexDefinition`, so a single object literal can be shared between CDK provisioning and runtime model code without taking a runtime dependency on pre-1.0 fabric. Table names default to CDK-generated names for proper namespacing across environments; use the `tableName` prop only when an explicit name is required.
 
 ### Next.js Deployment
 

--- a/packages/constructs/package.json
+++ b/packages/constructs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/constructs",
-  "version": "1.2.43",
+  "version": "1.2.44",
   "description": "CDK constructs for Jaypie applications",
   "repository": {
     "type": "git",
@@ -32,7 +32,6 @@
   },
   "dependencies": {
     "@jaypie/errors": "*",
-    "@jaypie/fabric": "*",
     "aws-cdk-lib": "^2.232.1",
     "cdk-nextjs-standalone": "^4.3.2",
     "constructs": "^10.4.3",

--- a/packages/constructs/rollup.config.js
+++ b/packages/constructs/rollup.config.js
@@ -27,7 +27,6 @@ export default [
     ],
     external: [
       "@jaypie/errors",
-      "@jaypie/fabric",
       "aws-cdk-lib",
       "aws-cdk-lib/aws-accessanalyzer",
       "aws-cdk-lib/aws-apigateway",
@@ -84,7 +83,6 @@ export default [
     ],
     external: [
       "@jaypie/errors",
-      "@jaypie/fabric",
       "aws-cdk-lib",
       "aws-cdk-lib/aws-accessanalyzer",
       "aws-cdk-lib/aws-apigateway",

--- a/packages/constructs/src/JaypieDynamoDb.ts
+++ b/packages/constructs/src/JaypieDynamoDb.ts
@@ -2,13 +2,9 @@ import { Construct } from "constructs";
 import { RemovalPolicy, Tags } from "aws-cdk-lib";
 import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
 
-import {
-  getGsiAttributeNames,
-  type IndexDefinition,
-} from "@jaypie/fabric";
-
 import { CDK } from "./constants";
 import { isProductionEnv } from "./helpers/isEnv";
+import type { IndexDefinition } from "./types/IndexDefinition";
 
 //
 //
@@ -16,13 +12,43 @@ import { isProductionEnv } from "./helpers/isEnv";
 //
 
 /**
- * Convert IndexDefinition[] from @jaypie/fabric to CDK GlobalSecondaryIndexPropsV2[].
+ * Derive GSI attribute names for an index definition.
  *
- * Uses `getGsiAttributeNames` as the single source of truth so runtime writes
- * and CDK provisioning agree on attribute names. Composite sk indexes
- * (sk.length > 1) get a dedicated STRING `{indexName}Sk` attribute; single-field
- * sk indexes reference the field directly (STRING in the general case, NUMBER
- * for the legacy `sequence` name).
+ * Mirrors `@jaypie/fabric`'s `getGsiAttributeNames` so CDK provisioning and
+ * any runtime write path agree on the attribute names. Kept local to avoid
+ * a runtime dependency on the pre-1.0 `@jaypie/fabric` package.
+ *
+ * - `pk` is always the index name (`index.name` or generated from `index.pk`)
+ * - `sk` is the single sk field name when `sk.length === 1`, or
+ *   `{indexName}Sk` when `sk.length > 1` (composite sk attribute)
+ */
+function getGsiAttributeNames(index: IndexDefinition): {
+  pk: string;
+  sk: string | undefined;
+} {
+  const name = index.name ?? generateIndexName(index.pk);
+  let sk: string | undefined;
+  if (index.sk && index.sk.length > 1) {
+    sk = `${name}Sk`;
+  } else if (index.sk && index.sk.length === 1) {
+    sk = index.sk[0];
+  }
+  return { pk: name, sk };
+}
+
+function generateIndexName(pk: string[]): string {
+  const suffix = pk
+    .map((field) => field.charAt(0).toUpperCase() + field.slice(1))
+    .join("");
+  return `index${suffix}`;
+}
+
+/**
+ * Convert IndexDefinition[] to CDK GlobalSecondaryIndexPropsV2[].
+ *
+ * Composite sk indexes (sk.length > 1) get a dedicated STRING `{indexName}Sk`
+ * attribute; single-field sk indexes reference the field directly (STRING in
+ * the general case, NUMBER for the legacy `sequence` name).
  */
 function indexesToGsi(
   indexes: IndexDefinition[],
@@ -61,19 +87,21 @@ export interface JaypieDynamoDbProps extends Omit<
   "globalSecondaryIndexes" | "partitionKey" | "sortKey"
 > {
   /**
-   * Configure GSIs for the table using @jaypie/fabric IndexDefinition format.
+   * Configure GSIs for the table using the IndexDefinition format.
    * - `undefined`: No GSIs (default)
-   * - Array of IndexDefinition: Use the specified indexes (prefer fabricIndex())
+   * - Array of IndexDefinition: Use the specified indexes
    *
    * @example
    * // No GSIs (default)
    * new JaypieDynamoDb(this, "myTable");
    *
    * @example
-   * // With fabricIndex-shaped indexes
-   * import { fabricIndex } from "@jaypie/fabric";
+   * // Inline indexes
    * new JaypieDynamoDb(this, "myTable", {
-   *   indexes: [fabricIndex(), fabricIndex("alias"), fabricIndex("xid")],
+   *   indexes: [
+   *     { name: "indexModel", pk: ["model"], sk: ["scope", "updatedAt"] },
+   *     { name: "indexModelAlias", pk: ["model", "alias"], sk: ["scope", "updatedAt"], sparse: true },
+   *   ],
    * });
    */
   indexes?: IndexDefinition[];
@@ -125,11 +153,13 @@ export interface JaypieDynamoDbProps extends Omit<
  * const table = new JaypieDynamoDb(this, "myApp");
  *
  * @example
- * // With fabricIndex() for GSIs
- * import { fabricIndex } from "@jaypie/fabric";
+ * // With inline IndexDefinition for GSIs
  * const table = new JaypieDynamoDb(this, "MyTable", {
  *   tableName: "custom-table-name",
- *   indexes: [fabricIndex(), fabricIndex("alias"), fabricIndex("xid")],
+ *   indexes: [
+ *     { name: "indexModel", pk: ["model"], sk: ["scope", "updatedAt"] },
+ *     { name: "indexModelAlias", pk: ["model", "alias"], sk: ["scope", "updatedAt"], sparse: true },
+ *   ],
  * });
  */
 export class JaypieDynamoDb extends Construct implements dynamodb.ITableV2 {

--- a/packages/constructs/src/__tests__/JaypieDynamoDb.spec.ts
+++ b/packages/constructs/src/__tests__/JaypieDynamoDb.spec.ts
@@ -2,15 +2,25 @@ import { describe, expect, it, beforeEach, afterEach } from "vitest";
 import { Stack, RemovalPolicy } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
 import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
-import { fabricIndex } from "@jaypie/fabric";
 import { JaypieDynamoDb } from "../JaypieDynamoDb.js";
+import type { IndexDefinition } from "../types/IndexDefinition.js";
 
-const STANDARD_INDEXES = [
-  fabricIndex(),
-  fabricIndex("alias"),
-  fabricIndex("category"),
-  fabricIndex("type"),
-  fabricIndex("xid"),
+const indexModel = (field?: string): IndexDefinition =>
+  field
+    ? {
+        name: `indexModel${field.charAt(0).toUpperCase()}${field.slice(1)}`,
+        pk: ["model", field],
+        sk: ["scope", "updatedAt"],
+        sparse: true,
+      }
+    : { name: "indexModel", pk: ["model"], sk: ["scope", "updatedAt"] };
+
+const STANDARD_INDEXES: IndexDefinition[] = [
+  indexModel(),
+  indexModel("alias"),
+  indexModel("category"),
+  indexModel("type"),
+  indexModel("xid"),
 ];
 
 describe("JaypieDynamoDb", () => {
@@ -175,7 +185,7 @@ describe("JaypieDynamoDb", () => {
       const stack = new Stack();
       new JaypieDynamoDb(stack, "TestTable", {
         tableName: "test-table",
-        indexes: [fabricIndex(), fabricIndex("alias")],
+        indexes: [indexModel(), indexModel("alias")],
       });
       const template = Template.fromStack(stack);
 
@@ -183,10 +193,10 @@ describe("JaypieDynamoDb", () => {
       const tableResource = Object.values(tables)[0];
 
       const gsis = tableResource?.Properties?.GlobalSecondaryIndexes;
-      const indexModel = gsis.find(
+      const indexModelGsi = gsis.find(
         (g: { IndexName: string }) => g.IndexName === "indexModel",
       );
-      const keySchema = indexModel?.KeySchema;
+      const keySchema = indexModelGsi?.KeySchema;
       expect(keySchema).toContainEqual({
         AttributeName: "indexModel",
         KeyType: "HASH",
@@ -201,7 +211,7 @@ describe("JaypieDynamoDb", () => {
       const stack = new Stack();
       new JaypieDynamoDb(stack, "TestTable", {
         tableName: "test-table",
-        indexes: [fabricIndex()],
+        indexes: [indexModel()],
       });
       const template = Template.fromStack(stack);
 
@@ -233,7 +243,7 @@ describe("JaypieDynamoDb", () => {
       const stack = new Stack();
       new JaypieDynamoDb(stack, "TestTable", {
         tableName: "test-table",
-        indexes: [fabricIndex(), fabricIndex("type")],
+        indexes: [indexModel(), indexModel("type")],
       });
       const template = Template.fromStack(stack);
 
@@ -253,7 +263,7 @@ describe("JaypieDynamoDb", () => {
       const stack = new Stack();
       new JaypieDynamoDb(stack, "TestTable", {
         tableName: "test-table",
-        indexes: [fabricIndex("taco")],
+        indexes: [indexModel("taco")],
       });
       const template = Template.fromStack(stack);
 

--- a/packages/constructs/src/index.ts
+++ b/packages/constructs/src/index.ts
@@ -26,8 +26,8 @@ export {
 } from "./JaypieDistribution";
 export { JaypieDnsRecord, JaypieDnsRecordProps } from "./JaypieDnsRecord";
 export { JaypieDynamoDb, JaypieDynamoDbProps } from "./JaypieDynamoDb";
-// Re-export IndexDefinition type for custom GSI definitions
-export type { IndexDefinition } from "@jaypie/fabric";
+// IndexDefinition type for custom GSI definitions
+export type { IndexDefinition } from "./types/IndexDefinition";
 export { JaypieEnvSecret } from "./JaypieEnvSecret";
 export { JaypieEventsRule, JaypieEventsRuleProps } from "./JaypieEventsRule";
 export { JaypieExpressLambda } from "./JaypieExpressLambda";

--- a/packages/constructs/src/types/IndexDefinition.ts
+++ b/packages/constructs/src/types/IndexDefinition.ts
@@ -1,0 +1,22 @@
+/**
+ * GSI index definition for JaypieDynamoDb.
+ *
+ * Shape mirrors `@jaypie/fabric`'s IndexDefinition so a single object can be
+ * shared between CDK provisioning (here) and runtime model code (fabric).
+ * The type is owned locally so `@jaypie/constructs` does not take a runtime
+ * dependency on the pre-1.0 `@jaypie/fabric` package.
+ *
+ * - `pk` fields are combined with a separator to form the partition key attribute
+ * - `sk` with one field uses that field directly as the GSI sort key
+ * - `sk` with multiple fields produces a composite `{indexName}Sk` attribute
+ */
+export interface IndexDefinition {
+  /** Name of the index (auto-generated from pk fields if not provided) */
+  name?: string;
+  /** Partition key fields - combined with separator */
+  pk: string[];
+  /** Sort key fields - combined with separator when composite */
+  sk?: string[];
+  /** Advisory: index key is only written when all pk/sk fields are present */
+  sparse?: boolean;
+}

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.31",
+  "version": "0.8.32",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/constructs/1.2.44.md
+++ b/packages/mcp/release-notes/constructs/1.2.44.md
@@ -1,0 +1,16 @@
+---
+version: 1.2.44
+date: 2026-04-14
+summary: Drop @jaypie/fabric runtime dependency; IndexDefinition is now owned locally
+---
+
+## Changes
+
+- `@jaypie/constructs` no longer depends on `@jaypie/fabric` at runtime
+- `IndexDefinition` is now declared inside `@jaypie/constructs` (same shape as fabric's)
+- GSI attribute-name derivation (`getGsiAttributeNames`) is inlined into `JaypieDynamoDb`
+- Consumers of `@jaypie/constructs` no longer transitively pick up pre-1.0 `@jaypie/fabric`
+
+## Why
+
+Stable packages should not take runtime deps on experimental pre-1.0 packages. Constructs only used 3 symbols from fabric (all trivial), so inlining removes the coupling without losing functionality. Apps that want fabric's runtime model/index utilities still import it directly.

--- a/packages/mcp/release-notes/mcp/0.8.32.md
+++ b/packages/mcp/release-notes/mcp/0.8.32.md
@@ -1,0 +1,9 @@
+---
+version: 0.8.32
+date: 2026-04-14
+summary: Include @jaypie/constructs 1.2.44 release notes
+---
+
+## Changes
+
+- Adds release notes for `@jaypie/constructs@1.2.44` (drop `@jaypie/fabric` runtime dependency)


### PR DESCRIPTION
## Summary
- Closes #295
- `@jaypie/constructs` no longer runtime-depends on pre-1.0 `@jaypie/fabric`
- `IndexDefinition` and GSI attribute-name helpers inlined into constructs; shape preserved so the same object literal still works across CDK and fabric runtime code when an app opts in
- Bumps `@jaypie/constructs` → 1.2.44 and `@jaypie/mcp` → 0.8.32 (release notes)

## Test plan
- [x] `npm run typecheck -w packages/constructs`
- [x] `npm run lint -w packages/constructs`
- [x] `npm run test -w packages/constructs` (469 tests pass)
- [x] `npm run build -w packages/constructs`
- [x] `npm run build -w packages/mcp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)