### PR TITLE
feat(constructs): grant ECR push permissions by default in JaypieGitHubDeployRole

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,13 +681,20 @@ const deployRole = new JaypieGitHubDeployRole(this, 'GitHubDeployRole', {
 const deployRole = new JaypieGitHubDeployRole(this, 'GitHubDeployRole', {
   output: 'CustomRoleArnOutput'
 });
+
+// Opt out of default ECR permissions
+const deployRole = new JaypieGitHubDeployRole(this, 'GitHubDeployRole', {
+  ecr: false
+});
 ```
 
 | Property | Type | Required | Description |
 | -------- | ---- | -------- | ----------- |
+| `ecr` | `boolean` | No | Grant ECR auth + push permissions by default (default: true) |
 | `oidcProviderArn` | `string` | No | OIDC provider ARN; defaults to CDK.IMPORT.OIDC_PROVIDER import |
 | `output` | `boolean \| string` | No | Output role ARN: true (default name), string (custom name), false (no output) |
 | `repoRestriction` | `string` | No | Repository restriction pattern; defaults to organization-wide from CDK_ENV_REPO or PROJECT_REPO |
+| `sponsor` | `string` | No | Sponsor prefix for ECR repository scope; defaults to PROJECT_SPONSOR or the org parsed from CDK_ENV_REPO/PROJECT_REPO |
 
 The construct automatically grants permissions for:
 - Assuming roles via OIDC
@@ -695,6 +702,7 @@ The construct automatically grants permissions for:
 - CloudFormation stack operations
 - S3 and Route53 read access
 - Passing roles for CDK deployment
+- ECR auth (`ecr:GetAuthorizationToken` on `*`) and push (`BatchCheckLayerAvailability`, `BatchGetImage`, `CompleteLayerUpload`, `CreateRepository`, `DescribeRepositories`, `InitiateLayerUpload`, `PutImage`, `UploadLayerPart`) scoped to `arn:aws:ecr:*:<account>:repository/<sponsor>-*` — set `ecr: false` to opt out
 
 #### `JaypieHostedZone`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28389,7 +28389,7 @@
     },
     "packages/constructs": {
       "name": "@jaypie/constructs",
-      "version": "1.2.50",
+      "version": "1.2.51",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29471,7 +29471,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.42",
+      "version": "0.8.43",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.4",

--- a/packages/constructs/package.json
+++ b/packages/constructs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/constructs",
-  "version": "1.2.50",
+  "version": "1.2.51",
   "description": "CDK constructs for Jaypie applications",
   "repository": {
     "type": "git",

--- a/packages/constructs/src/JaypieGitHubDeployRole.ts
+++ b/packages/constructs/src/JaypieGitHubDeployRole.ts
@@ -11,10 +11,23 @@ import { ConfigurationError } from "@jaypie/errors";
 import { CDK } from "./constants";
 
 export interface JaypieGitHubDeployRoleProps {
+  ecr?: boolean;
   oidcProviderArn?: string;
   output?: boolean | string;
   repoRestriction?: string;
+  sponsor?: string;
 }
+
+const ECR_PUSH_ACTIONS = [
+  "ecr:BatchCheckLayerAvailability",
+  "ecr:BatchGetImage",
+  "ecr:CompleteLayerUpload",
+  "ecr:CreateRepository",
+  "ecr:DescribeRepositories",
+  "ecr:InitiateLayerUpload",
+  "ecr:PutImage",
+  "ecr:UploadLayerPart",
+];
 
 export class JaypieGitHubDeployRole extends Construct {
   private readonly _role: Role;
@@ -27,27 +40,32 @@ export class JaypieGitHubDeployRole extends Construct {
     super(scope, id);
 
     const {
+      ecr = true,
       oidcProviderArn = Fn.importValue(CDK.IMPORT.OIDC_PROVIDER),
       output = true,
       repoRestriction: propsRepoRestriction,
+      sponsor: propsSponsor,
     } = props;
 
     // Extract account ID from the scope
     const accountId = Stack.of(this).account;
 
-    // Resolve repoRestriction from props or environment variables
+    // Resolve repoRestriction and sponsor from props or environment variables
+    const envRepo = process.env.CDK_ENV_REPO || process.env.PROJECT_REPO;
+    const envRepoOrganization = envRepo ? envRepo.split("/")[0] : undefined;
+
     let repoRestriction = propsRepoRestriction;
     if (!repoRestriction) {
-      const envRepo = process.env.CDK_ENV_REPO || process.env.PROJECT_REPO;
-      if (!envRepo) {
+      if (!envRepoOrganization) {
         throw new ConfigurationError(
           "No repoRestriction provided. Set repoRestriction prop, CDK_ENV_REPO, or PROJECT_REPO environment variable",
         );
       }
-      // Extract organization from owner/repo format and create org-wide restriction
-      const organization = envRepo.split("/")[0];
-      repoRestriction = `repo:${organization}/*:*`;
+      repoRestriction = `repo:${envRepoOrganization}/*:*`;
     }
+
+    const sponsor =
+      propsSponsor || process.env.PROJECT_SPONSOR || envRepoOrganization;
 
     // Create the IAM role
     this._role = new Role(this, "GitHubActionsRole", {
@@ -109,6 +127,29 @@ export class JaypieGitHubDeployRole extends Construct {
         ],
       }),
     );
+
+    // Grant ECR auth + push scoped to <sponsor>-* repositories
+    if (ecr) {
+      if (!sponsor) {
+        throw new ConfigurationError(
+          "Cannot grant default ECR permissions without a sponsor. Set sponsor prop, PROJECT_SPONSOR, CDK_ENV_REPO, or PROJECT_REPO, or pass `ecr: false`",
+        );
+      }
+      this._role.addToPolicy(
+        new PolicyStatement({
+          actions: ["ecr:GetAuthorizationToken"],
+          effect: Effect.ALLOW,
+          resources: ["*"],
+        }),
+      );
+      this._role.addToPolicy(
+        new PolicyStatement({
+          actions: ECR_PUSH_ACTIONS,
+          effect: Effect.ALLOW,
+          resources: [`arn:aws:ecr:*:${accountId}:repository/${sponsor}-*`],
+        }),
+      );
+    }
 
     // Export the ARN of the role
     if (output !== false) {

--- a/packages/constructs/src/__tests__/JaypieGitHubDeployRole.spec.ts
+++ b/packages/constructs/src/__tests__/JaypieGitHubDeployRole.spec.ts
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Stack } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { JaypieGitHubDeployRole } from "../JaypieGitHubDeployRole";
+
+const OIDC_ARN =
+  "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com";
+
+describe("JaypieGitHubDeployRole", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.CDK_ENV_REPO;
+    delete process.env.PROJECT_REPO;
+    delete process.env.PROJECT_SPONSOR;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  describe("Base Cases", () => {
+    it("is a function", () => {
+      expect(JaypieGitHubDeployRole).toBeFunction();
+    });
+
+    it("creates an IAM role", () => {
+      const stack = new Stack();
+      new JaypieGitHubDeployRole(stack, "Role", {
+        oidcProviderArn: OIDC_ARN,
+        repoRestriction: "repo:example-org/*:*",
+        sponsor: "example-org",
+      });
+      const template = Template.fromStack(stack);
+      template.resourceCountIs("AWS::IAM::Role", 1);
+    });
+  });
+
+  describe("ECR default permissions", () => {
+    it("grants ecr:GetAuthorizationToken on * with sponsor from PROJECT_SPONSOR", () => {
+      process.env.PROJECT_SPONSOR = "acme";
+      const stack = new Stack();
+      new JaypieGitHubDeployRole(stack, "Role", {
+        oidcProviderArn: OIDC_ARN,
+        repoRestriction: "repo:acme/*:*",
+      });
+      const template = Template.fromStack(stack);
+
+      template.hasResourceProperties("AWS::IAM::Policy", {
+        PolicyDocument: {
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Action: "ecr:GetAuthorizationToken",
+              Effect: "Allow",
+              Resource: "*",
+            }),
+          ]),
+        },
+      });
+    });
+
+    it("grants ecr push actions scoped to <sponsor>-* repositories", () => {
+      process.env.PROJECT_SPONSOR = "acme";
+      const stack = new Stack();
+      new JaypieGitHubDeployRole(stack, "Role", {
+        oidcProviderArn: OIDC_ARN,
+        repoRestriction: "repo:acme/*:*",
+      });
+      const template = Template.fromStack(stack);
+
+      template.hasResourceProperties("AWS::IAM::Policy", {
+        PolicyDocument: {
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Action: Match.arrayWith([
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:BatchGetImage",
+                "ecr:CompleteLayerUpload",
+                "ecr:CreateRepository",
+                "ecr:DescribeRepositories",
+                "ecr:InitiateLayerUpload",
+                "ecr:PutImage",
+                "ecr:UploadLayerPart",
+              ]),
+              Effect: "Allow",
+              Resource: {
+                "Fn::Join": [
+                  "",
+                  Match.arrayWith([
+                    Match.stringLikeRegexp(
+                      "^arn:aws:ecr:\\*:$|:repository/acme-\\*$",
+                    ),
+                  ]),
+                ],
+              },
+            }),
+          ]),
+        },
+      });
+    });
+
+    it("derives sponsor from CDK_ENV_REPO when PROJECT_SPONSOR is unset", () => {
+      process.env.CDK_ENV_REPO = "widgets-inc/infra";
+      const stack = new Stack();
+      new JaypieGitHubDeployRole(stack, "Role", {
+        oidcProviderArn: OIDC_ARN,
+      });
+      const template = Template.fromStack(stack);
+
+      // Resource ARN should include "widgets-inc-*"
+      const policies = template.findResources("AWS::IAM::Policy");
+      const statements = Object.values(policies)
+        .flatMap((p) => p.Properties.PolicyDocument.Statement as any[])
+        .filter((s) =>
+          Array.isArray(s.Action)
+            ? s.Action.includes("ecr:PutImage")
+            : s.Action === "ecr:PutImage",
+        );
+      expect(statements.length).toBeGreaterThan(0);
+      const [joinStr, parts] = statements[0].Resource["Fn::Join"];
+      expect(joinStr).toBe("");
+      expect(parts.join("")).toContain(":repository/widgets-inc-*");
+    });
+
+    it("accepts sponsor prop and overrides env-derived sponsor", () => {
+      process.env.PROJECT_SPONSOR = "fromenv";
+      const stack = new Stack();
+      new JaypieGitHubDeployRole(stack, "Role", {
+        oidcProviderArn: OIDC_ARN,
+        repoRestriction: "repo:fromprops/*:*",
+        sponsor: "fromprops",
+      });
+      const template = Template.fromStack(stack);
+      const policies = template.findResources("AWS::IAM::Policy");
+      const statements = Object.values(policies)
+        .flatMap((p) => p.Properties.PolicyDocument.Statement as any[])
+        .filter((s) =>
+          Array.isArray(s.Action)
+            ? s.Action.includes("ecr:PutImage")
+            : s.Action === "ecr:PutImage",
+        );
+      expect(statements.length).toBeGreaterThan(0);
+      const [, parts] = statements[0].Resource["Fn::Join"];
+      expect(parts.join("")).toContain(":repository/fromprops-*");
+      expect(parts.join("")).not.toContain("fromenv");
+    });
+
+    it("omits ECR statements when ecr is disabled", () => {
+      process.env.PROJECT_SPONSOR = "acme";
+      const stack = new Stack();
+      new JaypieGitHubDeployRole(stack, "Role", {
+        oidcProviderArn: OIDC_ARN,
+        repoRestriction: "repo:acme/*:*",
+        ecr: false,
+      });
+      const template = Template.fromStack(stack);
+      const policies = template.findResources("AWS::IAM::Policy");
+      const statements = Object.values(policies).flatMap(
+        (p) => p.Properties.PolicyDocument.Statement as any[],
+      );
+      const ecrStatements = statements.filter((s) =>
+        Array.isArray(s.Action)
+          ? s.Action.some((a: string) => a.startsWith("ecr:"))
+          : typeof s.Action === "string" && s.Action.startsWith("ecr:"),
+      );
+      expect(ecrStatements).toHaveLength(0);
+    });
+  });
+});

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.42",
+  "version": "0.8.43",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/constructs/1.2.51.md
+++ b/packages/mcp/release-notes/constructs/1.2.51.md
@@ -1,0 +1,22 @@
+---
+version: 1.2.51
+date: 2026-04-19
+summary: JaypieGitHubDeployRole grants ECR auth and push by default, scoped to <sponsor>-* repositories
+---
+
+## Changes
+
+- `JaypieGitHubDeployRole` grants `ecr:GetAuthorizationToken` on `*` and push actions (`ecr:BatchCheckLayerAvailability`, `ecr:BatchGetImage`, `ecr:CompleteLayerUpload`, `ecr:CreateRepository`, `ecr:DescribeRepositories`, `ecr:InitiateLayerUpload`, `ecr:PutImage`, `ecr:UploadLayerPart`) scoped to `arn:aws:ecr:*:<account>:repository/<sponsor>-*` by default.
+- Sponsor is resolved from `sponsor` prop, `PROJECT_SPONSOR`, or the organization parsed from `CDK_ENV_REPO` / `PROJECT_REPO` (same parse that produces the `repoRestriction`), keeping ECR scope aligned with the OIDC `sub` condition.
+- New `sponsor` and `ecr` props on `JaypieGitHubDeployRoleProps`. Set `ecr: false` to opt out.
+
+## Motivation
+
+Any project shipping a Docker artifact (ECS/Fargate, Lambda containers) needs ECR auth + push on the GitHub Actions deploy role. Previously every consumer had to extend the role downstream. Since `JaypieGitHubDeployRole` already constrains the OIDC `sub` to the organization's repos, granting ECR by default removes boilerplate without expanding the threat surface.
+
+## Migration
+
+- Consumers deploying from a sponsor-scoped monorepo (`<sponsor>-*`) see no change beyond new default permissions.
+- Consumers who previously extended the role for ECR can remove the inline statements.
+- To keep prior behavior with no ECR permissions, pass `ecr: false`.
+- If no sponsor can be resolved (no `sponsor` prop, `PROJECT_SPONSOR`, `CDK_ENV_REPO`, or `PROJECT_REPO`), construction throws `ConfigurationError`; set `ecr: false` to skip the check.

--- a/packages/mcp/release-notes/mcp/0.8.43.md
+++ b/packages/mcp/release-notes/mcp/0.8.43.md
@@ -1,0 +1,9 @@
+---
+version: 0.8.43
+date: 2026-04-19
+summary: Release notes for @jaypie/constructs 1.2.51 (ECR defaults on JaypieGitHubDeployRole)
+---
+
+## Changes
+
+- Adds release notes for `@jaypie/constructs` 1.2.51, which grants ECR auth + push permissions by default on `JaypieGitHubDeployRole`, scoped to `<sponsor>-*` repositories.


### PR DESCRIPTION
## Summary

- `JaypieGitHubDeployRole` grants `ecr:GetAuthorizationToken` (on `*`) plus the ECR push action set (`BatchCheckLayerAvailability`, `BatchGetImage`, `CompleteLayerUpload`, `CreateRepository`, `DescribeRepositories`, `InitiateLayerUpload`, `PutImage`, `UploadLayerPart`) scoped to `arn:aws:ecr:*:<account>:repository/<sponsor>-*` by default.
- Sponsor resolution: `sponsor` prop → `PROJECT_SPONSOR` → org parsed from `CDK_ENV_REPO` / `PROJECT_REPO` (same parse that drives `repoRestriction`). Pass `ecr: false` to opt out.
- Closes #318.

## Test plan

- [x] `npm run test -w packages/constructs` — 492/492 pass (7 new)
- [x] `npm run typecheck -w packages/constructs`
- [x] `npm run build -w packages/constructs`
- [x] `npm run test -w packages/mcp` — 41/41 pass
- [x] NPM Check CI passes on `feat/issue-318`

🤖 Generated with [Claude Code](https://claude.com/claude-code)