### PR TITLE
fix(llm): update ANTHROPIC.LARGE to claude-opus-4-7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28436,7 +28436,7 @@
       "license": "MIT"
     },
     "packages/jaypie": {
-      "version": "1.2.37",
+      "version": "1.2.38",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "^1.2.7",
@@ -28461,7 +28461,7 @@
         "typescript-eslint": "^8.46.1"
       },
       "peerDependencies": {
-        "@jaypie/llm": "^1.2.26",
+        "@jaypie/llm": "^1.2.27",
         "@jaypie/mongoose": "^1.2.2"
       },
       "peerDependenciesMeta": {
@@ -28570,7 +28570,7 @@
     },
     "packages/llm": {
       "name": "@jaypie/llm",
-      "version": "1.2.26",
+      "version": "1.2.27",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "*",
@@ -28693,7 +28693,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.36",
+      "version": "0.8.37",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.4",

--- a/packages/jaypie/package.json
+++ b/packages/jaypie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jaypie",
-  "version": "1.2.37",
+  "version": "1.2.38",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"
@@ -54,7 +54,7 @@
     "typescript-eslint": "^8.46.1"
   },
   "peerDependencies": {
-    "@jaypie/llm": "^1.2.26",
+    "@jaypie/llm": "^1.2.27",
     "@jaypie/mongoose": "^1.2.2"
   },
   "peerDependenciesMeta": {

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/llm",
-  "version": "1.2.26",
+  "version": "1.2.27",
   "description": "Large language model utilities",
   "repository": {
     "type": "git",

--- a/packages/llm/src/constants.ts
+++ b/packages/llm/src/constants.ts
@@ -2,7 +2,7 @@ const FIRST_CLASS_PROVIDER = {
   // https://docs.anthropic.com/en/docs/about-claude/models/overview
   ANTHROPIC: {
     DEFAULT: "claude-sonnet-4-6" as const,
-    LARGE: "claude-opus-4-6" as const,
+    LARGE: "claude-opus-4-7" as const,
     SMALL: "claude-sonnet-4-6" as const,
     TINY: "claude-haiku-4-5" as const,
   },

--- a/packages/llm/src/operate/adapters/__tests__/AnthropicAdapter.spec.ts
+++ b/packages/llm/src/operate/adapters/__tests__/AnthropicAdapter.spec.ts
@@ -878,7 +878,7 @@ describe("AnthropicAdapter", () => {
 
     it("sets temperature on request when provided", () => {
       const request: OperateRequest = {
-        model: PROVIDER.ANTHROPIC.MODEL.LARGE,
+        model: PROVIDER.ANTHROPIC.MODEL.DEFAULT,
         messages: [
           {
             content: "Hello",
@@ -896,7 +896,7 @@ describe("AnthropicAdapter", () => {
 
     it("temperature takes precedence over providerOptions", () => {
       const request: OperateRequest = {
-        model: PROVIDER.ANTHROPIC.MODEL.LARGE,
+        model: PROVIDER.ANTHROPIC.MODEL.DEFAULT,
         messages: [],
         providerOptions: { temperature: 0.3 },
         temperature: 0.9,

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.36",
+  "version": "0.8.37",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/llm/1.2.27.md
+++ b/packages/mcp/release-notes/llm/1.2.27.md
@@ -1,0 +1,11 @@
+---
+version: 1.2.27
+date: 2026-04-17
+summary: Update ANTHROPIC.LARGE to claude-opus-4-7
+---
+
+## Changes
+
+- `PROVIDER.ANTHROPIC.MODEL.LARGE` bumped from `claude-opus-4-6` to `claude-opus-4-7` (the current flagship Anthropic model)
+- No behavior change for other providers; Gemini, OpenAI, and xAI model constants already reflect their latest URLs
+- Opus 4.7 is already covered by the existing `claude-opus-4-[789]` temperature denylist, so requests with temperature are stripped automatically


### PR DESCRIPTION
## Summary
- Update `PROVIDER.ANTHROPIC.MODEL.LARGE` from `claude-opus-4-6` to `claude-opus-4-7` (current Anthropic flagship)
- Audit the four provider URLs (Anthropic, Gemini, OpenAI, xAI); only Anthropic LARGE needed updating
- Bump `@jaypie/llm` 1.2.26 → 1.2.27, `jaypie` 1.2.37 → 1.2.38 (peer dep range), `@jaypie/mcp` 0.8.36 → 0.8.37 (release notes)

## Test plan
- [x] `npm run typecheck -w packages/llm -w packages/jaypie -w packages/mcp`
- [x] `npm run build -w packages/llm -w packages/jaypie -w packages/mcp`
- [x] `npm run test -w packages/llm -w packages/jaypie -w packages/mcp`
- [x] NPM Check workflow green

🤖 Generated with [Claude Code](https://claude.com/claude-code)