### PR TITLE
fix(constructs)!: require waf.name to avoid WAF resource collisions (#297)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27861,7 +27861,7 @@
     },
     "packages/constructs": {
       "name": "@jaypie/constructs",
-      "version": "1.2.44",
+      "version": "1.2.45",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*",
@@ -28693,7 +28693,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.32",
+      "version": "0.8.33",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.4",

--- a/packages/constructs/CLAUDE.md
+++ b/packages/constructs/CLAUDE.md
@@ -210,25 +210,26 @@ new JaypieDistribution(this, "Dist", { handler, waf: false });
 // Customize
 new JaypieDistribution(this, "Dist", {
   handler,
-  waf: { rateLimitPerIp: 500 },
+  waf: { name: "api", rateLimitPerIp: 500 },
 });
 
 // Existing WebACL
 new JaypieDistribution(this, "Dist", {
   handler,
-  waf: { webAclArn: "arn:aws:wafv2:..." },
+  waf: { name: "api", webAclArn: "arn:aws:wafv2:..." },
 });
 
 // Disable WAF logging only
 new JaypieDistribution(this, "Dist", {
   handler,
-  waf: { logBucket: false },
+  waf: { name: "api", logBucket: false },
 });
 
 // Override specific managed rule actions (e.g., allow large request bodies)
 new JaypieDistribution(this, "Dist", {
   handler,
   waf: {
+    name: "api",
     managedRuleOverrides: {
       AWSManagedRulesCommonRuleSet: [
         { name: "SizeRestrictions_BODY", actionToUse: { count: {} } },

--- a/packages/constructs/package.json
+++ b/packages/constructs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/constructs",
-  "version": "1.2.44",
+  "version": "1.2.45",
   "description": "CDK constructs for Jaypie applications",
   "repository": {
     "type": "git",

--- a/packages/constructs/src/JaypieDistribution.ts
+++ b/packages/constructs/src/JaypieDistribution.ts
@@ -32,6 +32,16 @@ const DEFAULT_MANAGED_RULES = [
 
 export interface JaypieWafConfig {
   /**
+   * Unique name for this distribution's WAF resources. Required when passing a
+   * WAF config object. Injected into the WebACL name and WAF log bucket name
+   * so multiple JaypieDistribution instances can coexist in the same
+   * account/env without S3/WAFv2 name collisions.
+   *
+   * Pass `waf: true` (or omit) to retain the legacy, non-namespaced names.
+   */
+  name: string;
+
+  /**
    * Whether WAF is enabled
    * @default true
    */
@@ -584,14 +594,17 @@ export class JaypieDistribution
           },
         });
 
+        const webAclName = wafConfig.name
+          ? constructEnvName(`${wafConfig.name}-WebAcl`)
+          : constructEnvName("WebAcl");
         const webAcl = new wafv2.CfnWebACL(this, "WebAcl", {
           defaultAction: { allow: {} },
-          name: constructEnvName("WebAcl"),
+          name: webAclName,
           rules,
           scope: "CLOUDFRONT",
           visibilityConfig: {
             cloudWatchMetricsEnabled: true,
-            metricName: constructEnvName("WebAcl"),
+            metricName: webAclName,
             sampledRequestsEnabled: true,
           },
         });
@@ -610,11 +623,17 @@ export class JaypieDistribution
       let wafLogBucket: s3.IBucket | undefined;
       if (wafLogBucketProp === true) {
         // Create inline WAF logging bucket with Datadog forwarding
+        const wafLogBucketId = wafConfig.name
+          ? constructEnvName(`${wafConfig.name}-WafLogBucket`)
+          : constructEnvName("WafLogBucket");
+        const wafLogBucketName = wafConfig.name
+          ? `aws-waf-logs-${constructEnvName(`${wafConfig.name}-waf`).toLowerCase()}`
+          : `aws-waf-logs-${constructEnvName("waf").toLowerCase()}`;
         const createdBucket = new s3.Bucket(
           this,
-          constructEnvName("WafLogBucket"),
+          wafLogBucketId,
           {
-            bucketName: `aws-waf-logs-${constructEnvName("waf").toLowerCase()}`,
+            bucketName: wafLogBucketName,
             lifecycleRules: [
               {
                 expiration: Duration.days(90),
@@ -728,7 +747,7 @@ export class JaypieDistribution
 
   private resolveWafConfig(
     wafProp: boolean | JaypieWafConfig,
-  ): JaypieWafConfig | undefined {
+  ): Partial<JaypieWafConfig> | undefined {
     if (wafProp === false) return undefined;
     if (wafProp === true) return {};
     if (wafProp.enabled === false) return undefined;

--- a/packages/constructs/src/__tests__/JaypieDistribution.spec.ts
+++ b/packages/constructs/src/__tests__/JaypieDistribution.spec.ts
@@ -881,7 +881,7 @@ describe("JaypieDistribution", () => {
         new JaypieDistribution(stack, "TestDistribution", {
           handler: origin,
           logBucket: true,
-          waf: { logBucket: false },
+          waf: { name: "test", logBucket: false },
         });
         const template = Template.fromStack(stack);
 
@@ -1483,7 +1483,7 @@ describe("JaypieDistribution", () => {
 
       const construct = new JaypieDistribution(stack, "TestDistribution", {
         handler: origin,
-        waf: { enabled: false },
+        waf: { name: "test", enabled: false },
       });
       const template = Template.fromStack(stack);
 
@@ -1498,7 +1498,7 @@ describe("JaypieDistribution", () => {
 
       new JaypieDistribution(stack, "TestDistribution", {
         handler: origin,
-        waf: { rateLimitPerIp: 500 },
+        waf: { name: "test", rateLimitPerIp: 500 },
       });
       const template = Template.fromStack(stack);
 
@@ -1523,7 +1523,7 @@ describe("JaypieDistribution", () => {
 
       new JaypieDistribution(stack, "TestDistribution", {
         handler: origin,
-        waf: { managedRules: ["AWSManagedRulesCommonRuleSet"] },
+        waf: { name: "test", managedRules: ["AWSManagedRulesCommonRuleSet"] },
       });
       const template = Template.fromStack(stack);
 
@@ -1544,6 +1544,7 @@ describe("JaypieDistribution", () => {
       new JaypieDistribution(stack, "TestDistribution", {
         handler: origin,
         waf: {
+          name: "test",
           managedRuleOverrides: {
             AWSManagedRulesCommonRuleSet: [
               {
@@ -1606,6 +1607,7 @@ describe("JaypieDistribution", () => {
       const construct = new JaypieDistribution(stack, "TestDistribution", {
         handler: origin,
         waf: {
+          name: "test",
           webAclArn:
             "arn:aws:wafv2:us-east-1:123456789012:global/webacl/my-acl/abc123",
         },
@@ -1664,7 +1666,7 @@ describe("JaypieDistribution", () => {
 
       const construct = new JaypieDistribution(stack, "TestDistribution", {
         handler: origin,
-        waf: { logBucket: false },
+        waf: { name: "test", logBucket: false },
       });
       const template = Template.fromStack(stack);
 
@@ -1682,7 +1684,7 @@ describe("JaypieDistribution", () => {
 
       const construct = new JaypieDistribution(stack, "TestDistribution", {
         handler: origin,
-        waf: { logBucket: wafBucket },
+        waf: { name: "test", logBucket: wafBucket },
       });
       const template = Template.fromStack(stack);
 
@@ -1704,6 +1706,58 @@ describe("JaypieDistribution", () => {
       template.resourceCountIs("AWS::WAFv2::LoggingConfiguration", 0);
     });
 
+    it("namespaces WebACL and log bucket when waf.name is provided", () => {
+      const stack = new Stack();
+      const bucket = new s3.Bucket(stack, "TestBucket");
+      const origin = origins.S3BucketOrigin.withOriginAccessControl(bucket);
+
+      new JaypieDistribution(stack, "TestDistribution", {
+        handler: origin,
+        waf: { name: "mcp" },
+      });
+      const template = Template.fromStack(stack);
+
+      const acls = template.findResources("AWS::WAFv2::WebACL");
+      const acl = Object.values(acls)[0] as any;
+      expect(acl?.Properties?.Name).toMatch(/-mcp-WebAcl-/);
+
+      const buckets = template.findResources("AWS::S3::Bucket");
+      const wafBucket = Object.values(buckets).find((b: any) =>
+        b.Properties?.BucketName?.startsWith?.("aws-waf-logs-"),
+      ) as any;
+      expect(wafBucket?.Properties?.BucketName).toMatch(/-mcp-waf-/);
+    });
+
+    it("allows two distributions in one stack via distinct waf.name", () => {
+      const stack = new Stack();
+      const bucket = new s3.Bucket(stack, "TestBucket");
+      const origin = origins.S3BucketOrigin.withOriginAccessControl(bucket);
+
+      new JaypieDistribution(stack, "Api", {
+        handler: origin,
+        waf: { name: "api" },
+      });
+      new JaypieDistribution(stack, "Mcp", {
+        handler: origin,
+        waf: { name: "mcp" },
+      });
+      const template = Template.fromStack(stack);
+
+      template.resourceCountIs("AWS::WAFv2::WebACL", 2);
+      const acls = Object.values(template.findResources("AWS::WAFv2::WebACL"));
+      const names = acls.map((a: any) => a.Properties.Name);
+      expect(new Set(names).size).toBe(2);
+
+      const wafBuckets = Object.values(
+        template.findResources("AWS::S3::Bucket"),
+      )
+        .map((b: any) => b.Properties?.BucketName)
+        .filter(
+          (n: any) => typeof n === "string" && n.startsWith("aws-waf-logs-"),
+        );
+      expect(new Set(wafBuckets).size).toBe(2);
+    });
+
     it("creates logging with external WebACL ARN", () => {
       const stack = new Stack();
       const bucket = new s3.Bucket(stack, "TestBucket");
@@ -1712,6 +1766,7 @@ describe("JaypieDistribution", () => {
       new JaypieDistribution(stack, "TestDistribution", {
         handler: origin,
         waf: {
+          name: "test",
           webAclArn:
             "arn:aws:wafv2:us-east-1:123456789012:global/webacl/my-acl/abc123",
         },

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.32",
+  "version": "0.8.33",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/constructs/1.2.45.md
+++ b/packages/mcp/release-notes/constructs/1.2.45.md
@@ -1,0 +1,25 @@
+---
+version: 1.2.45
+date: 2026-04-15
+summary: JaypieDistribution WAF resources support per-distribution namespacing via required `waf.name`
+---
+
+## Changes
+
+- `JaypieWafConfig.name` is now required whenever a WAF config object is passed to `JaypieDistribution`
+- When set, `name` is injected into both the WebACL name and the WAF log bucket name so multiple `JaypieDistribution` instances can coexist in one account/env
+- `waf: true` and absent `waf` continue to produce the legacy, non-namespaced names — existing deployments redeploy without change
+
+## Why
+
+Two `JaypieDistribution` instances in the same env collided on `aws-waf-logs-<env>-<key>-waf-<nonce>` (global S3 name) and the `WebACL` name. The only workarounds were disabling WAF or the log bucket. Requiring `waf.name` on object configs forces a unique suffix exactly where collisions are possible, while leaving the common `waf: true` path untouched. Resolves #297.
+
+## Migration
+
+Anywhere a WAF config object is passed — e.g. `waf: { rateLimitPerIp: 500 }` — add a `name`:
+
+```typescript
+waf: { name: "api", rateLimitPerIp: 500 }
+```
+
+Stacks using `waf: true` (or omitting `waf`) need no changes.

--- a/packages/mcp/release-notes/mcp/0.8.33.md
+++ b/packages/mcp/release-notes/mcp/0.8.33.md
@@ -1,0 +1,10 @@
+---
+version: 0.8.33
+date: 2026-04-15
+summary: Update cdk skill examples for `@jaypie/constructs` WAF `name` requirement
+---
+
+## Changes
+
+- `cdk` skill: WAF config examples now pass `waf.name` (required on any object-form config as of `@jaypie/constructs@1.2.45`)
+- Added a collision-avoidance example showing two `JaypieDistribution` instances with distinct `waf.name` values

--- a/packages/mcp/skills/cdk.md
+++ b/packages/mcp/skills/cdk.md
@@ -318,34 +318,40 @@ new JaypieDistribution(this, "Dist", { handler });
 // Disable WAF entirely
 new JaypieDistribution(this, "Dist", { handler, waf: false });
 
-// Customize rate limit
+// Customize rate limit (name required on any waf config object)
 new JaypieDistribution(this, "Dist", {
   handler,
-  waf: { rateLimitPerIp: 500 },
+  waf: { name: "api", rateLimitPerIp: 500 },
 });
+
+// Multiple distributions in one env — set a unique waf.name on each to
+// avoid WebACL/S3 bucket name collisions between stacks.
+new JaypieDistribution(this, "Api", { handler: api, waf: { name: "api" } });
+new JaypieDistribution(this, "Mcp", { handler: mcp, waf: { name: "mcp" } });
 
 // Use existing WebACL
 new JaypieDistribution(this, "Dist", {
   handler,
-  waf: { webAclArn: "arn:aws:wafv2:..." },
+  waf: { name: "api", webAclArn: "arn:aws:wafv2:..." },
 });
 
 // Disable WAF logging only
 new JaypieDistribution(this, "Dist", {
   handler,
-  waf: { logBucket: false },
+  waf: { name: "api", logBucket: false },
 });
 
 // Bring your own WAF logging bucket
 new JaypieDistribution(this, "Dist", {
   handler,
-  waf: { logBucket: myWafBucket },
+  waf: { name: "api", logBucket: myWafBucket },
 });
 
 // Override specific managed rule actions (e.g., allow large request bodies)
 new JaypieDistribution(this, "Dist", {
   handler,
   waf: {
+    name: "api",
     managedRuleOverrides: {
       AWSManagedRulesCommonRuleSet: [
         { name: "SizeRestrictions_BODY", actionToUse: { count: {} } },


### PR DESCRIPTION
## Summary
- `JaypieWafConfig.name` is now required on any WAF config object; it's injected into the WebACL name and WAF log bucket name so multiple `JaypieDistribution` instances can coexist in one account/env
- `waf: true` / omitted → legacy names preserved; existing deployments redeploy unchanged
- Docs + skills updated; `@jaypie/constructs` → 1.2.45, `@jaypie/mcp` → 0.8.33

Closes #297

## Test plan
- [x] `npm run test -w packages/constructs` (471 pass, 2 new tests)
- [x] `npm run typecheck -w packages/constructs -w packages/mcp`
- [x] `npm run build -w packages/constructs -w packages/mcp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)