### PR TITLE
docs(mcp): add repokit skill (#322)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29471,7 +29471,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.45",
+      "version": "0.8.46",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.4",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.45",
+  "version": "0.8.46",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/mcp/0.8.46.md
+++ b/packages/mcp/release-notes/mcp/0.8.46.md
@@ -1,0 +1,11 @@
+---
+version: 0.8.46
+date: 2026-04-19
+summary: Add repokit skill documenting the @jaypie/repokit tooling bundle
+---
+
+## Changes
+
+- Added `skill("repokit")` covering what ships in `@jaypie/repokit` (`dotenv`, `env-cmd`, `rimraf`, `sort-package-json`, `tsx`), when to reach for it, and usage patterns — including the `env-cmd -f .env -- <cmd>` `--` separator gotcha
+- Registered `repokit` under the development category in `skill("skills")` and `skill("agents")`
+- Cross-linked from `skill("monorepo")` (added to related, recommended as root devDependency) and `skill("variables")` (added "Loading from `.env` Files" section)

--- a/packages/mcp/skills/agents.md
+++ b/packages/mcp/skills/agents.md
@@ -33,7 +33,7 @@ Complete stack styles, techniques, and traditions.
 `mcp__jaypie__skill(alias: String)`
 
 Contents: index, releasenotes
-Development: apikey, documentation, errors, llm, logs, mocks, monorepo, style, subpackages, tests, tools
+Development: apikey, documentation, errors, llm, logs, mocks, monorepo, repokit, style, subpackages, tests, tools
 Infrastructure: apigateway, aws, cdk, cicd, datadog, dns, dynamodb, express, lambda, migrations, secrets, sqs, streaming, variables, websockets
 Patterns: api, fabric, handlers, models, services, vocabulary
 Recipes: recipe-api-server

--- a/packages/mcp/skills/monorepo.md
+++ b/packages/mcp/skills/monorepo.md
@@ -1,6 +1,6 @@
 ---
 description: Initialize a Jaypie monorepo project
-related: subpackage, cicd, style, tests
+related: subpackage, cicd, repokit, style, tests
 ---
 
 # Jaypie Monorepo Setup
@@ -130,8 +130,10 @@ npm-debug.log*
 Install root dev dependencies:
 
 ```bash
-npm install --save-dev @jaypie/eslint @jaypie/testkit eslint rimraf sort-package-json tsx vite vite-plugin-dts vitest
+npm install --save-dev @jaypie/eslint @jaypie/repokit @jaypie/testkit eslint vite vite-plugin-dts vitest
 ```
+
+`@jaypie/repokit` bundles `dotenv`, `env-cmd`, `rimraf`, `sort-package-json`, and `tsx` at consistent versions. See `skill("repokit")`.
 
 ## Workspace Conventions
 

--- a/packages/mcp/skills/repokit.md
+++ b/packages/mcp/skills/repokit.md
@@ -1,0 +1,97 @@
+---
+description: Bundled development tooling for Jaypie repositories (dotenv, env-cmd, rimraf, sort-package-json, tsx)
+related: monorepo, subpackages, variables
+---
+
+# Repokit
+
+`@jaypie/repokit` is a convenience bundle that consolidates common development tooling used across Jaypie repositories into a single devDependency. Install once and get `dotenv`, `env-cmd`, `rimraf`, `sort-package-json`, and `tsx` at consistent versions.
+
+## What Ships
+
+| Tool | Purpose |
+|------|---------|
+| `dotenv` | Load environment variables from `.env` files (re-exported for programmatic use) |
+| `env-cmd` | Run commands with env file loaded (CLI; use in npm scripts) |
+| `rimraf` | Cross-platform `rm -rf` (re-exported and available as CLI) |
+| `sort-package-json` | Enforce consistent `package.json` key ordering (CLI) |
+| `tsx` | Run TypeScript files directly without precompilation (CLI) |
+
+## When to Reach for It
+
+- **Monorepo root devDependency** — single install so every package has access to the same tooling versions
+- **Subpackages** — add as a devDependency where build/clean/script tooling is needed
+- **Avoid** listing each of the five underlying packages individually — let `@jaypie/repokit` pin them
+
+## Install
+
+```bash
+npm install --save-dev @jaypie/repokit
+# Or in a monorepo root:
+npm install --save-dev @jaypie/repokit -w .
+```
+
+## Programmatic Exports
+
+```typescript
+import { config, rimraf } from "@jaypie/repokit";
+
+config();                 // dotenv — loads process.env from .env
+await rimraf("./dist");   // cross-platform directory removal
+```
+
+Re-exports:
+
+- Everything from `dotenv` (`config`, `parse`, `populate`, etc.)
+- `rimraf` from `rimraf`
+
+## CLI Usage in `package.json` Scripts
+
+```json
+{
+  "scripts": {
+    "clean": "rimraf ./dist",
+    "clean:all": "rimraf ./packages/*/dist",
+    "format:package": "sort-package-json ./package.json ./packages/*/package.json",
+    "script:setup": "tsx scripts/setup.ts",
+    "start:dev": "env-cmd -f .env.development -- node server.js"
+  }
+}
+```
+
+### `env-cmd` — the `--` separator is required
+
+`env-cmd -f <file> -- <command>` passes the env file to the process and runs the command with those variables loaded. **Omit the `--` and env-cmd treats the file as an rc/JSON config instead of a dotenv file, which silently does the wrong thing.**
+
+```bash
+# Correct — `.env.dev` is read as a dotenv file
+env-cmd -f .env.dev -- node server.js
+
+# Wrong — `.env.dev` is parsed as JSON/rc config; server.js still runs but without env vars
+env-cmd -f .env.dev node server.js
+```
+
+Use this pattern to load repo-level `.env` files into scripts without hard-coding variables in `package.json`.
+
+### `tsx` — for TypeScript scripts
+
+```bash
+tsx scripts/seed.ts
+env-cmd -f .env.local -- tsx scripts/seed.ts   # combine with env-cmd
+```
+
+### `sort-package-json` — for consistency
+
+Add a `format:package` script and run it before committing, or enforce it in a pre-commit hook.
+
+## Why Not the Five Packages Directly?
+
+- **One devDependency vs five** — fewer entries in `package.json` and `package-lock.json`
+- **Pinned versions** — every Jaypie repo using repokit gets the same `dotenv`/`rimraf`/etc. version
+- **Easier upgrades** — bump repokit once, all tooling updates together
+
+## See Also
+
+- `skill("monorepo")` — repokit is a recommended devDependency for the monorepo root
+- `skill("subpackages")` — use repokit as a devDependency in any package that needs build/clean/script tooling
+- `skill("variables")` — pair `env-cmd` with `.env` files to load project environment variables

--- a/packages/mcp/skills/skills.md
+++ b/packages/mcp/skills/skills.md
@@ -16,7 +16,7 @@ Look up skills by alias: `mcp__jaypie__skill(alias)`
 | Category | Skills |
 |----------|--------|
 | contents | index, releasenotes |
-| development | apikey, documentation, errors, llm, logs, mocks, monorepo, style, subpackages, tests, tools |
+| development | apikey, documentation, errors, llm, logs, mocks, monorepo, repokit, style, subpackages, tests, tools |
 | infrastructure | apigateway, aws, cdk, cicd, datadog, dns, dynamodb, express, lambda, migrations, secrets, sqs, streaming, variables, websockets |
 | patterns | api, fabric, handlers, models, services, vocabulary |
 | recipes | recipe-api-server |

--- a/packages/mcp/skills/variables.md
+++ b/packages/mcp/skills/variables.md
@@ -1,6 +1,6 @@
 ---
 description: Environment variables reference
-related: apikey, cdk, datadog, secrets
+related: apikey, cdk, datadog, repokit, secrets
 ---
 
 # Environment Variables
@@ -48,6 +48,21 @@ LOG_LEVEL=trace npm run dev
 # Normal debugging
 LOG_LEVEL=debug npm run dev
 ```
+
+### Loading from `.env` Files
+
+Use `env-cmd` (bundled with `@jaypie/repokit`) to load a dotenv file into a script. The `--` separator is required — without it, `env-cmd` treats the file as rc/JSON config and silently does the wrong thing:
+
+```json
+{
+  "scripts": {
+    "start:dev": "env-cmd -f .env.development -- node server.js",
+    "script:seed": "env-cmd -f .env.local -- tsx scripts/seed.ts"
+  }
+}
+```
+
+See `skill("repokit")` for the full tooling bundle.
 
 ## CDK Infrastructure Variables
 


### PR DESCRIPTION
## Summary

- Add `skill("repokit")` covering `@jaypie/repokit` — what ships (`dotenv`, `env-cmd`, `rimraf`, `sort-package-json`, `tsx`), when to reach for it, usage patterns, and the `env-cmd -f .env -- <cmd>` `--` separator gotcha
- Register `repokit` under the development category in `skills.md` and `agents.md`
- Cross-link from `skill("monorepo")` (added to `related:` frontmatter; installation snippet now recommends `@jaypie/repokit` as the root devDependency) and `skill("variables")` (added a "Loading from `.env` Files" section)

### Versions

- `@jaypie/mcp` 0.8.45 → 0.8.46

Closes #322

## Test plan

- [x] `npm run build -w packages/mcp`
- [x] `npm run test -w packages/mcp`
- [x] `npm run typecheck -w packages/mcp`
- [x] `npm run lint -w packages/mcp` (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)