### PR TITLE
feat: WAF scope-downs, xAI retry, fabricApiResponse, fabricExpress lifecycle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28955,6 +28955,7 @@
         "@jaypie/errors": "*"
       },
       "devDependencies": {
+        "@jaypie/express": "*",
         "@jaypie/testkit": "*",
         "@modelcontextprotocol/sdk": "^1.17.0",
         "@rollup/plugin-typescript": "^12.1.2",
@@ -28976,6 +28977,7 @@
       "peerDependencies": {
         "@jaypie/aws": "*",
         "@jaypie/dynamodb": "*",
+        "@jaypie/express": "*",
         "@jaypie/lambda": "*",
         "@modelcontextprotocol/sdk": ">=1.0.0",
         "commander": ">=12.0.0",
@@ -28987,6 +28989,9 @@
           "optional": true
         },
         "@jaypie/dynamodb": {
+          "optional": true
+        },
+        "@jaypie/express": {
           "optional": true
         },
         "@jaypie/lambda": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28464,7 +28464,7 @@
     },
     "packages/constructs": {
       "name": "@jaypie/constructs",
-      "version": "1.2.47",
+      "version": "1.2.48",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*",
@@ -28913,7 +28913,7 @@
     },
     "packages/express": {
       "name": "@jaypie/express",
-      "version": "1.2.21",
+      "version": "1.2.22",
       "license": "MIT",
       "dependencies": {
         "@jaypie/datadog": "*",
@@ -28949,7 +28949,7 @@
     },
     "packages/fabric": {
       "name": "@jaypie/fabric",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*"
@@ -29290,14 +29290,14 @@
       "license": "MIT"
     },
     "packages/jaypie": {
-      "version": "1.2.39",
+      "version": "1.2.40",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "^1.2.8",
         "@jaypie/core": "^1.2.2",
         "@jaypie/datadog": "^1.2.2",
         "@jaypie/errors": "^1.2.1",
-        "@jaypie/express": "^1.2.21",
+        "@jaypie/express": "^1.2.22",
         "@jaypie/kit": "^1.2.7",
         "@jaypie/lambda": "^1.2.5",
         "@jaypie/logger": "^1.2.15"
@@ -29315,7 +29315,7 @@
         "typescript-eslint": "^8.46.1"
       },
       "peerDependencies": {
-        "@jaypie/llm": "^1.2.28",
+        "@jaypie/llm": "^1.2.29",
         "@jaypie/mongoose": "^1.2.2"
       },
       "peerDependenciesMeta": {
@@ -29424,7 +29424,7 @@
     },
     "packages/llm": {
       "name": "@jaypie/llm",
-      "version": "1.2.28",
+      "version": "1.2.29",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "*",
@@ -29547,7 +29547,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.38",
+      "version": "0.8.39",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.4",
@@ -29954,7 +29954,7 @@
     },
     "packages/testkit": {
       "name": "@jaypie/testkit",
-      "version": "1.2.34",
+      "version": "1.2.35",
       "license": "MIT",
       "dependencies": {
         "jest-extended": "^4.0.2",

--- a/packages/constructs/CLAUDE.md
+++ b/packages/constructs/CLAUDE.md
@@ -237,6 +237,28 @@ new JaypieDistribution(this, "Dist", {
     },
   },
 });
+
+// Scope a managed rule group to (or away from) specific URL patterns
+new JaypieDistribution(this, "Dist", {
+  handler,
+  waf: {
+    name: "api",
+    managedRuleScopeDowns: {
+      AWSManagedRulesCommonRuleSet: {
+        notStatement: {
+          statement: {
+            byteMatchStatement: {
+              fieldToMatch: { uriPath: {} },
+              positionalConstraint: "STARTS_WITH",
+              searchString: "/chat",
+              textTransformations: [{ priority: 0, type: "NONE" }],
+            },
+          },
+        },
+      },
+    },
+  },
+});
 ```
 
 ### Streaming Lambda

--- a/packages/constructs/package.json
+++ b/packages/constructs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/constructs",
-  "version": "1.2.47",
+  "version": "1.2.48",
   "description": "CDK constructs for Jaypie applications",
   "repository": {
     "type": "git",

--- a/packages/constructs/src/JaypieDistribution.ts
+++ b/packages/constructs/src/JaypieDistribution.ts
@@ -72,6 +72,31 @@ export interface JaypieWafConfig {
   >;
 
   /**
+   * Optional scope-down statements per managed rule group. When supplied,
+   * the managed rule group only evaluates requests that match the
+   * scope-down statement. Key is the managed rule group name; value is a
+   * `CfnWebACL.StatementProperty`.
+   *
+   * @example
+   * // Only run AWSManagedRulesCommonRuleSet for non-/chat paths
+   * managedRuleScopeDowns: {
+   *   AWSManagedRulesCommonRuleSet: {
+   *     notStatement: {
+   *       statement: {
+   *         byteMatchStatement: {
+   *           fieldToMatch: { uriPath: {} },
+   *           positionalConstraint: "STARTS_WITH",
+   *           searchString: "/chat",
+   *           textTransformations: [{ priority: 0, type: "NONE" }],
+   *         },
+   *       },
+   *     },
+   *   },
+   * }
+   */
+  managedRuleScopeDowns?: Record<string, wafv2.CfnWebACL.StatementProperty>;
+
+  /**
    * Managed rule group names to apply
    * @default ["AWSManagedRulesCommonRuleSet", "AWSManagedRulesKnownBadInputsRuleSet"]
    */
@@ -547,6 +572,7 @@ export class JaypieDistribution
         // Create new WebACL
         const {
           managedRuleOverrides,
+          managedRuleScopeDowns,
           managedRules = DEFAULT_MANAGED_RULES,
           rateLimitPerIp = DEFAULT_RATE_LIMIT,
         } = wafConfig;
@@ -557,6 +583,7 @@ export class JaypieDistribution
         // Add managed rule groups
         for (const ruleName of managedRules) {
           const ruleActionOverrides = managedRuleOverrides?.[ruleName];
+          const scopeDownStatement = managedRuleScopeDowns?.[ruleName];
           rules.push({
             name: ruleName,
             priority: priority++,
@@ -566,6 +593,7 @@ export class JaypieDistribution
                 name: ruleName,
                 vendorName: "AWS",
                 ...(ruleActionOverrides && { ruleActionOverrides }),
+                ...(scopeDownStatement && { scopeDownStatement }),
               },
             },
             visibilityConfig: {

--- a/packages/constructs/src/__tests__/JaypieDistribution.spec.ts
+++ b/packages/constructs/src/__tests__/JaypieDistribution.spec.ts
@@ -1599,6 +1599,133 @@ describe("JaypieDistribution", () => {
       ).toBeUndefined();
     });
 
+    it("supports managedRuleScopeDowns to scope a managed rule group", () => {
+      const stack = new Stack();
+      const bucket = new s3.Bucket(stack, "TestBucket");
+      const origin = origins.S3BucketOrigin.withOriginAccessControl(bucket);
+
+      new JaypieDistribution(stack, "TestDistribution", {
+        handler: origin,
+        waf: {
+          name: "test",
+          managedRuleScopeDowns: {
+            AWSManagedRulesCommonRuleSet: {
+              notStatement: {
+                statement: {
+                  byteMatchStatement: {
+                    fieldToMatch: { uriPath: {} },
+                    positionalConstraint: "STARTS_WITH",
+                    searchString: "/chat",
+                    textTransformations: [{ priority: 0, type: "NONE" }],
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+      const template = Template.fromStack(stack);
+
+      template.hasResourceProperties("AWS::WAFv2::WebACL", {
+        Rules: Match.arrayWith([
+          Match.objectLike({
+            Name: "AWSManagedRulesCommonRuleSet",
+            Statement: {
+              ManagedRuleGroupStatement: {
+                Name: "AWSManagedRulesCommonRuleSet",
+                VendorName: "AWS",
+                ScopeDownStatement: {
+                  NotStatement: {
+                    Statement: {
+                      ByteMatchStatement: {
+                        FieldToMatch: { UriPath: {} },
+                        PositionalConstraint: "STARTS_WITH",
+                        SearchString: "/chat",
+                        TextTransformations: [{ Priority: 0, Type: "NONE" }],
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          }),
+        ]),
+      });
+    });
+
+    it("does not add scopeDownStatement when managedRuleScopeDowns is not provided", () => {
+      const stack = new Stack();
+      const bucket = new s3.Bucket(stack, "TestBucket");
+      const origin = origins.S3BucketOrigin.withOriginAccessControl(bucket);
+
+      new JaypieDistribution(stack, "TestDistribution", {
+        handler: origin,
+      });
+      const template = Template.fromStack(stack);
+
+      const resources = template.findResources("AWS::WAFv2::WebACL");
+      const webAcl = Object.values(resources)[0];
+      const rules = webAcl?.Properties?.Rules || [];
+      const commonRule = rules.find(
+        (r: any) => r.Name === "AWSManagedRulesCommonRuleSet",
+      );
+      expect(
+        commonRule?.Statement?.ManagedRuleGroupStatement?.ScopeDownStatement,
+      ).toBeUndefined();
+    });
+
+    it("combines managedRuleOverrides and managedRuleScopeDowns", () => {
+      const stack = new Stack();
+      const bucket = new s3.Bucket(stack, "TestBucket");
+      const origin = origins.S3BucketOrigin.withOriginAccessControl(bucket);
+
+      new JaypieDistribution(stack, "TestDistribution", {
+        handler: origin,
+        waf: {
+          name: "test",
+          managedRuleOverrides: {
+            AWSManagedRulesCommonRuleSet: [
+              { name: "SizeRestrictions_BODY", actionToUse: { count: {} } },
+            ],
+          },
+          managedRuleScopeDowns: {
+            AWSManagedRulesCommonRuleSet: {
+              byteMatchStatement: {
+                fieldToMatch: { uriPath: {} },
+                positionalConstraint: "STARTS_WITH",
+                searchString: "/chat",
+                textTransformations: [{ priority: 0, type: "NONE" }],
+              },
+            },
+          },
+        },
+      });
+      const template = Template.fromStack(stack);
+
+      template.hasResourceProperties("AWS::WAFv2::WebACL", {
+        Rules: Match.arrayWith([
+          Match.objectLike({
+            Name: "AWSManagedRulesCommonRuleSet",
+            Statement: {
+              ManagedRuleGroupStatement: {
+                RuleActionOverrides: [
+                  {
+                    Name: "SizeRestrictions_BODY",
+                    ActionToUse: { Count: {} },
+                  },
+                ],
+                ScopeDownStatement: {
+                  ByteMatchStatement: Match.objectLike({
+                    SearchString: "/chat",
+                  }),
+                },
+              },
+            },
+          }),
+        ]),
+      });
+    });
+
     it("supports existing WebACL ARN", () => {
       const stack = new Stack();
       const bucket = new s3.Bucket(stack, "TestBucket");

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/express",
-  "version": "1.2.21",
+  "version": "1.2.22",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"

--- a/packages/express/src/__tests__/expressHandler.spec.ts
+++ b/packages/express/src/__tests__/expressHandler.spec.ts
@@ -489,6 +489,88 @@ describe("Express Handler", () => {
         expect(mockResSend).toBeCalled();
         expect(mockResSend).toBeCalledWith(12);
       });
+    });
+    describe("fabric option", () => {
+      it("Wraps a plain object return value in { data }", async () => {
+        // Arrange
+        const mockFunction = vi.fn(() => ({ id: "1" }));
+        const handler = expressHandler(mockFunction, { fabric: true });
+        const req: MockRequest = {};
+        const mockResJson = vi.fn();
+        const res: MockResponse = {
+          end: vi.fn(),
+          send: vi.fn(),
+          json: mockResJson,
+          on: vi.fn(),
+          status: vi.fn(() => res) as unknown as ReturnType<typeof vi.fn>,
+        };
+        const next = () => {};
+        // Act
+        await handler(req as Request, res as Response, next);
+        // Assert
+        expect(mockResJson).toHaveBeenCalledTimes(1);
+        expect(mockResJson).toHaveBeenCalledWith({ data: { id: "1" } });
+      });
+      it("Passes already-wrapped { data } through unchanged", async () => {
+        // Arrange
+        const wrapped = { data: { id: "1" } };
+        const mockFunction = vi.fn(() => wrapped);
+        const handler = expressHandler(mockFunction, { fabric: true });
+        const req: MockRequest = {};
+        const mockResJson = vi.fn();
+        const res: MockResponse = {
+          end: vi.fn(),
+          send: vi.fn(),
+          json: mockResJson,
+          on: vi.fn(),
+          status: vi.fn(() => res) as unknown as ReturnType<typeof vi.fn>,
+        };
+        const next = () => {};
+        // Act
+        await handler(req as Request, res as Response, next);
+        // Assert
+        expect(mockResJson).toHaveBeenCalledWith(wrapped);
+      });
+      it("Wraps arrays in { data }", async () => {
+        // Arrange
+        const mockFunction = vi.fn(() => [{ id: "1" }, { id: "2" }]);
+        const handler = expressHandler(mockFunction, { fabric: true });
+        const req: MockRequest = {};
+        const mockResJson = vi.fn();
+        const res: MockResponse = {
+          end: vi.fn(),
+          send: vi.fn(),
+          json: mockResJson,
+          on: vi.fn(),
+          status: vi.fn(() => res) as unknown as ReturnType<typeof vi.fn>,
+        };
+        const next = () => {};
+        // Act
+        await handler(req as Request, res as Response, next);
+        // Assert
+        expect(mockResJson).toHaveBeenCalledWith({
+          data: [{ id: "1" }, { id: "2" }],
+        });
+      });
+      it("Wraps undefined as { data: null }", async () => {
+        // Arrange
+        const mockFunction = vi.fn(() => undefined);
+        const handler = expressHandler(mockFunction, { fabric: true });
+        const req: MockRequest = {};
+        const mockResJson = vi.fn();
+        const res: MockResponse = {
+          end: vi.fn(),
+          send: vi.fn(),
+          json: mockResJson,
+          on: vi.fn(),
+          status: vi.fn(() => res) as unknown as ReturnType<typeof vi.fn>,
+        };
+        const next = () => {};
+        // Act
+        await handler(req as Request, res as Response, next);
+        // Assert
+        expect(mockResJson).toHaveBeenCalledWith({ data: null });
+      });
       it("Will not override res.json() if it was sent", async () => {
         // Arrange
         const mockFunction = vi.fn((req: Request, res: Response) => {

--- a/packages/express/src/__tests__/fabricApiResponse.spec.ts
+++ b/packages/express/src/__tests__/fabricApiResponse.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import fabricApiResponse from "../fabricApiResponse.js";
+
+describe("fabricApiResponse", () => {
+  describe("Base Cases", () => {
+    it("is a function", () => {
+      expect(typeof fabricApiResponse).toBe("function");
+    });
+  });
+
+  describe("Nullish input", () => {
+    it("wraps null as { data: null }", () => {
+      expect(fabricApiResponse(null)).toEqual({ data: null });
+    });
+
+    it("wraps undefined as { data: null }", () => {
+      expect(fabricApiResponse(undefined)).toEqual({ data: null });
+    });
+  });
+
+  describe("Primitives and arrays", () => {
+    it("wraps a plain object in { data }", () => {
+      expect(fabricApiResponse({ id: "1" })).toEqual({ data: { id: "1" } });
+    });
+
+    it("wraps an array in { data }", () => {
+      expect(fabricApiResponse([{ a: 1 }, { a: 2 }])).toEqual({
+        data: [{ a: 1 }, { a: 2 }],
+      });
+    });
+
+    it("wraps a string in { data }", () => {
+      expect(fabricApiResponse("hello")).toEqual({ data: "hello" });
+    });
+
+    it("wraps a number in { data }", () => {
+      expect(fabricApiResponse(42)).toEqual({ data: 42 });
+    });
+  });
+
+  describe("Pass-through", () => {
+    it("passes { data } through unchanged", () => {
+      const input = { data: { id: "1" } };
+      expect(fabricApiResponse(input)).toBe(input);
+    });
+
+    it("passes { errors } through unchanged", () => {
+      const input = { errors: [{ status: 404, title: "Not Found" }] };
+      expect(fabricApiResponse(input)).toBe(input);
+    });
+  });
+
+  describe("Re-wraps objects with extra keys", () => {
+    it("wraps { data, other } (extra key)", () => {
+      const input = { data: { id: "1" }, other: "x" };
+      expect(fabricApiResponse(input)).toEqual({ data: input });
+    });
+
+    it("wraps { data, errors } (both present)", () => {
+      const input = { data: { id: "1" }, errors: [{ status: 400 }] };
+      expect(fabricApiResponse(input)).toEqual({ data: input });
+    });
+
+    it("wraps { items } (not 'data' or 'errors')", () => {
+      const input = { items: [1, 2, 3] };
+      expect(fabricApiResponse(input)).toEqual({ data: input });
+    });
+  });
+});

--- a/packages/express/src/expressHandler.ts
+++ b/packages/express/src/expressHandler.ts
@@ -9,6 +9,7 @@ import { JAYPIE_LAMBDA_MOCK } from "./adapter/LambdaResponseBuffered.js";
 import { JAYPIE_LAMBDA_STREAMING } from "./adapter/LambdaResponseStreaming.js";
 import getCurrentInvokeUuid from "./getCurrentInvokeUuid.adapter.js";
 import decorateResponse from "./decorateResponse.helper.js";
+import fabricApiResponse from "./fabricApiResponse.js";
 import summarizeRequest from "./summarizeRequest.helper.js";
 import summarizeResponse from "./summarizeResponse.helper.js";
 
@@ -84,6 +85,13 @@ export type ExpressHandlerLocals = (
 
 export interface ExpressHandlerOptions {
   chaos?: string;
+  /**
+   * When true, the handler's return value is wrapped with
+   * `fabricApiResponse` before `res.json()`. Plain objects become
+   * `{ data: value }`; pre-wrapped `{ data }` or `{ errors }` payloads
+   * pass through unchanged. `null` / `undefined` become `{ data: null }`.
+   */
+  fabric?: boolean;
   locals?: Record<string, unknown | ExpressHandlerLocals>;
   name?: string;
   secrets?: string[];
@@ -306,6 +314,7 @@ function expressHandler<T>(
   //
   let {
     chaos,
+    fabric,
     locals,
     name,
     secrets,
@@ -520,6 +529,13 @@ function expressHandler<T>(
         | T
         | Record<string, unknown>
         | undefined;
+
+      if (fabric) {
+        response = fabricApiResponse(response) as
+          | T
+          | Record<string, unknown>
+          | undefined;
+      }
 
       //
       //

--- a/packages/express/src/fabricApiResponse.ts
+++ b/packages/express/src/fabricApiResponse.ts
@@ -1,0 +1,49 @@
+//
+//
+// Helpers
+//
+
+function isWrappedData(value: unknown): value is { data: unknown } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.keys(value).length === 1 &&
+    "data" in value
+  );
+}
+
+function isWrappedErrors(value: unknown): value is { errors: unknown[] } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.keys(value).length === 1 &&
+    "errors" in value
+  );
+}
+
+//
+//
+// Main
+//
+
+/**
+ * Wrap a service return value in the canonical Jaypie API envelope.
+ *
+ * Rules:
+ * - `null` / `undefined` → `{ data: null }`
+ * - `{ data }` with exactly one key → passthrough
+ * - `{ errors }` with exactly one key → passthrough
+ * - everything else (including `{ data, other }`) → `{ data: value }`
+ *
+ * The "only one key, and that key is `data` or `errors`" check prevents
+ * false positives where a domain object happens to contain a `data` field.
+ */
+export function fabricApiResponse(result: unknown): unknown {
+  if (result === null || result === undefined) return { data: null };
+  if (isWrappedData(result) || isWrappedErrors(result)) return result;
+  return { data: result };
+}
+
+export default fabricApiResponse;

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -23,6 +23,7 @@ export type {
 export { EXPRESS } from "./constants.js";
 export { default as cors } from "./cors.helper.js";
 export type { CorsConfig } from "./cors.helper.js";
+export { default as fabricApiResponse } from "./fabricApiResponse.js";
 export { default as expressHandler } from "./expressHandler.js";
 export type {
   ExpressHandlerLocals,

--- a/packages/fabric/package.json
+++ b/packages/fabric/package.json
@@ -75,6 +75,7 @@
     "@jaypie/errors": "*"
   },
   "devDependencies": {
+    "@jaypie/express": "*",
     "@jaypie/testkit": "*",
     "@modelcontextprotocol/sdk": "^1.17.0",
     "@rollup/plugin-typescript": "^12.1.2",
@@ -96,6 +97,7 @@
   "peerDependencies": {
     "@jaypie/aws": "*",
     "@jaypie/dynamodb": "*",
+    "@jaypie/express": "*",
     "@jaypie/lambda": "*",
     "@modelcontextprotocol/sdk": ">=1.0.0",
     "commander": ">=12.0.0",
@@ -107,6 +109,9 @@
       "optional": true
     },
     "@jaypie/dynamodb": {
+      "optional": true
+    },
+    "@jaypie/express": {
       "optional": true
     },
     "@jaypie/lambda": {

--- a/packages/fabric/package.json
+++ b/packages/fabric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/fabric",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Jaypie modeling framework with type conversion, service handlers, and adapters",
   "repository": {
     "type": "git",

--- a/packages/fabric/src/__tests__/express.spec.ts
+++ b/packages/fabric/src/__tests__/express.spec.ts
@@ -50,22 +50,40 @@ function createMockRequest(
   };
 }
 
-// Mock Express response
+// Mock Express response — covers surface touched by both fabricExpress and
+// the `expressHandler` wrap (which binds .end/.json/.send/.status and attaches
+// a `finish` listener via .on). The bind() on each spy is replaced to return
+// the original spy, so referential identity survives expressHandler's
+// illegal-call replay (which saves `.bind(res)` and later reassigns).
+function stableSpy(): ReturnType<typeof vi.fn> {
+  const fn = vi.fn();
+  (fn as unknown as { bind: () => typeof fn }).bind = () => fn;
+  return fn;
+}
+
 function createMockResponse(): {
+  end: ReturnType<typeof vi.fn>;
   status: ReturnType<typeof vi.fn>;
   json: ReturnType<typeof vi.fn>;
   send: ReturnType<typeof vi.fn>;
   set: ReturnType<typeof vi.fn>;
+  on: ReturnType<typeof vi.fn>;
+  emit: ReturnType<typeof vi.fn>;
   statusCode: number;
   headersSent: boolean;
+  locals: Record<string, unknown>;
 } {
   const res = {
-    status: vi.fn(),
-    json: vi.fn(),
-    send: vi.fn(),
-    set: vi.fn(),
+    end: stableSpy(),
+    status: stableSpy(),
+    json: stableSpy(),
+    send: stableSpy(),
+    set: stableSpy(),
+    on: vi.fn(),
+    emit: vi.fn(),
     statusCode: 200,
     headersSent: false,
+    locals: {} as Record<string, unknown>,
   };
   // Chain methods
   res.status.mockReturnValue(res);
@@ -439,6 +457,112 @@ describe("Express Adapter", () => {
           expect.objectContaining({ userId: "user-123" }),
           expect.any(Object),
         );
+      });
+    });
+
+    describe("Lifecycle Integration (expressHandler)", () => {
+      it("runs setup functions before the service", async () => {
+        const order: string[] = [];
+        const setup = vi.fn(async () => {
+          order.push("setup");
+        });
+        const serviceFn = vi.fn(() => {
+          order.push("service");
+          return "ok";
+        });
+        const httpService = fabricHttp({
+          alias: "test",
+          service: serviceFn,
+        });
+
+        const middleware = fabricExpress({
+          service: httpService,
+          setup,
+        });
+
+        const req = createMockRequest({ method: "GET" });
+        const res = createMockResponse();
+        const next = vi.fn();
+
+        await middleware(req as never, res as never, next);
+
+        expect(setup).toHaveBeenCalledTimes(1);
+        expect(serviceFn).toHaveBeenCalledTimes(1);
+        expect(order).toEqual(["setup", "service"]);
+      });
+
+      it("runs teardown functions after the service", async () => {
+        const order: string[] = [];
+        const teardown = vi.fn(async () => {
+          order.push("teardown");
+        });
+        const serviceFn = vi.fn(() => {
+          order.push("service");
+          return "ok";
+        });
+        const httpService = fabricHttp({
+          alias: "test",
+          service: serviceFn,
+        });
+
+        const middleware = fabricExpress({
+          service: httpService,
+          teardown,
+        });
+
+        const req = createMockRequest({ method: "GET" });
+        const res = createMockResponse();
+        const next = vi.fn();
+
+        await middleware(req as never, res as never, next);
+
+        expect(teardown).toHaveBeenCalledTimes(1);
+        expect(order).toEqual(["service", "teardown"]);
+      });
+
+      it("returns 503 when unavailable is true (service never runs)", async () => {
+        const serviceFn = vi.fn().mockReturnValue("result");
+        const httpService = fabricHttp({
+          alias: "test",
+          service: serviceFn,
+        });
+
+        const middleware = fabricExpress({
+          service: httpService,
+          unavailable: true,
+        });
+
+        const req = createMockRequest({ method: "GET" });
+        const res = createMockResponse();
+        const next = vi.fn();
+
+        await middleware(req as never, res as never, next);
+
+        expect(serviceFn).not.toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(503);
+      });
+
+      it("runs validate functions before the service", async () => {
+        const validate = vi.fn(() => true);
+        const serviceFn = vi.fn().mockReturnValue("ok");
+        const httpService = fabricHttp({
+          alias: "test",
+          service: serviceFn,
+        });
+
+        const middleware = fabricExpress({
+          service: httpService,
+          validate: [validate],
+        });
+
+        const req = createMockRequest({ method: "GET" });
+        const res = createMockResponse();
+        const next = vi.fn();
+
+        await middleware(req as never, res as never, next);
+
+        expect(validate).toHaveBeenCalledTimes(1);
+        expect(serviceFn).toHaveBeenCalledTimes(1);
       });
     });
 

--- a/packages/fabric/src/express/fabricExpress.ts
+++ b/packages/fabric/src/express/fabricExpress.ts
@@ -1,4 +1,5 @@
 import type { NextFunction, Request, Response } from "express";
+import { expressHandler } from "@jaypie/express";
 
 import { isFabricHttpService } from "../http/fabricHttp.js";
 import type { HttpServiceContext } from "../http/fabricHttp.js";
@@ -203,8 +204,30 @@ export function fabricExpress<
     }
   };
 
+  // Wrap with expressHandler to pick up Jaypie lifecycle (secrets, setup,
+  // teardown, validate, unavailable, locals) and observability. The inner
+  // middleware calls res.json/res.status/res.send directly; expressHandler
+  // captures those as "illegal" calls and replays them after postprocess.
+  const wrapped = expressHandler(
+    middleware as unknown as (req: Request, res: Response) => Promise<void>,
+    {
+      chaos: config.chaos,
+      locals: config.locals,
+      name: config.name ?? service.alias,
+      secrets: config.secrets,
+      setup: config.setup,
+      teardown: config.teardown,
+      unavailable: config.unavailable,
+      validate: config.validate,
+    },
+  ) as unknown as (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ) => Promise<void>;
+
   // Attach metadata to middleware
-  const expressMiddleware = middleware as FabricExpressMiddleware;
+  const expressMiddleware = wrapped as FabricExpressMiddleware;
   expressMiddleware.service = service;
   expressMiddleware.path = path;
   expressMiddleware.methods = methods;

--- a/packages/fabric/src/express/types.ts
+++ b/packages/fabric/src/express/types.ts
@@ -10,6 +10,30 @@ import type {
 // #region fabricExpress
 
 /**
+ * Per-request lifecycle function types forwarded to `expressHandler`.
+ * Defined locally to avoid a hard type dependency on `@jaypie/express`.
+ */
+export type FabricExpressSetup = (
+  req: Request,
+  res: Response,
+) => Promise<void> | void;
+
+export type FabricExpressTeardown = (
+  req: Request,
+  res: Response,
+) => Promise<void> | void;
+
+export type FabricExpressValidate = (
+  req: Request,
+  res: Response,
+) => Promise<boolean | void> | boolean | void;
+
+export type FabricExpressLocalsFn = (
+  req: Request,
+  res: Response,
+) => Promise<unknown> | unknown;
+
+/**
  * Configuration for fabricExpress middleware
  */
 export interface FabricExpressConfig<
@@ -23,6 +47,25 @@ export interface FabricExpressConfig<
   path?: string;
   /** HTTP methods to handle (defaults to DEFAULT_HTTP_METHODS) */
   methods?: HttpMethod[];
+
+  // `expressHandler` lifecycle pass-through
+
+  /** Chaos mode identifier forwarded to `expressHandler`. */
+  chaos?: string;
+  /** Per-request locals forwarded to `expressHandler`. */
+  locals?: Record<string, unknown | FabricExpressLocalsFn>;
+  /** Handler name for logging. Defaults to the service alias. */
+  name?: string;
+  /** AWS Secret names to load into `process.env` before the handler runs. */
+  secrets?: string[];
+  /** Pre-handler setup function(s). */
+  setup?: FabricExpressSetup | FabricExpressSetup[];
+  /** Post-handler teardown function(s) — always run. */
+  teardown?: FabricExpressTeardown | FabricExpressTeardown[];
+  /** If true, the handler returns 503 immediately without running. */
+  unavailable?: boolean;
+  /** Validation function(s) run before the handler. */
+  validate?: FabricExpressValidate | FabricExpressValidate[];
 }
 
 /**

--- a/packages/jaypie/package.json
+++ b/packages/jaypie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jaypie",
-  "version": "1.2.39",
+  "version": "1.2.40",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"
@@ -36,7 +36,7 @@
     "@jaypie/core": "^1.2.2",
     "@jaypie/datadog": "^1.2.2",
     "@jaypie/errors": "^1.2.1",
-    "@jaypie/express": "^1.2.21",
+    "@jaypie/express": "^1.2.22",
     "@jaypie/kit": "^1.2.7",
     "@jaypie/lambda": "^1.2.5",
     "@jaypie/logger": "^1.2.15"
@@ -54,7 +54,7 @@
     "typescript-eslint": "^8.46.1"
   },
   "peerDependencies": {
-    "@jaypie/llm": "^1.2.28",
+    "@jaypie/llm": "^1.2.29",
     "@jaypie/mongoose": "^1.2.2"
   },
   "peerDependenciesMeta": {

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/llm",
-  "version": "1.2.28",
+  "version": "1.2.29",
   "description": "Large language model utilities",
   "repository": {
     "type": "git",

--- a/packages/llm/src/operate/adapters/XaiAdapter.ts
+++ b/packages/llm/src/operate/adapters/XaiAdapter.ts
@@ -1,16 +1,52 @@
+import { BadRequestError } from "openai";
+
 import { PROVIDER } from "../../constants.js";
+import { ClassifiedError, ErrorCategory } from "../types.js";
 import { OpenAiAdapter } from "./OpenAiAdapter.js";
 
 /**
+ * Error-message substrings that indicate a transient xAI media-ingest flake.
+ * The xAI ingest service enters a bad state after ~12 consecutive file-bearing
+ * calls and rejects subsequent requests with HTTP 400. The condition is
+ * self-clearing, so these errors should be retried with backoff rather than
+ * surfaced as unrecoverable.
+ *
+ * See: github.com/finlaysonstudio/jaypie issue #301
+ */
+const TRANSIENT_INGEST_MESSAGE_PATTERNS = [
+  "failed to ingest inline file bytes",
+] as const;
+
+function isTransientIngestError(error: unknown): boolean {
+  if (!(error instanceof BadRequestError)) return false;
+  const message = (error.message ?? "").toLowerCase();
+  return TRANSIENT_INGEST_MESSAGE_PATTERNS.some((pattern) =>
+    message.includes(pattern),
+  );
+}
+
+/**
  * XaiAdapter extends OpenAiAdapter since xAI (Grok) uses an OpenAI-compatible API.
- * Only the name and default model are overridden; all request building, response parsing,
- * error classification, tool handling, and streaming are inherited.
+ * Name, default model, and transient-ingest-error detection are overridden;
+ * all request building, response parsing, tool handling, and streaming are
+ * inherited.
  */
 export class XaiAdapter extends OpenAiAdapter {
   // @ts-expect-error Narrowing override: xAI name differs from parent's literal "openai"
   readonly name = PROVIDER.XAI.NAME;
   // @ts-expect-error Narrowing override: xAI default model differs from parent's literal
   readonly defaultModel = PROVIDER.XAI.MODEL.DEFAULT;
+
+  classifyError(error: unknown): ClassifiedError {
+    if (isTransientIngestError(error)) {
+      return {
+        error,
+        category: ErrorCategory.Retryable,
+        shouldRetry: true,
+      };
+    }
+    return super.classifyError(error);
+  }
 }
 
 // Export singleton instance

--- a/packages/llm/src/operate/adapters/__tests__/XaiAdapter.spec.ts
+++ b/packages/llm/src/operate/adapters/__tests__/XaiAdapter.spec.ts
@@ -250,6 +250,29 @@ describe("XaiAdapter", () => {
         expect(result.category).toBe(ErrorCategory.Unrecoverable);
         expect(result.shouldRetry).toBe(false);
       });
+
+      it("retries on transient xAI ingest-bytes error (400 with 'failed to ingest inline file bytes')", async () => {
+        const { BadRequestError } = await import("openai");
+        // @ts-expect-error Mock doesn't require constructor args
+        const error = new BadRequestError();
+        error.message = "400 failed to ingest inline file bytes";
+
+        const result = xaiAdapter.classifyError(error);
+
+        expect(result.category).toBe(ErrorCategory.Retryable);
+        expect(result.shouldRetry).toBe(true);
+      });
+
+      it("does not retry on unrelated BadRequestError", async () => {
+        const { BadRequestError } = await import("openai");
+        // @ts-expect-error Mock doesn't require constructor args
+        const error = new BadRequestError();
+        error.message = "400 invalid model";
+
+        const result = xaiAdapter.classifyError(error);
+
+        expect(result.shouldRetry).toBe(false);
+      });
     });
   });
 });

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.38",
+  "version": "0.8.39",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/constructs/1.2.48.md
+++ b/packages/mcp/release-notes/constructs/1.2.48.md
@@ -10,4 +10,8 @@ summary: Add managedRuleScopeDowns to JaypieWafConfig
 - Keyed by managed rule group name, parallel to `managedRuleOverrides`.
 - Use case: scope `AWSManagedRulesCommonRuleSet` away from `/chat` paths so large chat request bodies don't collide with `SizeRestrictions_BODY` without weakening protection globally.
 
+## Skills
+
+- ~cdk — WAF section adds a `managedRuleScopeDowns` example alongside the existing `managedRuleOverrides` one.
+
 Closes #306.

--- a/packages/mcp/release-notes/constructs/1.2.48.md
+++ b/packages/mcp/release-notes/constructs/1.2.48.md
@@ -1,0 +1,13 @@
+---
+version: 1.2.48
+date: 2026-04-17
+summary: Add managedRuleScopeDowns to JaypieWafConfig
+---
+
+## Changes
+
+- `JaypieDistribution` WAF config now accepts `managedRuleScopeDowns?: Record<string, CfnWebACL.StatementProperty>`, allowing any managed rule group to be narrowed to a specific URL pattern (or any other WAFv2 statement shape).
+- Keyed by managed rule group name, parallel to `managedRuleOverrides`.
+- Use case: scope `AWSManagedRulesCommonRuleSet` away from `/chat` paths so large chat request bodies don't collide with `SizeRestrictions_BODY` without weakening protection globally.
+
+Closes #306.

--- a/packages/mcp/release-notes/express/1.2.22.md
+++ b/packages/mcp/release-notes/express/1.2.22.md
@@ -17,4 +17,9 @@ summary: Add fabricApiResponse helper and expressHandler fabric option
 
 The `skill("api")` envelope contract says a response contains either `data` or `errors`, never both, and no other top-level keys. The helper and handler option make conforming to that contract the easy path.
 
+## Skills
+
+- ~express — Handler Options block documents the new `fabric` flag; new "fabricApiResponse and `{ fabric: true }`" section covers the helper and wrap rules.
+- ~handlers — Express handler example now shows `{ fabric: true }` as the recommended envelope path.
+
 Closes #309.

--- a/packages/mcp/release-notes/express/1.2.22.md
+++ b/packages/mcp/release-notes/express/1.2.22.md
@@ -1,0 +1,20 @@
+---
+version: 1.2.22
+date: 2026-04-17
+summary: Add fabricApiResponse helper and expressHandler fabric option
+---
+
+## Changes
+
+- New export `fabricApiResponse(value)` wraps a value in the canonical Jaypie API envelope:
+  - `null` / `undefined` → `{ data: null }`
+  - `{ data }` with exactly one key → passthrough
+  - `{ errors }` with exactly one key → passthrough
+  - anything else (including `{ data, other }`) → `{ data: value }`
+- New `expressHandler` option `{ fabric: true }` applies `fabricApiResponse` to the handler's return value before `res.json()`, removing the `apiResponse(await service())` boilerplate.
+
+## Why
+
+The `skill("api")` envelope contract says a response contains either `data` or `errors`, never both, and no other top-level keys. The helper and handler option make conforming to that contract the easy path.
+
+Closes #309.

--- a/packages/mcp/release-notes/fabric/0.3.2.md
+++ b/packages/mcp/release-notes/fabric/0.3.2.md
@@ -1,0 +1,19 @@
+---
+version: 0.3.2
+date: 2026-04-17
+summary: fabricExpress integrates expressHandler lifecycle
+---
+
+## Changes
+
+- `FabricExpressConfig` now accepts the full set of `expressHandler` lifecycle options: `chaos`, `locals`, `name`, `secrets`, `setup`, `teardown`, `unavailable`, `validate`.
+- `fabricExpress` wraps the inner middleware with `expressHandler` so per-request lifecycle (secrets loading, setup/teardown, validate, unavailable, locals, observability) runs automatically — matching `fabricLambda` / `fabricWebSocket` adapter patterns.
+- Inner middleware still calls `res.json` / `res.status` / `res.send` directly; `expressHandler` captures these as illegal calls and replays them after postprocess, preserving existing envelope and 405/204 behavior.
+
+## Peer dependencies
+
+- Adds `@jaypie/express` as an optional peer dependency (alongside `@jaypie/lambda`).
+
+## Why
+
+Previously `fabricExpress` was a plain middleware — an asymmetry with `fabricLambda` (wraps `lambdaHandler`) and `fabricWebSocket` (wraps `websocketHandler`). Consumers had to stack `expressHandler(fabricExpress(...))` themselves to get lifecycle, defeating convenience. This change makes lifecycle the default.

--- a/packages/mcp/release-notes/fabric/0.3.2.md
+++ b/packages/mcp/release-notes/fabric/0.3.2.md
@@ -17,3 +17,7 @@ summary: fabricExpress integrates expressHandler lifecycle
 ## Why
 
 Previously `fabricExpress` was a plain middleware — an asymmetry with `fabricLambda` (wraps `lambdaHandler`) and `fabricWebSocket` (wraps `websocketHandler`). Consumers had to stack `expressHandler(fabricExpress(...))` themselves to get lifecycle, defeating convenience. This change makes lifecycle the default.
+
+## Skills
+
+- ~fabric — Adapters section adds an Express Middleware example covering `fabricHttp` + `fabricExpress` + `FabricRouter`, including lifecycle pass-through.

--- a/packages/mcp/release-notes/jaypie/1.2.40.md
+++ b/packages/mcp/release-notes/jaypie/1.2.40.md
@@ -1,0 +1,11 @@
+---
+version: 1.2.40
+date: 2026-04-17
+summary: Bump @jaypie/express and @jaypie/llm deps
+---
+
+## Changes
+
+- Dependency bumps:
+  - `@jaypie/express` ^1.2.21 → ^1.2.22 (`fabricApiResponse` helper, `{ fabric: true }` handler option)
+  - `@jaypie/llm` ^1.2.28 → ^1.2.29 (peer; xAI retries transient ingest-bytes 400s)

--- a/packages/mcp/release-notes/llm/1.2.29.md
+++ b/packages/mcp/release-notes/llm/1.2.29.md
@@ -1,0 +1,16 @@
+---
+version: 1.2.29
+date: 2026-04-17
+summary: xAI adapter retries transient "failed to ingest inline file bytes" 400s
+---
+
+## Changes
+
+- `XaiAdapter` now overrides `classifyError` to mark HTTP 400 responses whose message contains `"failed to ingest inline file bytes"` as retryable. The existing exponential-backoff retry loop then retries them (same pattern as transient-network retries).
+- Unrelated `BadRequestError`s remain non-retryable — they fall through to the parent OpenAI-compatible classifier.
+
+## Why
+
+xAI's media-ingest service enters a bad state after ~12 consecutive file-bearing calls and self-clears after a short pause. Previously these 400s were terminal, losing all downstream work in a batch; they're now transparently retried.
+
+Closes #301.

--- a/packages/mcp/release-notes/mcp/0.8.39.md
+++ b/packages/mcp/release-notes/mcp/0.8.39.md
@@ -1,0 +1,16 @@
+---
+version: 0.8.39
+date: 2026-04-17
+summary: Add release notes for the #301/#306/#309 + fabricExpress lifecycle batch
+---
+
+## Changes
+
+Added release notes for:
+
+- `@jaypie/constructs@1.2.48` (#306 — WAF scopeDownStatement)
+- `@jaypie/express@1.2.22` (#309 — fabricApiResponse + fabric option)
+- `@jaypie/fabric@0.3.2` (fabricExpress wraps expressHandler)
+- `@jaypie/llm@1.2.29` (#301 — xAI ingest-bytes retry)
+- `@jaypie/testkit@1.2.35` (mock fabricApiResponse)
+- `jaypie@1.2.40` (dependency bumps)

--- a/packages/mcp/release-notes/mcp/0.8.39.md
+++ b/packages/mcp/release-notes/mcp/0.8.39.md
@@ -14,3 +14,10 @@ Added release notes for:
 - `@jaypie/llm@1.2.29` (#301 — xAI ingest-bytes retry)
 - `@jaypie/testkit@1.2.35` (mock fabricApiResponse)
 - `jaypie@1.2.40` (dependency bumps)
+
+## Skills updated
+
+- ~cdk — WAF section adds `managedRuleScopeDowns` example.
+- ~express — documents `fabric` option and `fabricApiResponse` helper.
+- ~fabric — Adapters section adds Express Middleware / FabricRouter example with lifecycle pass-through.
+- ~handlers — Express handler example uses `{ fabric: true }`.

--- a/packages/mcp/release-notes/testkit/1.2.35.md
+++ b/packages/mcp/release-notes/testkit/1.2.35.md
@@ -1,0 +1,9 @@
+---
+version: 1.2.35
+date: 2026-04-17
+summary: Mock fabricApiResponse from @jaypie/express
+---
+
+## Changes
+
+- Added a mock for `fabricApiResponse` (new export in `@jaypie/express@1.2.22`) so consumers get a wrapped mock via `@jaypie/testkit/mock` alongside `cors`, `expressHandler`, etc.

--- a/packages/mcp/skills/cdk.md
+++ b/packages/mcp/skills/cdk.md
@@ -359,6 +359,31 @@ new JaypieDistribution(this, "Dist", {
     },
   },
 });
+
+// Scope a managed rule group to (or away from) specific URL patterns
+new JaypieDistribution(this, "Dist", {
+  handler,
+  waf: {
+    name: "api",
+    managedRuleScopeDowns: {
+      // Only run the CommonRuleSet for paths OTHER than /chat — lets /chat
+      // handle large AI-generated request bodies without weakening protection
+      // elsewhere.
+      AWSManagedRulesCommonRuleSet: {
+        notStatement: {
+          statement: {
+            byteMatchStatement: {
+              fieldToMatch: { uriPath: {} },
+              positionalConstraint: "STARTS_WITH",
+              searchString: "/chat",
+              textTransformations: [{ priority: 0, type: "NONE" }],
+            },
+          },
+        },
+      },
+    },
+  },
+});
 ```
 
 Cost: $5/month per WebACL + $1/month per rule + $0.60 per million requests. Use `waf: false` to opt out.

--- a/packages/mcp/skills/express.md
+++ b/packages/mcp/skills/express.md
@@ -46,14 +46,39 @@ app.get("/api/users", expressHandler(async (req, res) => {
 
 ```typescript
 expressHandler(handler, {
+  fabric: false,     // Wrap return with fabricApiResponse before res.json (default false)
   locals: {},        // Values passed to res.locals
   name: "handler",   // Handler name for logging
+  secrets: [],       // AWS Secrets names to load into process.env
   setup: async (req, res) => {},    // Pre-handler setup
   teardown: async (req, res) => {}, // Post-handler cleanup
   unavailable: false, // Return 503 immediately if true
   validate: async (req, res) => {}, // Validation before handler
 });
 ```
+
+### fabricApiResponse and `{ fabric: true }`
+
+Return plain domain objects and opt into the canonical Jaypie API envelope:
+
+```typescript
+import { expressHandler, fabricApiResponse } from "jaypie";
+
+// Handler option — wraps the return value automatically
+app.get(
+  "/ping",
+  expressHandler(async (req) => ping(req.query), { fabric: true }),
+);
+
+// Standalone helper — same rules as `{ fabric: true }`
+fabricApiResponse({ id: "1" });        // { data: { id: "1" } }
+fabricApiResponse([{ id: "1" }]);      // { data: [{ id: "1" }] }
+fabricApiResponse({ data: {...} });    // passthrough
+fabricApiResponse({ errors: [...] });  // passthrough
+fabricApiResponse(null);               // { data: null }
+```
+
+Wrap rules: only `{ data }` alone or `{ errors }` alone pass through. Anything else (including `{ data, other }`) gets wrapped as `{ data: value }`.
 
 ## Lambda Adapter
 

--- a/packages/mcp/skills/fabric.md
+++ b/packages/mcp/skills/fabric.md
@@ -77,6 +77,37 @@ const tools = [fabricLlmTool(greetService)];
 // Available to LLM as function call
 ```
 
+### Express Middleware
+
+```typescript
+import { fabricHttp } from "@jaypie/fabric/http";
+import { fabricExpress, FabricRouter } from "@jaypie/fabric/express";
+
+// Wrap service with fabricHttp first (HTTP context + default input transform)
+const greetHttp = fabricHttp({ service: greetService });
+
+// Single-route middleware — alias becomes default path ("/greet")
+app.get("/greet", fabricExpress({ service: greetHttp }));
+
+// Lifecycle pass-through (forwarded to expressHandler): secrets, setup,
+// teardown, validate, unavailable, locals, name, chaos
+app.post(
+  "/records",
+  fabricExpress({
+    service: recordsHttp,
+    secrets: ["MONGODB_URI"],
+    setup: async (req) => { /* ... */ },
+  }),
+);
+
+// Multi-service router — alias-derived paths under a prefix
+app.use(FabricRouter({ services: [greetHttp, searchHttp], prefix: "/api" }));
+```
+
+`fabricExpress` wraps the middleware with `expressHandler` internally, so
+per-route lifecycle and observability come along for the ride (parallel to
+`fabricLambda` → `lambdaHandler` and `fabricWebSocket` → `websocketHandler`).
+
 ## Service Suites
 
 Group related services:

--- a/packages/mcp/skills/handlers.md
+++ b/packages/mcp/skills/handlers.md
@@ -90,6 +90,13 @@ app.get("/api/users", expressHandler(async (req, res) => {
   return { users: [] };
 }));
 
+// Return plain domain objects and let `{ fabric: true }` apply the
+// canonical Jaypie `{ data }` envelope automatically.
+app.get(
+  "/ping",
+  expressHandler(async (req) => ping(req.query), { fabric: true }),
+);
+
 // Convert Express app to Lambda
 export const handler = createLambdaHandler(app);
 ```

--- a/packages/testkit/package.json
+++ b/packages/testkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/testkit",
-  "version": "1.2.34",
+  "version": "1.2.35",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"

--- a/packages/testkit/src/mock/express.ts
+++ b/packages/testkit/src/mock/express.ts
@@ -87,6 +87,10 @@ export const expressHttpCodeHandler = createMockWrappedFunction(
 
 export const cors = createMockWrappedFunction(original.cors as any);
 
+export const fabricApiResponse = createMockWrappedFunction(
+  original.fabricApiResponse as any,
+);
+
 export const getCurrentInvokeUuid = createMockReturnedFunction<
   string | undefined
 >("mock-invoke-uuid-12345678");


### PR DESCRIPTION
## Summary

Four independent fixes / features bundled into one release, plus version and docs housekeeping.

## Closes

- #301 — xAI adapter now retries transient `400 "failed to ingest inline file bytes"` with exponential backoff
- #306 — `JaypieDistribution` WAF config accepts `managedRuleScopeDowns` for per-URL-pattern scoping of managed rule groups
- #309 — New `fabricApiResponse` helper and `expressHandler({ fabric: true })` option for automatic JSON:API envelope wrapping

Also ships: `fabricExpress` now wraps `expressHandler` internally so per-route lifecycle (`secrets`, `setup`, `teardown`, `validate`, `unavailable`, `locals`, `name`, `chaos`) flows through. Matches the `fabricLambda` → `lambdaHandler` and `fabricWebSocket` → `websocketHandler` pattern.

## Not in this PR

- #302 (xAI Files API) — deferred to a follow-up branch. The catastrophic failure is mitigated by #301's retry; #302 needs live-credential investigation of xAI Files API availability, shape, and lifecycle before implementation.

## Bumps

| Package | From | To |
|---|---|---|
| `@jaypie/constructs` | 1.2.47 | 1.2.48 |
| `@jaypie/express` | 1.2.21 | 1.2.22 |
| `@jaypie/fabric` | 0.3.1 | 0.3.2 |
| `@jaypie/llm` | 1.2.28 | 1.2.29 |
| `@jaypie/mcp` | 0.8.38 | 0.8.39 |
| `@jaypie/testkit` | 1.2.34 | 1.2.35 |
| `jaypie` | 1.2.39 | 1.2.40 |

## Skills updated

- `~cdk` — WAF `managedRuleScopeDowns` example
- `~express` — `fabric` option + `fabricApiResponse` helper
- `~fabric` — Express Middleware adapter example with lifecycle pass-through
- `~handlers` — Express handler example uses `{ fabric: true }`

## Test plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [x] `npm test` — 3154 tests / 200 files pass
- [x] NPM Check workflow green

🤖 Generated with [Claude Code](https://claude.com/claude-code)