### PR TITLE
fix(constructs): JaypieEnvSecret shorthand validates missing env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,8 +364,10 @@ Manages build-environment secrets, allowing consumer environments (personal envi
 Most Jaypie projects will not need to specify `consumer` or `provider` properties, as the construct will automatically handle the correct behavior based on the environment.
 
 ```typescript
-// Shorthand: if the second parameter is an environment variable key with a non-empty value,
-// it will be used as envKey and the construct id becomes "EnvSecret_${envKey}"
+// Shorthand: when the second parameter is a SCREAMING_SNAKE_CASE string or matches an
+// env var with a non-empty value, it is used as envKey and the construct id becomes
+// "EnvSecret_${envKey}". If the env var is missing and no value/generateSecretString
+// is provided, construction throws ConfigurationError.
 const mongoSecret = new JaypieEnvSecret(this, "MONGODB_URI");
 // Equivalent to: new JaypieEnvSecret(this, "EnvSecret_MONGODB_URI", { envKey: "MONGODB_URI" })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28389,7 +28389,7 @@
     },
     "packages/constructs": {
       "name": "@jaypie/constructs",
-      "version": "1.2.49",
+      "version": "1.2.50",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*",
@@ -29471,7 +29471,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.41",
+      "version": "0.8.42",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.4",

--- a/packages/constructs/package.json
+++ b/packages/constructs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/constructs",
-  "version": "1.2.49",
+  "version": "1.2.50",
   "description": "CDK constructs for Jaypie applications",
   "repository": {
     "type": "git",

--- a/packages/constructs/src/JaypieEnvSecret.ts
+++ b/packages/constructs/src/JaypieEnvSecret.ts
@@ -81,13 +81,17 @@ export class JaypieEnvSecret extends Construct implements ISecret {
     idOrEnvKey: string,
     props?: JaypieEnvSecretProps,
   ) {
-    // Check if idOrEnvKey should be treated as envKey:
-    // - No props provided OR props.envKey is not set
-    // - AND idOrEnvKey exists as a non-empty string in process.env
+    // Shorthand detection: treat idOrEnvKey as envKey when envKey prop is
+    // not set and idOrEnvKey either looks like a SCREAMING_SNAKE_CASE env
+    // var name or is already present in process.env. Convention-based
+    // detection ensures missing env vars still go through envKey validation
+    // instead of silently creating an empty secret.
+    const looksLikeEnvKey = /^[A-Z][A-Z0-9_]*$/.test(idOrEnvKey);
     const treatAsEnvKey =
       (!props || props.envKey === undefined) &&
-      typeof process.env[idOrEnvKey] === "string" &&
-      process.env[idOrEnvKey] !== "";
+      (looksLikeEnvKey ||
+        (typeof process.env[idOrEnvKey] === "string" &&
+          process.env[idOrEnvKey] !== ""));
 
     const id = treatAsEnvKey ? `EnvSecret_${idOrEnvKey}` : idOrEnvKey;
 

--- a/packages/constructs/src/__tests__/JaypieEnvSecret.spec.ts
+++ b/packages/constructs/src/__tests__/JaypieEnvSecret.spec.ts
@@ -214,5 +214,23 @@ describe("JaypieSecret", () => {
         new JaypieEnvSecret(stack, "TestSecret");
       }).not.toThrow();
     });
+
+    it("throws ConfigurationError when shorthand env key is missing from process.env", () => {
+      delete process.env.MISSING_SHORTHAND_SECRET;
+      const stack = new Stack();
+      expect(() => {
+        new JaypieEnvSecret(stack, "MISSING_SHORTHAND_SECRET");
+      }).toThrow(ConfigurationError);
+    });
+
+    it("does not throw when shorthand env key is missing but value is provided", () => {
+      delete process.env.MISSING_SHORTHAND_SECRET;
+      const stack = new Stack();
+      expect(() => {
+        new JaypieEnvSecret(stack, "MISSING_SHORTHAND_SECRET", {
+          value: "fallback",
+        });
+      }).not.toThrow();
+    });
   });
 });

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.41",
+  "version": "0.8.42",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/constructs/1.2.50.md
+++ b/packages/mcp/release-notes/constructs/1.2.50.md
@@ -1,0 +1,21 @@
+---
+version: 1.2.50
+date: 2026-04-18
+summary: JaypieEnvSecret shorthand now validates missing env vars instead of silently creating empty secrets
+---
+
+## Changes
+
+- `JaypieEnvSecret` detects shorthand by convention: a SCREAMING_SNAKE_CASE string (e.g., `MONGODB_URI`, `ANTHROPIC_API_KEY`) as the second constructor argument is treated as an `envKey`, even when the env var is not set at deploy time.
+- When shorthand is used without a backing env var, `value`, or `generateSecretString`, construction throws `ConfigurationError` instead of silently producing an empty secret.
+- Non-shorthand PascalCase ids (e.g., `TestSecret`, `ProjectSalt`) continue to behave as before.
+
+## Motivation
+
+The prior shorthand detection required `process.env[name]` to be a non-empty string. A missing env var fell through to the plain-id branch and produced a secret with no value, which surfaced only at runtime via `loadEnvSecrets`. The new convention-based detection keeps shorthand calls on the envKey validation path regardless of env state.
+
+## Migration
+
+- Consumers already setting env vars at deploy time see no change.
+- Stacks relying on the old silent behavior should pass `value` or `generateSecretString`, or set the expected env var.
+- Provider/consumer shorthand pairs now derive the same `EnvSecret_*` construct id on both sides, fixing a latent export-name mismatch when the env var was unset in the consumer environment.

--- a/packages/mcp/release-notes/mcp/0.8.42.md
+++ b/packages/mcp/release-notes/mcp/0.8.42.md
@@ -1,0 +1,10 @@
+---
+version: 0.8.42
+date: 2026-04-18
+summary: Update secrets skill and add release notes for constructs 1.2.50
+---
+
+## Changes
+
+- Updates `skills/secrets.md` to document convention-based shorthand detection and the new missing-env `ConfigurationError`.
+- Adds release notes for `@jaypie/constructs` 1.2.50.

--- a/packages/mcp/skills/secrets.md
+++ b/packages/mcp/skills/secrets.md
@@ -34,9 +34,12 @@ new JaypieLambda(this, "Handler", {
 });
 ```
 
-When the construct ID matches an environment variable name, `JaypieEnvSecret` automatically:
-- Uses that env var's value as the secret content
-- Sets `envKey` to the ID for later reference
+When the construct ID is a SCREAMING_SNAKE_CASE string (or matches an environment variable name with a non-empty value), `JaypieEnvSecret` automatically:
+- Treats the ID as the `envKey`
+- Uses the env var's value as the secret content
+- Namespaces the CDK construct id as `EnvSecret_${envKey}`
+
+If the shorthand env var is missing at deploy time and no `value` or `generateSecretString` is provided, construction throws `ConfigurationError`. Supply a `value` or `generateSecretString` when the env var may be absent.
 
 ### CI/CD Setup
 


### PR DESCRIPTION
## Summary
- `JaypieEnvSecret` detects shorthand by SCREAMING_SNAKE_CASE convention so missing env vars throw `ConfigurationError` instead of silently creating an empty secret.
- Fixes a latent provider/consumer shorthand mismatch: both sides now derive the same `EnvSecret_*` construct id regardless of whether the env var is set on the consumer side.
- Bumps `@jaypie/constructs` to 1.2.50 and `@jaypie/mcp` to 0.8.42 (skill + release notes).

## Test plan
- [x] `npm run test -w packages/constructs` — 485 passed, including two new tests covering missing-shorthand error and value-fallback
- [x] `npm run typecheck -w packages/constructs`
- [x] NPM Check workflow green

🤖 Generated with [Claude Code](https://claude.com/claude-code)