### PR TITLE
feat(express): split query from path, add contentType/contentLength to session report

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -146,7 +146,6 @@
     "node_modules/@algolia/client-search": {
       "version": "5.49.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.49.2",
         "@algolia/requester-browser-xhr": "5.49.2",
@@ -281,7 +280,6 @@
         "semver"
       ],
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "jsonschema": "~1.4.1",
         "semver": "^7.7.3"
@@ -530,7 +528,6 @@
     "node_modules/@aws-sdk/client-dynamodb": {
       "version": "3.1014.0",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -1521,7 +1518,6 @@
     "node_modules/@babel/core": {
       "version": "7.29.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -3273,7 +3269,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -3294,7 +3289,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3394,7 +3388,6 @@
     "node_modules/@csstools/postcss-cascade-layers/node_modules/postcss-selector-parser": {
       "version": "7.1.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -3784,7 +3777,6 @@
     "node_modules/@csstools/postcss-is-pseudo-class/node_modules/postcss-selector-parser": {
       "version": "7.1.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -4694,7 +4686,6 @@
     "node_modules/@docusaurus/plugin-content-docs": {
       "version": "3.9.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@docusaurus/core": "3.9.2",
         "@docusaurus/logger": "3.9.2",
@@ -6754,7 +6745,6 @@
     "node_modules/@mdx-js/react": {
       "version": "3.1.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdx": "^2.0.0"
       },
@@ -6918,7 +6908,6 @@
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.27.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -7828,7 +7817,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7842,7 +7830,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7854,7 +7841,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7868,7 +7854,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7882,7 +7867,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7896,7 +7880,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7910,7 +7893,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7924,7 +7906,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7938,7 +7919,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7952,7 +7932,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7966,7 +7945,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7980,7 +7958,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7994,7 +7971,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8008,7 +7984,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8022,7 +7997,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8036,7 +8010,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8050,7 +8023,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8064,7 +8036,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8078,7 +8049,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8092,7 +8062,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8106,7 +8075,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8120,7 +8088,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8134,7 +8101,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8148,7 +8114,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8162,7 +8127,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8201,7 +8165,6 @@
     "node_modules/@rushstack/node-core-library/node_modules/ajv": {
       "version": "8.18.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -9147,7 +9110,6 @@
     "node_modules/@svgr/core": {
       "version": "8.1.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -9581,7 +9543,6 @@
     "node_modules/@types/react": {
       "version": "19.2.14",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -9742,7 +9703,6 @@
       "version": "8.57.1",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.57.1",
@@ -9778,7 +9738,6 @@
       "version": "8.57.1",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.1",
         "@typescript-eslint/types": "8.57.1",
@@ -9946,7 +9905,6 @@
       "version": "8.57.1",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
         "@typescript-eslint/scope-manager": "8.57.1",
@@ -10566,7 +10524,6 @@
     "node_modules/acorn": {
       "version": "8.16.0",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -10630,7 +10587,6 @@
     "node_modules/ajv": {
       "version": "6.14.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -10685,7 +10641,6 @@
     "node_modules/algoliasearch": {
       "version": "5.49.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/abtesting": "1.15.2",
         "@algolia/client-abtesting": "5.49.2",
@@ -11109,7 +11064,6 @@
         "mime-types"
       ],
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "2.2.263",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
@@ -11974,7 +11928,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -12669,8 +12622,7 @@
     },
     "node_modules/constructs": {
       "version": "10.5.1",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -12987,7 +12939,6 @@
     "node_modules/css-has-pseudo/node_modules/postcss-selector-parser": {
       "version": "7.1.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -13898,7 +13849,6 @@
     "node_modules/env-cmd/node_modules/commander": {
       "version": "13.1.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -14179,7 +14129,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.1.tgz",
       "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -14303,7 +14252,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -14489,7 +14437,6 @@
       "version": "0.3.9",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^3.2.7",
         "is-core-module": "^2.13.0",
@@ -14567,7 +14514,6 @@
     "node_modules/eslint-plugin-import-x": {
       "version": "4.16.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@package-json/types": "^0.0.12",
         "@typescript-eslint/types": "^8.56.0",
@@ -15240,7 +15186,6 @@
     "node_modules/express": {
       "version": "4.22.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -16575,7 +16520,6 @@
     "node_modules/hono": {
       "version": "4.12.8",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -17701,7 +17645,6 @@
       "version": "29.7.0",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -21175,7 +21118,6 @@
     "node_modules/next": {
       "version": "16.2.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "16.2.1",
         "@swc/helpers": "0.5.15",
@@ -22170,7 +22112,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -22978,7 +22919,6 @@
     "node_modules/postcss-nesting/node_modules/postcss-selector-parser": {
       "version": "7.1.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -23472,7 +23412,6 @@
     "node_modules/prettier": {
       "version": "3.8.1",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -23799,7 +23738,6 @@
     "node_modules/react": {
       "version": "18.3.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -23810,7 +23748,6 @@
     "node_modules/react-dom": {
       "version": "18.3.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -23857,7 +23794,6 @@
       "name": "@docusaurus/react-loadable",
       "version": "6.0.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/react": "*"
       },
@@ -23882,7 +23818,6 @@
     "node_modules/react-router": {
       "version": "5.3.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -24578,7 +24513,6 @@
       "version": "4.59.0",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -24912,7 +24846,6 @@
     "node_modules/schema-utils/node_modules/ajv": {
       "version": "8.18.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -26373,8 +26306,7 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -26526,7 +26458,6 @@
     "node_modules/typescript": {
       "version": "5.9.3",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -26591,7 +26522,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.2.tgz",
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -27363,7 +27293,6 @@
       "version": "7.3.1",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -27483,7 +27412,6 @@
       "version": "3.2.4",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -27609,7 +27537,6 @@
     "node_modules/webpack": {
       "version": "5.105.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -27813,7 +27740,6 @@
     "node_modules/webpack-dev-server/node_modules/@types/express": {
       "version": "4.17.25",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -28386,7 +28312,6 @@
     "node_modules/zod": {
       "version": "4.3.6",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -28688,7 +28613,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.2.tgz",
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -28913,7 +28837,7 @@
     },
     "packages/express": {
       "name": "@jaypie/express",
-      "version": "1.2.22",
+      "version": "1.2.23",
       "license": "MIT",
       "dependencies": {
         "@jaypie/datadog": "*",
@@ -29290,14 +29214,14 @@
       "license": "MIT"
     },
     "packages/jaypie": {
-      "version": "1.2.40",
+      "version": "1.2.41",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "^1.2.8",
         "@jaypie/core": "^1.2.2",
         "@jaypie/datadog": "^1.2.2",
         "@jaypie/errors": "^1.2.1",
-        "@jaypie/express": "^1.2.22",
+        "@jaypie/express": "^1.2.23",
         "@jaypie/kit": "^1.2.7",
         "@jaypie/lambda": "^1.2.5",
         "@jaypie/logger": "^1.2.15"
@@ -29547,7 +29471,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.40",
+      "version": "0.8.41",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.4",
@@ -29651,7 +29575,6 @@
     "packages/mcp/node_modules/commander": {
       "version": "14.0.3",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -29672,7 +29595,6 @@
       "version": "5.2.1",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -30273,7 +30195,6 @@
     "workspaces/garden-ui/node_modules/react": {
       "version": "19.2.4",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/express",
-  "version": "1.2.22",
+  "version": "1.2.23",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"

--- a/packages/express/src/__tests__/supertest.spec.ts
+++ b/packages/express/src/__tests__/supertest.spec.ts
@@ -313,6 +313,76 @@ describe("Express handler", () => {
         expect(res.body).toEqual({});
       });
 
+      describe("Session report", () => {
+        it("Reports path, empty query, and content metadata for GET with no body", async () => {
+          const mockFunction = vi.fn(() => ({ ok: true }));
+          const handler = expressHandler(mockFunction, { name: "handler" });
+          const app = express();
+          app.use(handler);
+          await request(app).get("/ping");
+          expect(log.report).toHaveBeenCalledWith(
+            expect.objectContaining({
+              method: "GET",
+              path: "/ping",
+              query: "",
+              contentType: "",
+              contentLength: 0,
+              status: "200",
+            }),
+          );
+        });
+
+        it("Separates query from path and normalizes param order", async () => {
+          const mockFunction = vi.fn(() => ({ ok: true }));
+          const handler = expressHandler(mockFunction, { name: "handler" });
+          const app = express();
+          app.use(handler);
+          await request(app).get("/ping?salutation=Hello&name=World");
+          expect(log.report).toHaveBeenCalledWith(
+            expect.objectContaining({
+              path: "/ping",
+              query: "name=World&salutation=Hello",
+            }),
+          );
+        });
+
+        it("Normalizes query regardless of input param order", async () => {
+          const mockFunction = vi.fn(() => ({ ok: true }));
+          const handler = expressHandler(mockFunction, { name: "handler" });
+          const app = express();
+          app.use(handler);
+          await request(app).get("/ping?name=World&salutation=Hello");
+          expect(log.report).toHaveBeenCalledWith(
+            expect.objectContaining({
+              query: "name=World&salutation=Hello",
+            }),
+          );
+        });
+
+        it("Reports contentType and contentLength for POST body", async () => {
+          const mockFunction = vi.fn(() => ({ ok: true }));
+          const handler = expressHandler(mockFunction, { name: "handler" });
+          const app = express();
+          app.use(express.json());
+          app.use(handler);
+          const body = { hello: "world" };
+          const bodyString = JSON.stringify(body);
+          await request(app)
+            .post("/ping")
+            .set("Content-Type", "application/json")
+            .send(body);
+          expect(log.report).toHaveBeenCalledWith(
+            expect.objectContaining({
+              method: "POST",
+              path: "/ping",
+              query: "",
+              contentType: expect.stringContaining("application/json"),
+              contentLength: bodyString.length,
+            }),
+          );
+        });
+      });
+
       it("OPTIONS request (CORS preflight)", async () => {
         const mockFunction = vi.fn(() => ({ ok: true }));
         const handler = expressHandler(mockFunction, { name: "handler" });

--- a/packages/express/src/expressHandler.ts
+++ b/packages/express/src/expressHandler.ts
@@ -655,10 +655,14 @@ function expressHandler<T>(
     });
 
     // Construct normalized path for reporting and metrics
-    let path = (req.baseUrl || "") + (req.url || "");
-    if (!path.startsWith("/")) {
-      path = "/" + path;
+    let pathWithQuery = (req.baseUrl || "") + (req.url || "");
+    if (!pathWithQuery.startsWith("/")) {
+      pathWithQuery = "/" + pathWithQuery;
     }
+    const queryIndex = pathWithQuery.indexOf("?");
+    let path =
+      queryIndex >= 0 ? pathWithQuery.slice(0, queryIndex) : pathWithQuery;
+    const rawQuery = queryIndex >= 0 ? pathWithQuery.slice(queryIndex + 1) : "";
     if (path.length > 1 && path.endsWith("/")) {
       path = path.slice(0, -1);
     }
@@ -668,10 +672,27 @@ function expressHandler<T>(
       ":id",
     );
 
+    // Normalize query params (sort alphabetically for stable aggregation)
+    let query = "";
+    if (rawQuery) {
+      const params = new URLSearchParams(rawQuery);
+      params.sort();
+      query = params.toString();
+    }
+
+    // Capture request content metadata
+    const headers = req.headers || {};
+    const contentType = String(headers["content-type"] || "");
+    const contentLengthHeader = headers["content-length"];
+    const contentLength = contentLengthHeader ? Number(contentLengthHeader) : 0;
+
     // Add request data to session report
     logger.report({
       method: req.method,
       path,
+      query,
+      contentType,
+      contentLength,
       status: String(res.statusCode),
     });
 

--- a/packages/jaypie/package.json
+++ b/packages/jaypie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jaypie",
-  "version": "1.2.40",
+  "version": "1.2.41",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"
@@ -36,7 +36,7 @@
     "@jaypie/core": "^1.2.2",
     "@jaypie/datadog": "^1.2.2",
     "@jaypie/errors": "^1.2.1",
-    "@jaypie/express": "^1.2.22",
+    "@jaypie/express": "^1.2.23",
     "@jaypie/kit": "^1.2.7",
     "@jaypie/lambda": "^1.2.5",
     "@jaypie/logger": "^1.2.15"

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.40",
+  "version": "0.8.41",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/express/1.2.23.md
+++ b/packages/mcp/release-notes/express/1.2.23.md
@@ -1,0 +1,10 @@
+---
+version: 1.2.23
+date: 2026-04-18
+summary: Split query from path and add content metadata to express session report
+---
+
+## Changes
+
+- `expressHandler` session report now separates `query` from `path`. Query parameters are sorted alphabetically so `/ping?name=World&salutation=Hello` and `/ping?salutation=Hello&name=World` produce the same report entry.
+- Adds `contentType` and `contentLength` to the `log.report` payload, populated from the request `content-type` and `content-length` headers.

--- a/packages/mcp/release-notes/jaypie/1.2.41.md
+++ b/packages/mcp/release-notes/jaypie/1.2.41.md
@@ -1,0 +1,9 @@
+---
+version: 1.2.41
+date: 2026-04-18
+summary: Pull in @jaypie/express 1.2.23 with enhanced session report
+---
+
+## Changes
+
+- Bumps `@jaypie/express` to `^1.2.23` which splits `query` from `path` and adds `contentType` / `contentLength` to the session report.

--- a/packages/mcp/release-notes/mcp/0.8.41.md
+++ b/packages/mcp/release-notes/mcp/0.8.41.md
@@ -1,0 +1,10 @@
+---
+version: 0.8.41
+date: 2026-04-18
+summary: Add release notes for express 1.2.23 and jaypie 1.2.41
+---
+
+## Changes
+
+- Adds release notes for `@jaypie/express` 1.2.23 (split query from path, report contentType/contentLength).
+- Adds release notes for `jaypie` 1.2.41.


### PR DESCRIPTION
## Summary
- Split `query` from `path` in the express handler session report and sort query params alphabetically so `/ping?name=World&salutation=Hello` and `/ping?salutation=Hello&name=World` match.
- Add `contentType` and `contentLength` (from request headers) to the `log.report` payload.
- Bump `@jaypie/express` → 1.2.23, `jaypie` → 1.2.41, `@jaypie/mcp` → 0.8.41 with release notes.

## Test plan
- [x] `npm test -w packages/express` (358 tests, 4 new)
- [x] `npm run typecheck -w packages/express`
- [x] `npm run lint -w packages/express` (0 errors)
- [x] `npm run build -w packages/express`
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)