### PR TITLE
fix(constructs): JaypieEnvSecret fails loudly when envKey env var is empty

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27861,7 +27861,7 @@
     },
     "packages/constructs": {
       "name": "@jaypie/constructs",
-      "version": "1.2.45",
+      "version": "1.2.46",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*",
@@ -28693,7 +28693,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.34",
+      "version": "0.8.35",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.4",

--- a/packages/constructs/package.json
+++ b/packages/constructs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/constructs",
-  "version": "1.2.45",
+  "version": "1.2.46",
   "description": "CDK constructs for Jaypie applications",
   "repository": {
     "type": "git",

--- a/packages/constructs/src/JaypieEnvSecret.ts
+++ b/packages/constructs/src/JaypieEnvSecret.ts
@@ -22,6 +22,8 @@ import {
   AddToResourcePolicyResult,
 } from "aws-cdk-lib/aws-iam";
 
+import { ConfigurationError } from "@jaypie/errors";
+
 import { CDK } from "./constants";
 
 // It is a consumer if the environment is ephemeral
@@ -113,6 +115,18 @@ export class JaypieEnvSecret extends Construct implements ISecret {
       exportName = exportEnvName(id);
     } else {
       exportName = cleanName(exportParam);
+    }
+
+    if (
+      !consumer &&
+      envKey &&
+      !process.env[envKey] &&
+      value === undefined &&
+      !generateSecretString
+    ) {
+      throw new ConfigurationError(
+        `JaypieEnvSecret(${id}): envKey "${envKey}" is empty in process.env and no value or generateSecretString was provided`,
+      );
     }
 
     if (consumer) {

--- a/packages/constructs/src/__tests__/JaypieEnvSecret.spec.ts
+++ b/packages/constructs/src/__tests__/JaypieEnvSecret.spec.ts
@@ -1,3 +1,4 @@
+import { ConfigurationError } from "@jaypie/errors";
 import { expect, it, describe } from "vitest";
 import { RemovalPolicy, Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
@@ -113,12 +114,14 @@ describe("JaypieSecret", () => {
     });
 
     it("exposes envKey through getter", () => {
+      process.env.TEST_ENV_KEY = "test-value";
       const stack = new Stack();
       const secret = new JaypieEnvSecret(stack, "TestSecret", {
         envKey: "TEST_ENV_KEY",
       });
 
       expect(secret.envKey).toBe("TEST_ENV_KEY");
+      delete process.env.TEST_ENV_KEY;
     });
 
     it("applies RETAIN removal policy when removalPolicy is true", () => {
@@ -158,6 +161,58 @@ describe("JaypieSecret", () => {
         DeletionPolicy: "Retain",
         UpdateReplacePolicy: "Retain",
       });
+    });
+  });
+
+  describe("Error Cases", () => {
+    it("throws ConfigurationError when envKey is set but env var is missing and no value or generateSecretString", () => {
+      delete process.env.MISSING_SECRET;
+      const stack = new Stack();
+      expect(() => {
+        new JaypieEnvSecret(stack, "TestSecret", {
+          envKey: "MISSING_SECRET",
+        });
+      }).toThrow(ConfigurationError);
+    });
+
+    it("throws ConfigurationError when envKey is set but env var is empty string", () => {
+      process.env.EMPTY_SECRET = "";
+      const stack = new Stack();
+      expect(() => {
+        new JaypieEnvSecret(stack, "TestSecret", {
+          envKey: "EMPTY_SECRET",
+        });
+      }).toThrow(ConfigurationError);
+      delete process.env.EMPTY_SECRET;
+    });
+
+    it("does not throw when envKey is missing but value is provided", () => {
+      delete process.env.MISSING_SECRET;
+      const stack = new Stack();
+      expect(() => {
+        new JaypieEnvSecret(stack, "TestSecret", {
+          envKey: "MISSING_SECRET",
+          value: "fallback",
+        });
+      }).not.toThrow();
+    });
+
+    it("does not throw when envKey is missing but generateSecretString is provided", () => {
+      delete process.env.MISSING_SECRET;
+      const stack = new Stack();
+      expect(() => {
+        new JaypieEnvSecret(stack, "TestSecret", {
+          envKey: "MISSING_SECRET",
+          generateSecretString: {},
+        });
+      }).not.toThrow();
+    });
+
+    it("does not throw when no envKey is set (plain secret)", () => {
+      const stack = new Stack();
+      expect(() => {
+        new JaypieEnvSecret(stack, "TestSecret");
+      }).not.toThrow();
     });
   });
 });

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.34",
+  "version": "0.8.35",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/constructs/1.2.46.md
+++ b/packages/mcp/release-notes/constructs/1.2.46.md
@@ -1,0 +1,18 @@
+---
+version: 1.2.46
+date: 2026-04-16
+summary: JaypieEnvSecret throws ConfigurationError when envKey env var is missing or empty
+---
+
+## Changes
+
+- `JaypieEnvSecret` now throws `ConfigurationError` at synth when `envKey` is set but `process.env[envKey]` is missing or empty and neither `value` nor `generateSecretString` was provided
+- Consumers (ephemeral envs that import from a provider) continue to resolve the secret name via `Fn.importValue` and are not affected
+
+## Why
+
+Previously, a missing or empty `envKey` env var silently fell through to `secretsmanager.Secret` with both `secretStringValue` and `generateSecretString` undefined, which causes CDK to auto-generate a random JSON password. Deployments succeeded with the wrong value and consumers got 401s that were hard to attribute. Failing loudly at synth surfaces the configuration gap before it reaches Secrets Manager. Resolves #287.
+
+## Migration
+
+If you relied on CDK's auto-generated fallback, pass `generateSecretString: {}` (or a valid options object) explicitly, or provide a `value`.


### PR DESCRIPTION
## Summary
- `JaypieEnvSecret` now throws `ConfigurationError` at synth when `envKey` is set but `process.env[envKey]` is missing/empty and neither `value` nor `generateSecretString` was provided — previously it silently fell through to a CDK auto-generated random secret
- Adds 5 test cases covering the throw, opt-outs (`value`, `generateSecretString`), and unaffected plain-secret path
- Bumps `@jaypie/constructs` 1.2.45 → 1.2.46 and `@jaypie/mcp` 0.8.34 → 0.8.35 (for the new release note)

Resolves #287

## Test plan
- [x] `npm test -w packages/constructs` (476 tests pass)
- [x] `npm run typecheck -w packages/constructs`
- [x] `npm run build -w packages/constructs`
- [x] `npm test -w packages/mcp`
- [x] NPM Check workflow green on branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)