### PR TITLE
docs(mcp): add web skill for static site hosting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29471,7 +29471,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.46",
+      "version": "0.8.47",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.4",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.46",
+  "version": "0.8.47",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/mcp/0.8.47.md
+++ b/packages/mcp/release-notes/mcp/0.8.47.md
@@ -1,0 +1,12 @@
+---
+version: 0.8.47
+date: 2026-04-22
+summary: Add web skill covering JaypieWebDeploymentBucket, JaypieStaticWebBucket, and related CloudFront/S3 web hosting patterns
+---
+
+## Changes
+
+- Added `skill("web")` covering static site hosting with `@jaypie/constructs`: `JaypieWebDeploymentBucket`, `JaypieStaticWebBucket`, and pointers to `JaypieDistribution` for dynamic origins
+- Documented the OIDC deploy role flow, CfnOutputs consumed by CI/CD (`DestinationBucketName`, `DestinationBucketDeployRoleArn`, `DistributionId`, `CertificateArn`), and production caching behavior
+- Registered `web` under the infrastructure category in `skill("skills")`, `skill("agents")`, and `skill("infrastructure")`
+- Cross-linked from `skill("cdk")` (added to See Also) and `skill("dns")` (added to related + See Also)

--- a/packages/mcp/skills/agents.md
+++ b/packages/mcp/skills/agents.md
@@ -34,7 +34,7 @@ Complete stack styles, techniques, and traditions.
 
 Contents: index, releasenotes
 Development: apikey, documentation, errors, llm, logs, mocks, monorepo, repokit, style, subpackages, tests, tools
-Infrastructure: apigateway, aws, cdk, cicd, datadog, dns, dynamodb, express, lambda, migrations, secrets, sqs, streaming, variables, websockets
+Infrastructure: apigateway, aws, cdk, cicd, datadog, dns, dynamodb, express, lambda, migrations, secrets, sqs, streaming, variables, web, websockets
 Patterns: api, fabric, handlers, models, services, vocabulary
 Recipes: recipe-api-server
 Meta: issues, jaypie, mcp, skills

--- a/packages/mcp/skills/cdk.md
+++ b/packages/mcp/skills/cdk.md
@@ -1,6 +1,6 @@
 ---
 description: CDK constructs and deployment patterns
-related: apikey, aws, cicd, dynamodb, express, lambda, migrations, secrets, streaming, websockets
+related: apikey, aws, cicd, dynamodb, express, lambda, migrations, secrets, streaming, web, websockets
 ---
 
 # CDK Constructs
@@ -422,4 +422,5 @@ new JaypieOrganizationTrail(this, "OrgTrail", {
 - **`skill("secrets")`** - Secret management with JaypieEnvSecret
 - **`skill("streaming")`** - JaypieDistribution and JaypieNextJs streaming configuration
 - **`skill("variables")`** - Environment variables reference
+- **`skill("web")`** - JaypieWebDeploymentBucket and JaypieStaticWebBucket for static sites
 - **`skill("websockets")`** - JaypieWebSocket and JaypieWebSocketTable constructs

--- a/packages/mcp/skills/dns.md
+++ b/packages/mcp/skills/dns.md
@@ -1,6 +1,6 @@
 ---
 description: DNS and domain configuration
-related: cdk, aws
+related: aws, cdk, web
 ---
 
 # DNS Configuration
@@ -135,4 +135,5 @@ openssl s_client -connect app.example.com:443 -servername app.example.com
 ## See Also
 
 - **`skill("cdk")`** - CDK constructs including JaypieDistribution and JaypieNextJs
+- **`skill("web")`** - Static site hosting with JaypieWebDeploymentBucket and JaypieStaticWebBucket
 

--- a/packages/mcp/skills/infrastructure.md
+++ b/packages/mcp/skills/infrastructure.md
@@ -1,6 +1,6 @@
 ---
 description: AWS, CDK, CI/CD, and observability
-related: aws, cdk, cicd, cicd-actions, cicd-deploy, cicd-environments, datadog, dns, dynamodb, secrets, variables, websockets
+related: aws, cdk, cicd, cicd-actions, cicd-deploy, cicd-environments, datadog, dns, dynamodb, secrets, variables, web, websockets
 ---
 
 # Infrastructure
@@ -23,4 +23,5 @@ Cloud infrastructure and deployment patterns.
 | `migrations` | DynamoDB migration custom resources |
 | `secrets` | AWS Secrets Manager |
 | `variables` | Environment variables reference |
+| `web` | Static site and web content hosting |
 | `websockets` | WebSocket API Gateway constructs |

--- a/packages/mcp/skills/skills.md
+++ b/packages/mcp/skills/skills.md
@@ -17,7 +17,7 @@ Look up skills by alias: `mcp__jaypie__skill(alias)`
 |----------|--------|
 | contents | index, releasenotes |
 | development | apikey, documentation, errors, llm, logs, mocks, monorepo, repokit, style, subpackages, tests, tools |
-| infrastructure | apigateway, aws, cdk, cicd, datadog, dns, dynamodb, express, lambda, migrations, secrets, sqs, streaming, variables, websockets |
+| infrastructure | apigateway, aws, cdk, cicd, datadog, dns, dynamodb, express, lambda, migrations, secrets, sqs, streaming, variables, web, websockets |
 | patterns | api, fabric, handlers, models, services, vocabulary |
 | recipes | recipe-api-server |
 | meta | issues, jaypie, mcp, skills |

--- a/packages/mcp/skills/web.md
+++ b/packages/mcp/skills/web.md
@@ -1,0 +1,205 @@
+---
+description: Static site and web content hosting with CloudFront, S3, and DNS
+related: cdk, cicd-deploy, dns, secrets, streaming
+---
+
+# Web Hosting
+
+Deploying static websites and web content through `@jaypie/constructs`. Pair an S3 origin with a CloudFront distribution, Route53 alias, ACM certificate, and (optionally) an OIDC deploy role for GitHub Actions — all wired up by one construct.
+
+## Constructs
+
+| Construct | Purpose |
+|-----------|---------|
+| `JaypieWebDeploymentBucket` | S3 + CloudFront + Route53 + OIDC deploy role for a static site |
+| `JaypieStaticWebBucket` | Pre-configured `JaypieWebDeploymentBucket` that defaults to the `static` subdomain |
+| `JaypieDistribution` | CloudFront in front of a dynamic handler (Lambda / Function URL / origin) |
+| `JaypieNextJs` | Server-rendered Next.js deployment (see `skill("cdk")`) |
+
+Use `JaypieWebDeploymentBucket` / `JaypieStaticWebBucket` for pre-built assets (SPA bundles, static docs). Use `JaypieDistribution` when CloudFront fronts an Express Lambda or streaming handler. Use `JaypieNextJs` for SSR Next.js.
+
+## JaypieWebDeploymentBucket
+
+Static site on S3 fronted by CloudFront, wired to Route53 and ACM. Setting `CDK_ENV_REPO` also provisions an OIDC deploy role with scoped S3 and CloudFront invalidation permissions for GitHub Actions.
+
+```typescript
+import { JaypieWebDeploymentBucket } from "@jaypie/constructs";
+
+new JaypieWebDeploymentBucket(this, "Web", {
+  host: "app.example.com",
+  zone: "example.com",
+});
+```
+
+### Props
+
+| Prop | Type | Default |
+|------|------|---------|
+| `host` | `string` | `mergeDomain(CDK_ENV_WEB_SUBDOMAIN, CDK_ENV_WEB_HOSTED_ZONE \|\| CDK_ENV_HOSTED_ZONE)` |
+| `zone` | `string \| IHostedZone \| JaypieHostedZone` | `CDK_ENV_WEB_HOSTED_ZONE \|\| CDK_ENV_HOSTED_ZONE` |
+| `certificate` | `boolean \| ICertificate` | `true` (creates via `resolveCertificate`) |
+| `name` | `string` | `constructEnvName("web")` |
+| `roleTag` | `string` | `CDK.ROLE.HOSTING` |
+
+Also accepts all `s3.BucketProps` — the bucket defaults to `autoDeleteObjects: true`, `publicReadAccess: true`, `websiteIndexDocument: "index.html"`, `websiteErrorDocument: "index.html"` (SPA-friendly).
+
+### CloudFront
+
+- Default behavior: S3 static website origin, `REDIRECT_TO_HTTPS`, `CACHING_DISABLED`.
+- In production (`isProductionEnv()`), a second behavior on `/*` enables `CACHING_OPTIMIZED` — `index.html` stays uncached so SPA deploys are visible immediately; hashed assets get edge cache.
+
+### DNS
+
+Creates an A record alias to the distribution. Tags the record with `CDK.ROLE.NETWORKING`.
+
+### Deploy Role (OIDC)
+
+When `CDK_ENV_REPO` is set (e.g., `finlaysonstudio/jaypie`), the construct creates an IAM role assumed via GitHub OIDC with:
+
+- `s3:PutObject`, `s3:DeleteObject`, `s3:GetObject`, `s3:ListObjectsV2` on the bucket
+- `s3:ListBucket` on the bucket
+- `cloudformation:DescribeStacks` on the owning stack (so workflows can read outputs)
+- `cloudfront:CreateInvalidation` on the distribution
+
+Exposed as `CfnOutput`s for workflow consumption:
+
+| Output | Contents |
+|--------|----------|
+| `DestinationBucketName` | Target bucket for `aws s3 sync` |
+| `DestinationBucketDeployRoleArn` | Role ARN for `aws-actions/configure-aws-credentials` |
+| `DistributionId` | CloudFront distribution for `aws cloudfront create-invalidation` |
+| `CertificateArn` | ACM certificate ARN (when a certificate is created) |
+
+See `skill("cicd-deploy")` for the workflow pattern that reads these outputs and deploys content.
+
+## JaypieStaticWebBucket
+
+`JaypieWebDeploymentBucket` with `static` as the default subdomain. Use for a "static.example.com" asset site sharing the project's hosted zone.
+
+```typescript
+import { JaypieStaticWebBucket } from "@jaypie/constructs";
+
+// Minimal — host defaults to `envHostname({ subdomain: "static" })`,
+// zone defaults to CDK_ENV_DOMAIN || CDK_ENV_HOSTED_ZONE
+new JaypieStaticWebBucket(this, "Static");
+
+// Override host/zone when needed
+new JaypieStaticWebBucket(this, "Docs", {
+  host: "docs.example.com",
+  zone: "example.com",
+});
+```
+
+The default `name` is `constructEnvName("static")` so the bucket is namespaced per environment.
+
+## Environment-Aware Hosts
+
+`envHostname()` resolves a hostname from `PROJECT_ENV`, producing apex for production and a prefixed subdomain otherwise.
+
+```typescript
+import { envHostname, JaypieStaticWebBucket } from "@jaypie/constructs";
+
+// production → "jaypie.net"
+// sandbox    → "sandbox.jaypie.net"
+// development → "development.jaypie.net"
+const host = envHostname({ domain: "jaypie.net" });
+
+new JaypieStaticWebBucket(this, "Bucket", { host, zone: "jaypie.net" });
+```
+
+See `skill("variables")` for the `PROJECT_ENV` / `CDK_ENV_*` variables involved.
+
+## JaypieDistribution (dynamic origins)
+
+For CloudFront in front of an Express Lambda, Function URL, or custom origin — not a static S3 site — reach for `JaypieDistribution`. It ships with ACM, Route53 alias, WAF, and security headers by default.
+
+```typescript
+import { JaypieDistribution, JaypieExpressLambda } from "@jaypie/constructs";
+
+const api = new JaypieExpressLambda(this, "Api", {
+  code: "../api/dist",
+  handler: "index.handler",
+});
+
+new JaypieDistribution(this, "Distribution", {
+  handler: api,
+  host: "api.example.com",
+  zone: "example.com",
+});
+```
+
+Security headers (`ResponseHeadersPolicy`) and WAFv2 WebACL are covered in `skill("cdk")`. Response streaming with `createLambdaStreamHandler` is covered in `skill("streaming")`.
+
+### Certificate Sharing
+
+`resolveCertificate` caches certificates at the stack level by domain, so swapping `JaypieDistribution` ↔ `JaypieApiGateway` on the same hostname does not tear down or recreate the certificate. For explicit control:
+
+```typescript
+import { JaypieCertificate, JaypieDistribution } from "@jaypie/constructs";
+
+const cert = new JaypieCertificate(this, "ApiCert", {
+  domainName: "api.example.com",
+  zone: "example.com",
+});
+
+new JaypieDistribution(this, "Dist", { handler: api, certificate: cert });
+```
+
+## Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `CDK_ENV_HOSTED_ZONE` | Default hosted zone for all web constructs |
+| `CDK_ENV_WEB_HOSTED_ZONE` | Override hosted zone for web buckets specifically |
+| `CDK_ENV_WEB_SUBDOMAIN` | Subdomain under the hosted zone |
+| `CDK_ENV_WEB_HOST` | Full host override (skips subdomain + zone composition) |
+| `CDK_ENV_REPO` | `owner/repo` — when set, provisions the OIDC deploy role |
+| `CDK_ENV_DOMAIN` | Default domain for `JaypieStaticWebBucket` zone resolution |
+
+See `skill("variables")` for the full environment variable reference.
+
+## Deployment Workflow
+
+A typical `feat/*` branch deploy:
+
+1. CDK deploys the bucket, distribution, and deploy role.
+2. Workflow reads `DestinationBucketName`, `DestinationBucketDeployRoleArn`, and `DistributionId` from stack outputs.
+3. Workflow assumes the deploy role, runs `aws s3 sync ./dist s3://$BUCKET`, then invalidates `/*` on the distribution.
+
+See `skill("cicd-deploy")` for the reusable action pattern.
+
+## Stack Example
+
+```typescript
+import { Construct } from "constructs";
+import {
+  envHostname,
+  JaypieAppStack,
+  JaypieStaticWebBucket,
+} from "@jaypie/constructs";
+
+export class DocumentationStack extends JaypieAppStack {
+  public readonly bucket: JaypieStaticWebBucket;
+
+  constructor(scope: Construct, id?: string) {
+    super(scope, id ?? "JaypieDocumentationStack", { key: "documentation" });
+
+    const zone = process.env.CDK_ENV_HOSTED_ZONE ?? "example.com";
+    const host = envHostname({ domain: zone });
+
+    this.bucket = new JaypieStaticWebBucket(this, "DocumentationBucket", {
+      host,
+      zone,
+    });
+  }
+}
+```
+
+## See Also
+
+- **`skill("cdk")`** — core constructs, `JaypieDistribution` WAF and security headers, `JaypieNextJs`
+- **`skill("cicd-deploy")`** — workflows that consume `DestinationBucketName` / `DeployRoleArn` / `DistributionId`
+- **`skill("dns")`** — hosted zones, ACM certificates, DNS debugging
+- **`skill("secrets")`** — `JaypieEnvSecret` provider/consumer pattern
+- **`skill("streaming")`** — `JaypieDistribution` streaming configuration
+- **`skill("variables")`** — environment variable reference


### PR DESCRIPTION
## Summary
- Adds `skill("web")` covering `JaypieWebDeploymentBucket`, `JaypieStaticWebBucket`, OIDC deploy role flow, CloudFront/S3 patterns, and production caching behavior
- Registers `web` under infrastructure in `skills.md`, `agents.md`, `infrastructure.md`; cross-links from `cdk.md` and `dns.md`
- Bumps `@jaypie/mcp` 0.8.46 → 0.8.47 with release note

## Test plan
- [x] NPM Check (lint, typecheck, unit tests) passes
- [ ] NPM Deploy publishes `@jaypie/mcp@0.8.47`

🤖 Generated with [Claude Code](https://claude.com/claude-code)