### PR TITLE
fix(fabricator): add repository field for npm provenance

### DIFF
--- a/packages/fabricator/package.json
+++ b/packages/fabricator/package.json
@@ -2,6 +2,10 @@
   "name": "@jaypie/fabricator",
   "version": "0.3.2",
   "private": false,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/finlaysonstudio/jaypie.git"
+  },
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
## Summary

- Fixes NPM Deploy failure for `@jaypie/fabricator@0.3.2` (PR #326)
- Adds the missing `repository` field to `packages/fabricator/package.json`
- Version stays at 0.3.2 — the prior publish was rejected by the registry, so it never landed

## Context

The npm registry rejected the publish with E422:
> Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: \"repository.url\" is \"\", expected to match \"https://github.com/finlaysonstudio/jaypie\" from provenance.

Confirmed every other published `@jaypie/*` package already has this field; fabricator was the only one missing.

## Test plan

- [x] NPM Check workflow green
- [ ] NPM Deploy succeeds and publishes 0.3.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)