### PR TITLE
chore: add tmp/ and var/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,26 +6,13 @@ cdk.out
 .open-next
 node_modules
 dist
+tmp
+var
 
 # local env files
-.aider*
 .env
 .env.local
 .env.*.local
-
-# Log files
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
-pnpm-debug.log*
-
-# Editor directories and files
-.idea
-*.suo
-*.ntvs*
-*.njsproj
-*.sln
-*.sw?
 
 **/.claude/settings.local.json
 *.tsbuildinfo


### PR DESCRIPTION
## Summary

- Adds `tmp/` and `var/` to `.gitignore` so scratch/probe work doesn't pollute git state.
- Drops a handful of stale patterns no longer relevant (`.aider*`, log files, JetBrains/Visual Studio/vim editor noise).

## Context

Companion cleanup from investigating #302 — the probe for xAI Files API ran out of `var/xai-files-probe/` and this keeps that kind of throwaway work untracked by default.

## Test plan

- [x] `git status` clean after commit
- [x] No tracked files affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)