### PR TITLE
fix(llm): strip temperature for Anthropic models that reject it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28436,7 +28436,7 @@
       "license": "MIT"
     },
     "packages/jaypie": {
-      "version": "1.2.36",
+      "version": "1.2.37",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "^1.2.7",
@@ -28461,7 +28461,7 @@
         "typescript-eslint": "^8.46.1"
       },
       "peerDependencies": {
-        "@jaypie/llm": "^1.2.25",
+        "@jaypie/llm": "^1.2.26",
         "@jaypie/mongoose": "^1.2.2"
       },
       "peerDependenciesMeta": {
@@ -28570,7 +28570,7 @@
     },
     "packages/llm": {
       "name": "@jaypie/llm",
-      "version": "1.2.25",
+      "version": "1.2.26",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "*",
@@ -28693,7 +28693,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.35",
+      "version": "0.8.36",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.4",

--- a/packages/jaypie/package.json
+++ b/packages/jaypie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jaypie",
-  "version": "1.2.36",
+  "version": "1.2.37",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"
@@ -54,7 +54,7 @@
     "typescript-eslint": "^8.46.1"
   },
   "peerDependencies": {
-    "@jaypie/llm": "^1.2.25",
+    "@jaypie/llm": "^1.2.26",
     "@jaypie/mongoose": "^1.2.2"
   },
   "peerDependenciesMeta": {

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/llm",
-  "version": "1.2.25",
+  "version": "1.2.26",
   "description": "Large language model utilities",
   "repository": {
     "type": "git",

--- a/packages/llm/src/operate/adapters/AnthropicAdapter.ts
+++ b/packages/llm/src/operate/adapters/AnthropicAdapter.ts
@@ -129,6 +129,30 @@ const NOT_RETRYABLE_ERROR_NAMES = [
   "PermissionDeniedError",
 ];
 
+// Models known not to accept `temperature`.
+// Patterns (not exact names) so dated variants and future releases are covered
+// without code changes — Anthropic is trending toward removing temperature on
+// newer Claude models.
+const MODELS_WITHOUT_TEMPERATURE: RegExp[] = [
+  /^claude-opus-4-[789]/,
+  /^claude-opus-[5-9]/,
+];
+
+function isTemperatureDeprecationError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const err = error as {
+    status?: number;
+    message?: string;
+    error?: { message?: string };
+  };
+  const name = (error as Error)?.constructor?.name;
+  if (name !== "BadRequestError" && err.status !== 400) return false;
+  const messages = [err.message, err.error?.message].filter(
+    (m): m is string => typeof m === "string",
+  );
+  return messages.some((m) => m.toLowerCase().includes("temperature"));
+}
+
 //
 //
 // Main
@@ -142,6 +166,23 @@ const NOT_RETRYABLE_ERROR_NAMES = [
 export class AnthropicAdapter extends BaseProviderAdapter {
   readonly name = PROVIDER.ANTHROPIC.NAME;
   readonly defaultModel = PROVIDER.ANTHROPIC.MODEL.DEFAULT;
+
+  // Session-level cache of models observed to reject `temperature` at runtime.
+  // Populated by executeRequest on 400 errors so repeat calls skip the param.
+  private runtimeNoTemperatureModels = new Set<string>();
+
+  rememberModelRejectsTemperature(model: string): void {
+    this.runtimeNoTemperatureModels.add(model);
+  }
+
+  clearRuntimeNoTemperatureModels(): void {
+    this.runtimeNoTemperatureModels.clear();
+  }
+
+  private supportsTemperature(model: string): boolean {
+    if (this.runtimeNoTemperatureModels.has(model)) return false;
+    return !MODELS_WITHOUT_TEMPERATURE.some((pattern) => pattern.test(model));
+  }
 
   //
   // Request Building
@@ -257,6 +298,14 @@ export class AnthropicAdapter extends BaseProviderAdapter {
       anthropicRequest.temperature = request.temperature;
     }
 
+    // Strip temperature for models that don't support it (denylist + runtime cache)
+    if (
+      anthropicRequest.temperature !== undefined &&
+      !this.supportsTemperature(anthropicRequest.model as string)
+    ) {
+      delete anthropicRequest.temperature;
+    }
+
     return anthropicRequest;
   }
 
@@ -328,13 +377,29 @@ export class AnthropicAdapter extends BaseProviderAdapter {
     signal?: AbortSignal,
   ): Promise<Anthropic.Message> {
     const anthropic = client as Anthropic;
+    const anthropicRequest = request as Anthropic.MessageCreateParams;
     try {
       return (await anthropic.messages.create(
-        request as Anthropic.MessageCreateParams,
+        anthropicRequest,
         signal ? { signal } : undefined,
       )) as Anthropic.Message;
     } catch (error) {
       if (signal?.aborted) return undefined as unknown as Anthropic.Message;
+
+      // If the model rejected `temperature`, cache it and retry without the param
+      if (
+        anthropicRequest.temperature !== undefined &&
+        isTemperatureDeprecationError(error)
+      ) {
+        this.rememberModelRejectsTemperature(anthropicRequest.model as string);
+        const retryRequest = { ...anthropicRequest };
+        delete retryRequest.temperature;
+        return (await anthropic.messages.create(
+          retryRequest,
+          signal ? { signal } : undefined,
+        )) as Anthropic.Message;
+      }
+
       throw error;
     }
   }
@@ -345,15 +410,35 @@ export class AnthropicAdapter extends BaseProviderAdapter {
     signal?: AbortSignal,
   ): AsyncIterable<LlmStreamChunk> {
     const anthropic = client as Anthropic;
-    const streamRequest = {
+    let streamRequest = {
       ...(request as Anthropic.MessageCreateParams),
       stream: true,
     } as Anthropic.MessageCreateParamsStreaming;
 
-    const stream = await anthropic.messages.create(
-      streamRequest,
-      signal ? { signal } : undefined,
-    );
+    let stream;
+    try {
+      stream = await anthropic.messages.create(
+        streamRequest,
+        signal ? { signal } : undefined,
+      );
+    } catch (error) {
+      if (
+        streamRequest.temperature !== undefined &&
+        isTemperatureDeprecationError(error)
+      ) {
+        this.rememberModelRejectsTemperature(streamRequest.model as string);
+        streamRequest = {
+          ...streamRequest,
+        } as Anthropic.MessageCreateParamsStreaming;
+        delete streamRequest.temperature;
+        stream = await anthropic.messages.create(
+          streamRequest,
+          signal ? { signal } : undefined,
+        );
+      } else {
+        throw error;
+      }
+    }
 
     // Track current tool call being built
     let currentToolCall: {

--- a/packages/llm/src/operate/adapters/__tests__/AnthropicAdapter.spec.ts
+++ b/packages/llm/src/operate/adapters/__tests__/AnthropicAdapter.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AnthropicAdapter, anthropicAdapter } from "../AnthropicAdapter.js";
 import { PROVIDER } from "../../../constants.js";
@@ -736,6 +736,133 @@ describe("AnthropicAdapter", () => {
     });
   });
 
+  // Temperature-deprecation retry
+  describe("Temperature deprecation retry", () => {
+    beforeEach(() => {
+      anthropicAdapter.clearRuntimeNoTemperatureModels();
+    });
+
+    it("retries without temperature when Anthropic rejects it with 400", async () => {
+      const { BadRequestError } = await import("@anthropic-ai/sdk");
+      // @ts-expect-error Mock doesn't require constructor args
+      const error = new BadRequestError();
+      (error as unknown as { status: number }).status = 400;
+      error.message =
+        "400 {\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"`temperature` is deprecated for this model.\"}}";
+
+      const successResponse = {
+        content: [{ type: "text", text: "Hi" }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 1, output_tokens: 1 },
+      };
+      const mockCreate = vi.fn();
+      mockCreate.mockRejectedValueOnce(error as unknown as Error);
+      mockCreate.mockResolvedValueOnce(successResponse);
+      const mockClient = { messages: { create: mockCreate } };
+      const request = {
+        model: "claude-opus-4-7",
+        messages: [{ role: "user", content: "Hello" }],
+        max_tokens: 1024,
+        stream: false,
+        temperature: 0,
+      };
+
+      const result = await anthropicAdapter.executeRequest(mockClient, request);
+
+      expect(result as unknown).toBe(successResponse);
+      expect(mockCreate).toHaveBeenCalledTimes(2);
+      const retryRequest = mockCreate.mock.calls[1][0] as {
+        temperature?: number;
+      };
+      expect(retryRequest.temperature).toBeUndefined();
+    });
+
+    it("caches the model so subsequent buildRequest strips temperature", async () => {
+      const { BadRequestError } = await import("@anthropic-ai/sdk");
+      // @ts-expect-error Mock doesn't require constructor args
+      const error = new BadRequestError();
+      (error as unknown as { status: number }).status = 400;
+      error.message = "`temperature` is deprecated for this model.";
+
+      const mockCreate = vi.fn();
+      mockCreate.mockRejectedValueOnce(error as unknown as Error);
+      mockCreate.mockResolvedValueOnce({
+        content: [{ type: "text", text: "Hi" }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 1, output_tokens: 1 },
+      });
+      const mockClient = { messages: { create: mockCreate } };
+      await anthropicAdapter.executeRequest(mockClient, {
+        model: "claude-sonnet-9-mystery",
+        messages: [],
+        max_tokens: 1024,
+        stream: false,
+        temperature: 0.5,
+      });
+
+      const result = anthropicAdapter.buildRequest({
+        model: "claude-sonnet-9-mystery",
+        messages: [],
+        temperature: 0.5,
+      });
+
+      expect(result.temperature).toBeUndefined();
+    });
+
+    it("does not retry on 400 unrelated to temperature", async () => {
+      const { BadRequestError } = await import("@anthropic-ai/sdk");
+      // @ts-expect-error Mock doesn't require constructor args
+      const error = new BadRequestError();
+      (error as unknown as { status: number }).status = 400;
+      error.message = "some other bad-request reason";
+
+      const mockCreate = vi.fn();
+      mockCreate.mockRejectedValue(error as unknown as Error);
+      const mockClient = { messages: { create: mockCreate } };
+
+      let thrown: unknown;
+      try {
+        await anthropicAdapter.executeRequest(mockClient, {
+          model: "claude-opus-4-6",
+          messages: [],
+          max_tokens: 1024,
+          stream: false,
+          temperature: 0.2,
+        });
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown).toBe(error);
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not retry when request has no temperature", async () => {
+      const { BadRequestError } = await import("@anthropic-ai/sdk");
+      // @ts-expect-error Mock doesn't require constructor args
+      const error = new BadRequestError();
+      (error as unknown as { status: number }).status = 400;
+      error.message = "`temperature` is deprecated for this model.";
+
+      const mockCreate = vi.fn();
+      mockCreate.mockRejectedValue(error as unknown as Error);
+      const mockClient = { messages: { create: mockCreate } };
+
+      let thrown: unknown;
+      try {
+        await anthropicAdapter.executeRequest(mockClient, {
+          model: "claude-opus-4-7",
+          messages: [],
+          max_tokens: 1024,
+          stream: false,
+        });
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown).toBe(error);
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+    });
+  });
+
   // Specific Scenarios
   describe("Specific Scenarios", () => {
     it("uses default model when not specified", () => {
@@ -789,6 +916,97 @@ describe("AnthropicAdapter", () => {
       const result = anthropicAdapter.buildRequest(request);
 
       expect(result.temperature).toBeUndefined();
+    });
+
+    describe("models that do not support temperature", () => {
+      beforeEach(() => {
+        anthropicAdapter.clearRuntimeNoTemperatureModels();
+      });
+
+      it("strips temperature for claude-opus-4-7", () => {
+        const request: OperateRequest = {
+          model: "claude-opus-4-7",
+          messages: [],
+          temperature: 0,
+        };
+
+        const result = anthropicAdapter.buildRequest(request);
+
+        expect(result.temperature).toBeUndefined();
+      });
+
+      it("strips temperature for dated claude-opus-4-7 variant", () => {
+        const request: OperateRequest = {
+          model: "claude-opus-4-7-20250801",
+          messages: [],
+          temperature: 0.5,
+        };
+
+        const result = anthropicAdapter.buildRequest(request);
+
+        expect(result.temperature).toBeUndefined();
+      });
+
+      it("strips temperature for future claude-opus-5 models", () => {
+        const request: OperateRequest = {
+          model: "claude-opus-5-0",
+          messages: [],
+          temperature: 0.3,
+        };
+
+        const result = anthropicAdapter.buildRequest(request);
+
+        expect(result.temperature).toBeUndefined();
+      });
+
+      it("strips temperature from providerOptions for unsupported models", () => {
+        const request: OperateRequest = {
+          model: "claude-opus-4-8",
+          messages: [],
+          providerOptions: { temperature: 0.4 },
+        };
+
+        const result = anthropicAdapter.buildRequest(request);
+
+        expect(result.temperature).toBeUndefined();
+      });
+
+      it("keeps temperature for claude-opus-4-6 (still supported)", () => {
+        const request: OperateRequest = {
+          model: "claude-opus-4-6",
+          messages: [],
+          temperature: 0.2,
+        };
+
+        const result = anthropicAdapter.buildRequest(request);
+
+        expect(result.temperature).toBe(0.2);
+      });
+
+      it("keeps temperature for claude-sonnet-4-5 (still supported)", () => {
+        const request: OperateRequest = {
+          model: "claude-sonnet-4-5",
+          messages: [],
+          temperature: 0.2,
+        };
+
+        const result = anthropicAdapter.buildRequest(request);
+
+        expect(result.temperature).toBe(0.2);
+      });
+
+      it("strips temperature for models cached at runtime", () => {
+        const adapter = new AnthropicAdapter();
+        adapter.rememberModelRejectsTemperature("claude-sonnet-9-future");
+
+        const result = adapter.buildRequest({
+          model: "claude-sonnet-9-future",
+          messages: [],
+          temperature: 0.7,
+        });
+
+        expect(result.temperature).toBeUndefined();
+      });
     });
 
     it("sets tool_choice to any when structured output tool present", () => {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.35",
+  "version": "0.8.36",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/llm/1.2.26.md
+++ b/packages/mcp/release-notes/llm/1.2.26.md
@@ -1,0 +1,14 @@
+---
+version: 1.2.26
+date: 2026-04-16
+summary: Strip temperature for Anthropic models that reject it; auto-retry on 400
+---
+
+## Changes
+
+- Add a forward-compatible denylist of Anthropic models that no longer accept `temperature` (regex-matched: `claude-opus-4-7`+ and `claude-opus-5`+ including dated variants)
+- `AnthropicAdapter.buildRequest` strips `temperature` (and `providerOptions.temperature`) before the SDK sees it when the model is on the denylist
+- `executeRequest` and `executeStreamRequest` catch 400 `BadRequestError` responses whose message mentions "temperature", cache the model on the adapter instance, and retry once without the parameter
+- Runtime-cached models are consulted by subsequent `buildRequest` calls, so the same adapter instance skips the param on repeat calls
+- Exposes `rememberModelRejectsTemperature(model)` and `clearRuntimeNoTemperatureModels()` on `AnthropicAdapter`
+- Fixes cases where `Llm.operate({ model: "claude-opus-4-7", temperature: 0, ... })` failed as an unrecoverable DNC error, skipping every subsequent case in a plan

--- a/packages/mcp/release-notes/mcp/0.8.36.md
+++ b/packages/mcp/release-notes/mcp/0.8.36.md
@@ -1,0 +1,9 @@
+---
+version: 0.8.36
+date: 2026-04-16
+summary: Add release notes for @jaypie/llm 1.2.26
+---
+
+## Changes
+
+- Added release notes for `@jaypie/llm@1.2.26` (Anthropic temperature-deprecation handling)


### PR DESCRIPTION
## Summary
- Anthropic started rejecting `temperature` on `claude-opus-4-7` with a 400; this failure was non-retryable and caused every subsequent case in a mixed-model plan to be skipped as DNC.
- Strip `temperature` for a forward-compatible regex denylist (`claude-opus-4-[789]`, `claude-opus-[5-9]`), plus a session-level runtime cache populated by 400 responses whose message mentions "temperature".
- `executeRequest` and `executeStreamRequest` auto-retry once without the param on matching 400s.
- Bumps `@jaypie/llm` → 1.2.26, `jaypie` → 1.2.37, `@jaypie/mcp` → 0.8.36 (release notes).

Closes #304

## Test plan
- [x] 11 new unit tests in `AnthropicAdapter.spec.ts` covering denylist hits, dated/future variants, `providerOptions.temperature`, runtime cache, retry success, and retry refusals
- [x] Full `@jaypie/llm` suite green (756 tests)
- [x] `@jaypie/mcp` + `jaypie` suites green
- [x] CI NPM Check green on Node 24 and 25

🤖 Generated with [Claude Code](https://claude.com/claude-code)