### PR TITLE
docs(cicd): pin action versions to Node 24-native majors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29471,7 +29471,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.43",
+      "version": "0.8.44",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.4",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.43",
+  "version": "0.8.44",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/mcp/0.8.44.md
+++ b/packages/mcp/release-notes/mcp/0.8.44.md
@@ -1,0 +1,11 @@
+---
+version: 0.8.44
+date: 2026-04-19
+summary: Pin cicd skill GitHub Actions to Node 24-native majors
+---
+
+## Changes
+
+- Documents the Node 24-native action majors (`actions/checkout@v6`, `actions/setup-node@v6`, `actions/cache@v5`, `actions/upload-artifact@v7`, `actions/download-artifact@v8`, `aws-actions/configure-aws-credentials@v6`) at the top of `skills/cicd.md`.
+- Updates example workflows in `skills/cicd.md`, `skills/cicd-actions.md`, and `skills/cicd-deploy.md` so scaffolds land on Node 24-native actions on the first pass, avoiding the Node 20 deprecation warning and `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` opt-in.
+- Updates `workspaces/documentation/docs/guides/cicd.md` to match.

--- a/packages/mcp/skills/cicd-actions.md
+++ b/packages/mcp/skills/cicd-actions.md
@@ -176,13 +176,13 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
         cache: 'npm'
 
     - name: Cache node_modules
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           node_modules
@@ -194,7 +194,7 @@ runs:
 
     - name: Cache build outputs
       if: inputs.cache-builds == 'true'
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           packages/*/dist
@@ -282,7 +282,7 @@ runs:
           ${{ inputs.extra-args }}
 
     - name: Upload CDK outputs
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: cdk-outputs
         path: ${{ inputs.working-directory }}/cdk-outputs.json
@@ -302,7 +302,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup-environment
         with:

--- a/packages/mcp/skills/cicd-deploy.md
+++ b/packages/mcp/skills/cicd-deploy.md
@@ -30,7 +30,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-node-and-cache
       - uses: ./.github/actions/npm-install-build
         with:
@@ -40,7 +40,7 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-node-and-cache
       - uses: ./.github/actions/npm-install-build
         with:
@@ -53,7 +53,7 @@ jobs:
       matrix:
         node-version: [22, 24, 25]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-node-and-cache
         with:
           node-version: ${{ matrix.node-version }}
@@ -68,7 +68,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup-environment
         with:
@@ -112,7 +112,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-node-and-cache
       - uses: ./.github/actions/npm-install-build
         with:
@@ -122,7 +122,7 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-node-and-cache
       - uses: ./.github/actions/npm-install-build
         with:
@@ -135,7 +135,7 @@ jobs:
       matrix:
         node-version: [22, 24, 25]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-node-and-cache
         with:
           node-version: ${{ matrix.node-version }}
@@ -150,7 +150,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup-environment
         with:
@@ -200,7 +200,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/packages/mcp/skills/cicd.md
+++ b/packages/mcp/skills/cicd.md
@@ -15,6 +15,21 @@ Jaypie projects use GitHub Actions for continuous integration and deployment.
 | `cicd-deploy` | CDK deployment workflows (sandbox, production) |
 | `cicd-environments` | GitHub Environments configuration |
 
+## Action Versions
+
+GitHub Actions deprecated Node 20 runners on 2025-09-19. Pin third-party actions to majors that natively run on Node 24 to avoid deprecation warnings and the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` opt-in.
+
+| Action | Tag |
+|---|---|
+| `actions/checkout` | `v6` |
+| `actions/setup-node` | `v6` |
+| `actions/cache` | `v5` |
+| `actions/upload-artifact` | `v7` |
+| `actions/download-artifact` | `v8` |
+| `aws-actions/configure-aws-credentials` | `v6` |
+
+Refresh this list against the [Node 20 deprecation changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) when bumping action versions.
+
 ## Standard Workflows
 
 ### npm-check.yml
@@ -34,8 +49,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
       - run: npm ci
@@ -44,8 +59,8 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
       - run: npm ci
@@ -57,8 +72,8 @@ jobs:
       matrix:
         node-version: [22, 24, 25]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
@@ -87,8 +102,8 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'

--- a/workspaces/documentation/docs/guides/cicd.md
+++ b/workspaces/documentation/docs/guides/cicd.md
@@ -96,8 +96,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -107,8 +107,8 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -121,8 +121,8 @@ jobs:
       matrix:
         node-version: ['22', '24', '25']
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -162,7 +162,7 @@ jobs:
   lint-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-node-and-cache
       - uses: ./.github/actions/npm-install-build
       - run: npm run lint
@@ -172,7 +172,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: sandbox
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup-environment
         with:
@@ -217,7 +217,7 @@ jobs:
   lint-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-node-and-cache
       - uses: ./.github/actions/npm-install-build
       - run: npm run lint
@@ -228,7 +228,7 @@ jobs:
     needs: lint-and-test
     environment: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup-environment
         with:


### PR DESCRIPTION
## Summary

- Adds a Node 24-native action version table (plus link to the [Node 20 deprecation changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)) to `packages/mcp/skills/cicd.md`.
- Updates example workflows across `skills/cicd.md`, `skills/cicd-actions.md`, `skills/cicd-deploy.md`, and `workspaces/documentation/docs/guides/cicd.md` to `checkout@v6`, `setup-node@v6`, `cache@v5`, `upload-artifact@v7` so scaffolds skip the Node 20 deprecation warning and `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` opt-in.
- Bumps `@jaypie/mcp` to 0.8.44 with a release note.
- Closes #315.

## Test plan

- [x] `npm run test -w packages/mcp` — 41/41 pass
- [x] `npm run typecheck -w packages/mcp`
- [x] `npm run build -w packages/mcp`
- [ ] NPM Check CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)