### PR TITLE
fix(constructs): consolidate Route53 query log resource policy (issue #311)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28464,7 +28464,7 @@
     },
     "packages/constructs": {
       "name": "@jaypie/constructs",
-      "version": "1.2.48",
+      "version": "1.2.49",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*",
@@ -29547,7 +29547,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.39",
+      "version": "0.8.40",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.4",

--- a/packages/constructs/package.json
+++ b/packages/constructs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/constructs",
-  "version": "1.2.48",
+  "version": "1.2.49",
   "description": "CDK constructs for Jaypie applications",
   "repository": {
     "type": "git",

--- a/packages/constructs/src/JaypieHostedZone.ts
+++ b/packages/constructs/src/JaypieHostedZone.ts
@@ -1,6 +1,5 @@
 import { CDK } from "./constants";
 import * as cdk from "aws-cdk-lib";
-import { ServicePrincipal } from "aws-cdk-lib/aws-iam";
 import {
   FilterPattern,
   ILogGroup,
@@ -11,12 +10,9 @@ import { LambdaDestination } from "aws-cdk-lib/aws-logs-destinations";
 import { HostedZone, IHostedZone } from "aws-cdk-lib/aws-route53";
 import { Construct } from "constructs";
 
+import { ensureRoute53QueryLoggingPolicy } from "./helpers/ensureRoute53QueryLoggingPolicy";
 import { resolveDatadogLoggingDestination } from "./helpers/resolveDatadogLoggingDestination";
 import { JaypieDnsRecord, JaypieDnsRecordProps } from "./JaypieDnsRecord";
-
-const SERVICE = {
-  ROUTE53: "route53.amazonaws.com",
-} as const;
 
 /**
  * Check if a string is a valid hostname
@@ -78,6 +74,15 @@ interface JaypieHostedZoneProps {
    * Each record will be created as a JaypieDnsRecord construct
    */
   records?: JaypieHostedZoneRecordProps[];
+  /**
+   * Control the CloudWatch Logs resource policy that grants Route53 permission
+   * to write query logs. Defaults to `true`, which ensures a single
+   * stack-level wildcard policy covering every `/aws/route53/*` log group.
+   * Set to `false` to skip creating a managed policy (useful when an
+   * account-wide policy is provisioned externally).
+   * @default true
+   */
+  queryLoggingPolicy?: boolean;
 }
 
 export class JaypieHostedZone extends Construct {
@@ -144,8 +149,13 @@ export class JaypieHostedZone extends Construct {
       cdk.Tags.of(this.logGroup).add(CDK.TAG.PROJECT, project);
     }
 
-    // Grant Route 53 permissions to write to the log group
-    this.logGroup.grantWrite(new ServicePrincipal(SERVICE.ROUTE53));
+    // Grant Route53 permission to write query logs via a single stack-level
+    // resource policy. Per-zone policies exhaust the CloudWatch Logs
+    // 10-policy-per-region account quota (issue #311).
+    const queryLoggingPolicy = props.queryLoggingPolicy ?? true;
+    if (queryLoggingPolicy) {
+      ensureRoute53QueryLoggingPolicy(this);
+    }
 
     // Add destination based on configuration
     if (destination !== false) {

--- a/packages/constructs/src/__tests__/JaypieHostedZone.spec.ts
+++ b/packages/constructs/src/__tests__/JaypieHostedZone.spec.ts
@@ -224,4 +224,65 @@ describe("JaypieHostedZone", () => {
       expect(zone.dnsRecords).toHaveLength(0);
     });
   });
+
+  // Resource Policy Consolidation (issue #311)
+  describe("Resource Policy Consolidation", () => {
+    it("creates a single AWS::Logs::ResourcePolicy for multiple zones in one stack", () => {
+      app = new App();
+      stack = new Stack(app, "TestStack");
+      new JaypieHostedZone(stack, "ZoneA", { zoneName: "a.example.com" });
+      new JaypieHostedZone(stack, "ZoneB", { zoneName: "b.example.com" });
+      new JaypieHostedZone(stack, "ZoneC", { zoneName: "c.example.com" });
+      template = Template.fromStack(stack);
+
+      template.resourceCountIs("AWS::Logs::ResourcePolicy", 1);
+    });
+
+    it("consolidated policy uses a wildcard covering all /aws/route53 log groups", () => {
+      app = new App();
+      stack = new Stack(app, "TestStack");
+      new JaypieHostedZone(stack, "ZoneA", { zoneName: "a.example.com" });
+      new JaypieHostedZone(stack, "ZoneB", { zoneName: "b.example.com" });
+      template = Template.fromStack(stack);
+
+      const resources = template.findResources("AWS::Logs::ResourcePolicy");
+      const [policy] = Object.values(resources);
+      const serialized = JSON.stringify(policy.Properties.PolicyDocument);
+      expect(serialized).toContain("route53.amazonaws.com");
+      expect(serialized).toContain("logs:PutLogEvents");
+      expect(serialized).toContain("logs:CreateLogStream");
+      expect(serialized).toContain("/aws/route53/*");
+    });
+
+    it("omits the managed policy when queryLoggingPolicy is false", () => {
+      app = new App();
+      stack = new Stack(app, "TestStack");
+      new JaypieHostedZone(stack, "ZoneA", {
+        zoneName: "a.example.com",
+        queryLoggingPolicy: false,
+      });
+      new JaypieHostedZone(stack, "ZoneB", {
+        zoneName: "b.example.com",
+        queryLoggingPolicy: false,
+      });
+      template = Template.fromStack(stack);
+
+      template.resourceCountIs("AWS::Logs::ResourcePolicy", 0);
+    });
+
+    it("still creates the consolidated policy when any zone opts in", () => {
+      app = new App();
+      stack = new Stack(app, "TestStack");
+      new JaypieHostedZone(stack, "ZoneA", {
+        zoneName: "a.example.com",
+        queryLoggingPolicy: false,
+      });
+      new JaypieHostedZone(stack, "ZoneB", {
+        zoneName: "b.example.com",
+      });
+      template = Template.fromStack(stack);
+
+      template.resourceCountIs("AWS::Logs::ResourcePolicy", 1);
+    });
+  });
 });

--- a/packages/constructs/src/helpers/ensureRoute53QueryLoggingPolicy.ts
+++ b/packages/constructs/src/helpers/ensureRoute53QueryLoggingPolicy.ts
@@ -1,0 +1,41 @@
+import { Stack } from "aws-cdk-lib";
+import { CfnResourcePolicy } from "aws-cdk-lib/aws-logs";
+import { Construct } from "constructs";
+
+const SINGLETON_ID = "JaypieRoute53QueryLoggingPolicy";
+const ROUTE53_LOG_GROUP_PREFIX = "/aws/route53";
+const ROUTE53_SERVICE_PRINCIPAL = "route53.amazonaws.com";
+
+/**
+ * Create (or return the existing) stack-level CloudWatch Logs resource policy
+ * that grants Route53 permission to write query logs to any `/aws/route53/*`
+ * log group in the stack's account and region.
+ *
+ * Consolidates what would otherwise be one `AWS::Logs::ResourcePolicy` per
+ * hosted zone into a single wildcard policy, keeping the stack well clear of
+ * the 10-resource-policy-per-region account quota.
+ */
+export function ensureRoute53QueryLoggingPolicy(
+  scope: Construct,
+): CfnResourcePolicy {
+  const stack = Stack.of(scope);
+  const existing = stack.node.tryFindChild(SINGLETON_ID);
+  if (existing) return existing as CfnResourcePolicy;
+
+  const policyDocument = {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Principal: { Service: ROUTE53_SERVICE_PRINCIPAL },
+        Action: ["logs:CreateLogStream", "logs:PutLogEvents"],
+        Resource: `arn:${stack.partition}:logs:${stack.region}:${stack.account}:log-group:${ROUTE53_LOG_GROUP_PREFIX}/*:*`,
+      },
+    ],
+  };
+
+  return new CfnResourcePolicy(stack, SINGLETON_ID, {
+    policyName: `${stack.stackName}-Route53QueryLogging`,
+    policyDocument: JSON.stringify(policyDocument),
+  });
+}

--- a/packages/constructs/src/helpers/index.ts
+++ b/packages/constructs/src/helpers/index.ts
@@ -13,6 +13,7 @@ export {
   resolveCertificate,
   ResolveCertificateOptions,
 } from "./resolveCertificate";
+export { ensureRoute53QueryLoggingPolicy } from "./ensureRoute53QueryLoggingPolicy";
 export { isEnv, isProductionEnv, isSandboxEnv } from "./isEnv";
 export { isValidHostname } from "./isValidHostname";
 export { isValidSubdomain } from "./isValidSubdomain";

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.39",
+  "version": "0.8.40",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/constructs/1.2.49.md
+++ b/packages/mcp/release-notes/constructs/1.2.49.md
@@ -1,0 +1,23 @@
+---
+version: 1.2.49
+date: 2026-04-18
+summary: Consolidate JaypieHostedZone Route53 query log resource policy into a single stack-level singleton
+---
+
+## Changes
+
+- `JaypieHostedZone` no longer creates a per-zone `AWS::Logs::ResourcePolicy`. A single stack-level `CfnResourcePolicy` with a wildcard resource ARN (`arn:<partition>:logs:<region>:<account>:log-group:/aws/route53/*:*`) now grants Route53 permission to write query logs to every zone in the stack.
+- New `queryLoggingPolicy?: boolean` prop (default `true`). Set to `false` to skip the managed policy when provisioning an account-wide policy externally (useful for accounts with many small stacks each owning a hosted zone).
+- New `ensureRoute53QueryLoggingPolicy(scope)` helper exported from `@jaypie/constructs` for custom constructs that need the same stack-level singleton.
+
+## Motivation
+
+CloudWatch Logs enforces a 10-resource-policy-per-region account quota. The previous per-zone `grantWrite` call produced one policy per zone, so the 11th zone in a region failed to deploy with `ServiceLimitExceeded`.
+
+## Deploy Caveats
+
+- **Under the limit (< 10 zones per stack)**: CloudFormation swaps N per-zone policies for 1 consolidated policy on next deploy. A brief gap in Route53 query-log permissions is possible during the change window.
+- **At or past the 10-per-region limit**: CloudFormation does not guarantee delete-before-create across unrelated logical IDs. Creating the new consolidated policy may fail while the legacy per-zone policies still exist. Before deploying, manually delete one or more legacy `/aws/route53/*` resource policies to create headroom, then deploy.
+- **Many small stacks (1 zone each)**: The stack-level singleton still yields N policies across N stacks. Set `queryLoggingPolicy: false` on every zone and manage one account-wide policy externally.
+
+Closes #311.

--- a/packages/mcp/release-notes/mcp/0.8.40.md
+++ b/packages/mcp/release-notes/mcp/0.8.40.md
@@ -1,0 +1,9 @@
+---
+version: 0.8.40
+date: 2026-04-18
+summary: Include @jaypie/constructs 1.2.49 release notes
+---
+
+## Changes
+
+- Adds release notes for `@jaypie/constructs` 1.2.49 (consolidated Route53 query log resource policy).


### PR DESCRIPTION
## Summary
- Replaces the per-zone `AWS::Logs::ResourcePolicy` generated by `JaypieHostedZone` with a stack-level singleton `CfnResourcePolicy` whose wildcard Resource covers every `/aws/route53/*` log group in the stack's account and region.
- Adds a `queryLoggingPolicy?: boolean` opt-out prop (default `true`) for operators managing an account-wide policy externally.
- Exports a new `ensureRoute53QueryLoggingPolicy(scope)` helper for custom constructs that need the same singleton.

## Why
CloudWatch Logs enforces a 10-resource-policy-per-region account quota. The previous per-zone `grantWrite` call created one policy per zone, so the 11th zone failed to deploy with `ServiceLimitExceeded` (issue #311).

## Deploy Caveats
- **Under limit (< 10 zones per stack)**: CFN swaps N per-zone policies for 1 consolidated on next deploy; brief gap in Route53 query-log permissions during the change window.
- **At or past the 10-per-region limit**: CFN does not guarantee delete-before-create across unrelated logical IDs. Manually delete one or more legacy `/aws/route53/*` resource policies to create headroom before deploying.
- **Many small stacks (1 zone × N stacks)**: stack-level singleton still yields N policies. Set `queryLoggingPolicy: false` everywhere and manage one account-wide policy externally.

## Test plan
- [x] New tests: 3 zones → 1 resource policy; wildcard ARN; `queryLoggingPolicy: false` opt-out; mixed opt-in/opt-out
- [x] Full `@jaypie/constructs` suite: 483/483 pass
- [x] Typecheck + build clean
- [ ] NPM Check CI green on this PR

Closes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)