### PR TITLE
feat(llm): native structured outputs across all providers + capability matrix

### DIFF
--- a/.github/workflows/npm-check.yml
+++ b/.github/workflows/npm-check.yml
@@ -67,10 +67,10 @@ jobs:
         run: npm rebuild
       - run: npm run build
       - run: npm test
-  test-llm-client:
-    name: LLM Client Test (conditional)
+  test-llm-matrix:
+    name: LLM Capability Matrix (conditional)
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v4
@@ -91,11 +91,10 @@ jobs:
       - name: Build
         if: steps.changes.outputs.llm == 'true'
         run: npm run build
-      - name: Run LLM Client Tests
+      - name: Run LLM Capability Matrix
         if: steps.changes.outputs.llm == 'true'
-        run: LOG_LEVEL=trace npm run test:llm:all
+        run: LOG_LEVEL=warn npm run test:llm:matrix
         env:
-          APP_PROVIDER: anthropic,google,openai,xai
           ANTHROPIC_API_KEY: ${{ secrets.CICD_ANTHROPIC_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.CICD_GEMINI_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.CICD_OPENAI_API_KEY }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -29214,7 +29214,7 @@
       "license": "MIT"
     },
     "packages/jaypie": {
-      "version": "1.2.42",
+      "version": "1.2.43",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "^1.2.8",
@@ -29239,7 +29239,7 @@
         "typescript-eslint": "^8.46.1"
       },
       "peerDependencies": {
-        "@jaypie/llm": "^1.2.29",
+        "@jaypie/llm": "^1.2.31",
         "@jaypie/mongoose": "^1.2.2"
       },
       "peerDependenciesMeta": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29348,7 +29348,7 @@
     },
     "packages/llm": {
       "name": "@jaypie/llm",
-      "version": "1.2.29",
+      "version": "1.2.30",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "*",
@@ -29471,7 +29471,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.48",
+      "version": "0.8.49",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29348,7 +29348,7 @@
     },
     "packages/llm": {
       "name": "@jaypie/llm",
-      "version": "1.2.30",
+      "version": "1.2.31",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "*",
@@ -29471,7 +29471,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.49",
+      "version": "0.8.50",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.4",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "test:llm:document": "tsx packages/llm/test/document.ts",
     "test:llm:image": "tsx packages/llm/test/image.ts",
     "test:llm:joke": "tsx packages/llm/test/joke.ts",
+    "test:llm:matrix": "tsx packages/llm/test/matrix.ts",
     "test:llm:reasoning": "tsx packages/llm/test/reasoning.ts",
     "test:llm:structured": "tsx packages/llm/test/structured.ts",
     "test:mongoose": "npm run test --workspace packages/mongoose",

--- a/packages/jaypie/package.json
+++ b/packages/jaypie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jaypie",
-  "version": "1.2.42",
+  "version": "1.2.43",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"
@@ -54,7 +54,7 @@
     "typescript-eslint": "^8.46.1"
   },
   "peerDependencies": {
-    "@jaypie/llm": "^1.2.29",
+    "@jaypie/llm": "^1.2.31",
     "@jaypie/mongoose": "^1.2.2"
   },
   "peerDependenciesMeta": {

--- a/packages/llm/CLAUDE.md
+++ b/packages/llm/CLAUDE.md
@@ -142,6 +142,34 @@ const response = await Llm.operate(input, {
 - `fallbackUsed`: `true` if a fallback provider was used
 - `fallbackAttempts`: Number of providers tried (1 = primary only)
 
+### Structured Outputs
+
+Pass `format` (or `response` for `provider.send`) with a Zod or JSON-Schema definition to receive guaranteed-valid JSON.
+
+```typescript
+import { z } from "zod/v4";
+import Llm from "@jaypie/llm";
+
+const Greeting = z.object({
+  salutation: z.string(),
+  name: z.string(),
+});
+
+const response = await Llm.operate("Greet the world", {
+  model: "claude-opus-4-7",
+  format: Greeting,
+});
+// response.content is parsed JSON: { salutation: "Hello", name: "World" }
+```
+
+**Anthropic notes:**
+- Uses Anthropic's native `output_format` field (GA 2025-11; Claude 4.5+).
+- Schema constraints not supported by Anthropic's grammar (`minLength`, `maxLength`, `minimum`, `maximum`, `multipleOf`, regex `pattern`, recursive schemas, `additionalProperties: true`) are stripped at request time and folded into the field's `description`. The caller's Zod schema still validates the response, so all original constraints are enforced client-side.
+- `additionalProperties: false` is forced on every object.
+- Streaming structured outputs arrive as `LlmStreamChunkType.Text` deltas — concat to assemble JSON, or use `operate()` to get a parsed object directly.
+- `stop_reason: "refusal"` and `stop_reason: "max_tokens"` are surfaced as text rather than parsed JSON. `provider.send(..., { response })` throws on these; `operate()` surfaces them via `response.content` as a string.
+- A model that rejects `output_format` is cached for the session and transparently retried via the legacy fake-tool emulation. Citations + structured output (a 400 documented as incompatible) is **not** retried — the error propagates so callers can see the real cause.
+
 ### With Tools
 
 ```typescript

--- a/packages/llm/CLAUDE.md
+++ b/packages/llm/CLAUDE.md
@@ -170,6 +170,17 @@ const response = await Llm.operate("Greet the world", {
 - `stop_reason: "refusal"` and `stop_reason: "max_tokens"` are surfaced as text rather than parsed JSON. `provider.send(..., { response })` throws on these; `operate()` surfaces them via `response.content` as a string.
 - A model that rejects `output_format` is cached for the session and transparently retried via the legacy fake-tool emulation. Citations + structured output (a 400 documented as incompatible) is **not** retried — the error propagates so callers can see the real cause.
 
+**OpenRouter notes:**
+- Uses the OpenAI-style native `response_format: { type: "json_schema", json_schema: { name, schema, strict: true } }`. OpenRouter routes to a backend provider; many but not all backends support this — the SDK accepts the field on every model, and unsupported routes 4xx.
+- `additionalProperties: false` is forced on every object (required for `strict: true`).
+- A model that 400/422s on the `response_format` field is cached for the session and transparently retried via the legacy `structured_output` fake-tool emulation. The error message must mention `response_format`/`json_schema`/`structured_output`/`require_parameters` to trigger the fallback — generic 400s propagate.
+- For pre-flight enforcement, callers can pass `providerOptions: { provider: { require_parameters: true } }` to force OpenRouter to error rather than silently drop the field on backends that don't honor it.
+
+**Gemini notes:**
+- Format-only requests use native `responseMimeType: "application/json"` + `responseSchema` (OpenAPI 3.0) by default, or `responseJsonSchema` (standard JSON Schema) when `providerOptions.useJsonSchema: true`.
+- Format **and** tools combined: native `responseJsonSchema` + tools is supported only on Gemini 3 (preview) and is enabled automatically when the model id matches `^gemini-3`. Gemini 2.5 (including thinking) and earlier fall back to the `structured_output` fake-tool emulation with a system-prompt nudge.
+- A Gemini 3 model that 400s the combo is cached for the session and transparently retried via the fake-tool path. The error message must mention `responseJsonSchema`/`responseSchema`/`responseMime`/`function_call`/`tools` to trigger the fallback.
+
 ### With Tools
 
 ```typescript

--- a/packages/llm/CLAUDE.md
+++ b/packages/llm/CLAUDE.md
@@ -163,12 +163,12 @@ const response = await Llm.operate("Greet the world", {
 ```
 
 **Anthropic notes:**
-- Uses Anthropic's native `output_format` field (GA 2025-11; Claude 4.5+).
+- Uses Anthropic's native `output_config.format` field (GA 2025-11; Claude 4.5+). The earlier `output_format` field name is deprecated by the API.
 - Schema constraints not supported by Anthropic's grammar (`minLength`, `maxLength`, `minimum`, `maximum`, `multipleOf`, regex `pattern`, recursive schemas, `additionalProperties: true`) are stripped at request time and folded into the field's `description`. The caller's Zod schema still validates the response, so all original constraints are enforced client-side.
 - `additionalProperties: false` is forced on every object.
 - Streaming structured outputs arrive as `LlmStreamChunkType.Text` deltas — concat to assemble JSON, or use `operate()` to get a parsed object directly.
 - `stop_reason: "refusal"` and `stop_reason: "max_tokens"` are surfaced as text rather than parsed JSON. `provider.send(..., { response })` throws on these; `operate()` surfaces them via `response.content` as a string.
-- A model that rejects `output_format` is cached for the session and transparently retried via the legacy fake-tool emulation. Citations + structured output (a 400 documented as incompatible) is **not** retried — the error propagates so callers can see the real cause.
+- A model that rejects `output_config` is cached for the session and transparently retried via the legacy fake-tool emulation. Citations + structured output (a 400 documented as incompatible) and `output_format`-deprecation 400s are **not** retried — those errors propagate so callers can see the real cause.
 
 **OpenRouter notes:**
 - Uses the OpenAI-style native `response_format: { type: "json_schema", json_schema: { name, schema, strict: true } }`. OpenRouter routes to a backend provider; many but not all backends support this — the SDK accepts the field on every model, and unsupported routes 4xx.

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -28,6 +28,7 @@
     "format": "eslint . --fix",
     "lint": "eslint .",
     "test": "vitest run .",
+    "test:matrix": "tsx test/matrix.ts",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/llm",
-  "version": "1.2.30",
+  "version": "1.2.31",
   "description": "Large language model utilities",
   "repository": {
     "type": "git",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/llm",
-  "version": "1.2.29",
+  "version": "1.2.30",
   "description": "Large language model utilities",
   "repository": {
     "type": "git",

--- a/packages/llm/src/constants.ts
+++ b/packages/llm/src/constants.ts
@@ -16,7 +16,7 @@ const FIRST_CLASS_PROVIDER = {
   // https://developers.openai.com/api/docs/models
   OPENAI: {
     DEFAULT: "gpt-5.4" as const,
-    LARGE: "gpt-5.4" as const,
+    LARGE: "gpt-5.5" as const,
     SMALL: "gpt-5.4-mini" as const,
     TINY: "gpt-5.4-nano" as const,
   },

--- a/packages/llm/src/operate/adapters/AnthropicAdapter.ts
+++ b/packages/llm/src/operate/adapters/AnthropicAdapter.ts
@@ -1,4 +1,5 @@
 import type { Anthropic } from "@anthropic-ai/sdk";
+import log from "@jaypie/logger";
 import { JsonObject, NaturalSchema } from "@jaypie/types";
 import { z } from "zod/v4";
 
@@ -36,8 +37,195 @@ import { BaseProviderAdapter } from "./ProviderAdapter.interface.js";
 
 const STRUCTURED_OUTPUT_TOOL_NAME = "structured_output";
 
+/**
+ * Local extension of the SDK's `MessageCreateParams` to carry the legacy
+ * `output_format` field. SDK 0.71 only types `output_format` on the Beta
+ * namespace, but the field is accepted by the GA endpoint per Anthropic's
+ * structured-outputs docs (the deprecated beta header is no longer
+ * required). When the SDK promotes the typed field to the top-level
+ * `MessageCreateParams`, this extension can be removed.
+ */
+type AnthropicRequestParams = Anthropic.MessageCreateParams & {
+  output_format?: {
+    type: "json_schema";
+    schema: JsonObject;
+  };
+};
+
+/**
+ * Anthropic responses we annotate at receive time so downstream stateless
+ * methods (`hasStructuredOutput`, `extractStructuredOutput`) can tell whether
+ * the request asked for structured output without re-threading the request.
+ */
+type AnnotatedAnthropicMessage = Anthropic.Message & {
+  __jaypieStructuredOutput?: boolean;
+};
+
+const STRUCTURED_OUTPUT_NON_PARSE_STOP_REASONS = new Set([
+  "refusal",
+  "max_tokens",
+]);
+
 // Regular expression to parse data URLs: data:mime/type;base64,data
 const DATA_URL_REGEX = /^data:([^;]+);base64,(.+)$/;
+
+// String formats accepted by Anthropic's structured-output grammar compiler.
+// Other formats are stripped (move to description) so the API does not 400.
+const SUPPORTED_STRING_FORMATS = new Set([
+  "date",
+  "date-time",
+  "duration",
+  "email",
+  "hostname",
+  "ipv4",
+  "ipv6",
+  "time",
+  "uri",
+  "uuid",
+]);
+
+// Top-level keywords stripped wholesale before sending: not part of the spec
+// the API enforces and the validator can reject them.
+const STRIPPED_TOP_LEVEL_KEYWORDS = new Set(["$schema", "$id"]);
+
+// Keywords Anthropic's structured-output grammar does not support. They are
+// removed from the schema and appended to `description` so the model still
+// sees the intent.
+const UNSUPPORTED_CONSTRAINT_KEYWORDS = new Set([
+  "exclusiveMaximum",
+  "exclusiveMinimum",
+  "maxItems",
+  "maxLength",
+  "maxProperties",
+  "maximum",
+  "minLength",
+  "minProperties",
+  "minimum",
+  "multipleOf",
+  "pattern",
+  "patternProperties",
+  "uniqueItems",
+]);
+
+/**
+ * Recursively transform a JSON Schema into the strict shape Anthropic's
+ * structured-output grammar accepts: object types must have
+ * `additionalProperties: false`, unsupported numeric/string/array
+ * constraints are appended to `description`, and unsupported string
+ * formats are stripped. Mirrors @anthropic-ai/sdk's `transformJSONSchema`
+ * but inline so we do not take a runtime dependency on the optional
+ * peer SDK.
+ */
+function sanitizeJsonSchemaForAnthropic(
+  schema: JsonObject,
+  isRoot = true,
+): JsonObject {
+  const result: JsonObject = {};
+  const carriedConstraints: string[] = [];
+
+  for (const [key, value] of Object.entries(schema)) {
+    if (isRoot && STRIPPED_TOP_LEVEL_KEYWORDS.has(key)) {
+      continue;
+    }
+
+    if (UNSUPPORTED_CONSTRAINT_KEYWORDS.has(key)) {
+      carriedConstraints.push(`${key}: ${JSON.stringify(value)}`);
+      continue;
+    }
+
+    if (key === "format" && typeof value === "string") {
+      if (SUPPORTED_STRING_FORMATS.has(value)) {
+        result[key] = value;
+      } else {
+        carriedConstraints.push(`format: ${JSON.stringify(value)}`);
+      }
+      continue;
+    }
+
+    if (key === "minItems" && typeof value === "number") {
+      if (value === 0 || value === 1) {
+        result[key] = value;
+      } else {
+        carriedConstraints.push(`minItems: ${value}`);
+      }
+      continue;
+    }
+
+    if (
+      key === "properties" &&
+      value &&
+      typeof value === "object" &&
+      !Array.isArray(value)
+    ) {
+      const transformedProps: JsonObject = {};
+      for (const [propName, propSchema] of Object.entries(
+        value as JsonObject,
+      )) {
+        transformedProps[propName] = isJsonSchema(propSchema)
+          ? sanitizeJsonSchemaForAnthropic(propSchema, false)
+          : propSchema;
+      }
+      result[key] = transformedProps;
+      continue;
+    }
+
+    if (
+      (key === "items" || key === "additionalItems" || key === "contains") &&
+      isJsonSchema(value)
+    ) {
+      result[key] = sanitizeJsonSchemaForAnthropic(value, false);
+      continue;
+    }
+
+    if (
+      (key === "anyOf" || key === "oneOf" || key === "allOf") &&
+      Array.isArray(value)
+    ) {
+      const targetKey = key === "oneOf" ? "anyOf" : key;
+      result[targetKey] = value.map((entry) =>
+        isJsonSchema(entry)
+          ? sanitizeJsonSchemaForAnthropic(entry, false)
+          : entry,
+      );
+      continue;
+    }
+
+    if (key === "$defs" && value && typeof value === "object") {
+      const transformedDefs: JsonObject = {};
+      for (const [defName, defSchema] of Object.entries(value as JsonObject)) {
+        transformedDefs[defName] = isJsonSchema(defSchema)
+          ? sanitizeJsonSchemaForAnthropic(defSchema, false)
+          : defSchema;
+      }
+      result[key] = transformedDefs;
+      continue;
+    }
+
+    if (key === "additionalProperties") {
+      // Always force `false` on objects below; ignore caller-supplied value.
+      continue;
+    }
+
+    result[key] = value;
+  }
+
+  if (result.type === "object") {
+    result.additionalProperties = false;
+  }
+
+  if (carriedConstraints.length > 0) {
+    const existing =
+      typeof result.description === "string" ? result.description : "";
+    const suffix = `{${carriedConstraints.join(", ")}}`;
+    result.description = existing ? `${existing}\n\n${suffix}` : suffix;
+  }
+
+  return result;
+}
+
+function isJsonSchema(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
 
 /**
  * Parse a data URL into its components
@@ -153,6 +341,30 @@ function isTemperatureDeprecationError(error: unknown): boolean {
   return messages.some((m) => m.toLowerCase().includes("temperature"));
 }
 
+/**
+ * Detect 400 errors that indicate the model itself does not support
+ * `output_format`. Citations + structured output is also a 400 case but is a
+ * caller error rather than a model-capability gap, so we explicitly skip it
+ * to avoid masking the real problem under a tool-emulation retry.
+ */
+function isStructuredOutputUnsupportedError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const err = error as {
+    status?: number;
+    message?: string;
+    error?: { message?: string };
+  };
+  const name = (error as Error)?.constructor?.name;
+  if (name !== "BadRequestError" && err.status !== 400) return false;
+  const messages = [err.message, err.error?.message].filter(
+    (m): m is string => typeof m === "string",
+  );
+  if (messages.some((m) => /citation/i.test(m))) return false;
+  return messages.some((m) =>
+    /output_format|output_config|json[_ ]schema|structured/i.test(m),
+  );
+}
+
 //
 //
 // Main
@@ -171,6 +383,11 @@ export class AnthropicAdapter extends BaseProviderAdapter {
   // Populated by executeRequest on 400 errors so repeat calls skip the param.
   private runtimeNoTemperatureModels = new Set<string>();
 
+  // Session-level cache of models observed to reject `output_format`. When a
+  // model is in this set, buildRequest engages the legacy fake-tool path
+  // instead of native structured output.
+  private runtimeNoStructuredOutputModels = new Set<string>();
+
   rememberModelRejectsTemperature(model: string): void {
     this.runtimeNoTemperatureModels.add(model);
   }
@@ -179,16 +396,28 @@ export class AnthropicAdapter extends BaseProviderAdapter {
     this.runtimeNoTemperatureModels.clear();
   }
 
+  rememberModelRejectsStructuredOutput(model: string): void {
+    this.runtimeNoStructuredOutputModels.add(model);
+  }
+
+  clearRuntimeNoStructuredOutputModels(): void {
+    this.runtimeNoStructuredOutputModels.clear();
+  }
+
   private supportsTemperature(model: string): boolean {
     if (this.runtimeNoTemperatureModels.has(model)) return false;
     return !MODELS_WITHOUT_TEMPERATURE.some((pattern) => pattern.test(model));
+  }
+
+  private supportsStructuredOutput(model: string): boolean {
+    return !this.runtimeNoStructuredOutputModels.has(model);
   }
 
   //
   // Request Building
   //
 
-  buildRequest(request: OperateRequest): Anthropic.MessageCreateParams {
+  buildRequest(request: OperateRequest): AnthropicRequestParams {
     // Convert messages to Anthropic format
     // Handle different message types: regular messages, function calls, and function outputs
     const messages: Anthropic.MessageParam[] = [];
@@ -257,7 +486,7 @@ export class AnthropicAdapter extends BaseProviderAdapter {
       }
     }
 
-    const anthropicRequest: Anthropic.MessageCreateParams = {
+    const anthropicRequest: AnthropicRequestParams = {
       model: (request.model ||
         this.defaultModel) as Anthropic.MessageCreateParams["model"],
       messages,
@@ -269,8 +498,28 @@ export class AnthropicAdapter extends BaseProviderAdapter {
       anthropicRequest.system = request.system;
     }
 
-    if (request.tools && request.tools.length > 0) {
-      anthropicRequest.tools = request.tools.map((tool) => ({
+    const useFallbackStructuredOutput =
+      Boolean(request.format) &&
+      !this.supportsStructuredOutput(anthropicRequest.model as string);
+
+    const allTools: ProviderToolDefinition[] = request.tools
+      ? [...request.tools]
+      : [];
+    if (useFallbackStructuredOutput && request.format) {
+      log.warn(
+        `[AnthropicAdapter] Using legacy structured_output tool fallback for model ${anthropicRequest.model as string}; native output_format previously rejected for this model.`,
+      );
+      allTools.push({
+        name: STRUCTURED_OUTPUT_TOOL_NAME,
+        description:
+          "Output a structured JSON object, " +
+          "use this before your final response to give structured outputs to the user",
+        parameters: request.format,
+      });
+    }
+
+    if (allTools.length > 0) {
+      anthropicRequest.tools = allTools.map((tool) => ({
         name: tool.name,
         description: tool.description,
         input_schema: {
@@ -280,12 +529,18 @@ export class AnthropicAdapter extends BaseProviderAdapter {
         type: "custom" as const,
       }));
 
-      // Determine tool choice based on whether structured output is requested
-      const hasStructuredOutput = request.tools.some(
-        (t) => t.name === STRUCTURED_OUTPUT_TOOL_NAME,
-      );
-      anthropicRequest.tool_choice = {
-        type: hasStructuredOutput ? "any" : "auto",
+      anthropicRequest.tool_choice = useFallbackStructuredOutput
+        ? { type: "any" }
+        : { type: "auto" };
+    }
+
+    // Native structured output: send schema as `output_format`. The legacy
+    // tool-emulation path is engaged only as a runtime fallback for models
+    // the API has flagged as not supporting `output_format`.
+    if (request.format && !useFallbackStructuredOutput) {
+      anthropicRequest.output_format = {
+        type: "json_schema",
+        schema: request.format,
       };
     }
 
@@ -311,9 +566,13 @@ export class AnthropicAdapter extends BaseProviderAdapter {
 
   formatTools(
     toolkit: Toolkit,
-    outputSchema?: JsonObject,
+    // outputSchema is part of the interface contract but Anthropic now uses
+    // native `output_format` (set in buildRequest), so we no longer inject a
+    // synthetic structured-output tool here.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _outputSchema?: JsonObject,
   ): ProviderToolDefinition[] {
-    const tools: ProviderToolDefinition[] = toolkit.tools.map((tool) => ({
+    return toolkit.tools.map((tool) => ({
       name: tool.name,
       description: tool.description,
       parameters: {
@@ -321,19 +580,6 @@ export class AnthropicAdapter extends BaseProviderAdapter {
         type: "object",
       } as JsonObject,
     }));
-
-    // Add structured output tool if schema is provided
-    if (outputSchema) {
-      tools.push({
-        name: STRUCTURED_OUTPUT_TOOL_NAME,
-        description:
-          "Output a structured JSON object, " +
-          "use this before your final response to give structured outputs to the user",
-        parameters: outputSchema,
-      });
-    }
-
-    return tools;
   }
 
   formatOutputSchema(
@@ -359,12 +605,7 @@ export class AnthropicAdapter extends BaseProviderAdapter {
       jsonSchema = z.toJSONSchema(zodSchema) as JsonObject;
     }
 
-    // Remove $schema property (causes issues with validator)
-    if (jsonSchema.$schema) {
-      delete jsonSchema.$schema;
-    }
-
-    return jsonSchema;
+    return sanitizeJsonSchemaForAnthropic(jsonSchema);
   }
 
   //
@@ -377,12 +618,17 @@ export class AnthropicAdapter extends BaseProviderAdapter {
     signal?: AbortSignal,
   ): Promise<Anthropic.Message> {
     const anthropic = client as Anthropic;
-    const anthropicRequest = request as Anthropic.MessageCreateParams;
+    const anthropicRequest = request as AnthropicRequestParams;
+    const wantsStructuredOutput = Boolean(anthropicRequest.output_format);
     try {
-      return (await anthropic.messages.create(
-        anthropicRequest,
+      const response = (await anthropic.messages.create(
+        anthropicRequest as Anthropic.MessageCreateParams,
         signal ? { signal } : undefined,
-      )) as Anthropic.Message;
+      )) as AnnotatedAnthropicMessage;
+      if (wantsStructuredOutput) {
+        response.__jaypieStructuredOutput = true;
+      }
+      return response;
     } catch (error) {
       if (signal?.aborted) return undefined as unknown as Anthropic.Message;
 
@@ -394,8 +640,28 @@ export class AnthropicAdapter extends BaseProviderAdapter {
         this.rememberModelRejectsTemperature(anthropicRequest.model as string);
         const retryRequest = { ...anthropicRequest };
         delete retryRequest.temperature;
+        const response = (await anthropic.messages.create(
+          retryRequest as Anthropic.MessageCreateParams,
+          signal ? { signal } : undefined,
+        )) as AnnotatedAnthropicMessage;
+        if (wantsStructuredOutput) {
+          response.__jaypieStructuredOutput = true;
+        }
+        return response;
+      }
+
+      // If the model rejected `output_format`, cache it and retry with the
+      // legacy fake-tool emulation path.
+      if (wantsStructuredOutput && isStructuredOutputUnsupportedError(error)) {
+        const model = anthropicRequest.model as string;
+        this.rememberModelRejectsStructuredOutput(model);
+        log.warn(
+          `[AnthropicAdapter] Model ${model} rejected native output_format; falling back to legacy structured_output tool emulation.`,
+        );
+        const fallbackRequest =
+          this.toFallbackStructuredOutputRequest(anthropicRequest);
         return (await anthropic.messages.create(
-          retryRequest,
+          fallbackRequest as Anthropic.MessageCreateParams,
           signal ? { signal } : undefined,
         )) as Anthropic.Message;
       }
@@ -404,21 +670,51 @@ export class AnthropicAdapter extends BaseProviderAdapter {
     }
   }
 
+  /**
+   * Rebuild a structured-output request without `output_format`, swapping in
+   * the legacy fake-tool emulation. Used as a runtime fallback when a model
+   * rejects native `output_format`.
+   */
+  private toFallbackStructuredOutputRequest(
+    request: AnthropicRequestParams,
+  ): AnthropicRequestParams {
+    const { output_format, ...rest } = request;
+    if (!output_format) return request;
+    const fallbackRequest: AnthropicRequestParams = { ...rest };
+    const fakeTool = {
+      name: STRUCTURED_OUTPUT_TOOL_NAME,
+      description:
+        "Output a structured JSON object, " +
+        "use this before your final response to give structured outputs to the user",
+      input_schema: {
+        ...output_format.schema,
+        type: "object",
+      } as Anthropic.Messages.Tool.InputSchema,
+      type: "custom" as const,
+    };
+    fallbackRequest.tools = [...(fallbackRequest.tools ?? []), fakeTool];
+    fallbackRequest.tool_choice = { type: "any" };
+    return fallbackRequest;
+  }
+
   async *executeStreamRequest(
     client: unknown,
     request: unknown,
     signal?: AbortSignal,
   ): AsyncIterable<LlmStreamChunk> {
     const anthropic = client as Anthropic;
+    // Preserve `output_format` when passing through to the SDK by typing
+    // through the local extension instead of the upstream
+    // MessageCreateParams shape.
     let streamRequest = {
-      ...(request as Anthropic.MessageCreateParams),
+      ...(request as AnthropicRequestParams),
       stream: true,
-    } as Anthropic.MessageCreateParamsStreaming;
+    } as AnthropicRequestParams & { stream: true };
 
     let stream;
     try {
       stream = await anthropic.messages.create(
-        streamRequest,
+        streamRequest as Anthropic.MessageCreateParamsStreaming,
         signal ? { signal } : undefined,
       );
     } catch (error) {
@@ -429,10 +725,10 @@ export class AnthropicAdapter extends BaseProviderAdapter {
         this.rememberModelRejectsTemperature(streamRequest.model as string);
         streamRequest = {
           ...streamRequest,
-        } as Anthropic.MessageCreateParamsStreaming;
+        };
         delete streamRequest.temperature;
         stream = await anthropic.messages.create(
-          streamRequest,
+          streamRequest as Anthropic.MessageCreateParamsStreaming,
           signal ? { signal } : undefined,
         );
       } else {
@@ -725,9 +1021,16 @@ export class AnthropicAdapter extends BaseProviderAdapter {
   }
 
   override hasStructuredOutput(response: unknown): boolean {
-    const anthropicResponse = response as Anthropic.Message;
+    const anthropicResponse = response as AnnotatedAnthropicMessage;
 
-    // Check if the last content block is a tool_use with structured_output
+    // Native path: executeRequest annotates the response when we sent
+    // `output_format`, so we can detect intent statelessly.
+    if (anthropicResponse.__jaypieStructuredOutput) {
+      return this.extractStructuredOutput(response) !== undefined;
+    }
+
+    // Fallback path: legacy fake-tool emulation, kept for models that the
+    // runtime has cached as not supporting `output_format`.
     const lastBlock =
       anthropicResponse.content[anthropicResponse.content.length - 1];
     return (
@@ -737,8 +1040,35 @@ export class AnthropicAdapter extends BaseProviderAdapter {
   }
 
   override extractStructuredOutput(response: unknown): JsonObject | undefined {
-    const anthropicResponse = response as Anthropic.Message;
+    const anthropicResponse = response as AnnotatedAnthropicMessage;
 
+    if (anthropicResponse.__jaypieStructuredOutput) {
+      // Refusal and truncation are explicit non-JSON outcomes per Anthropic
+      // structured-outputs docs — surface the text upstream instead of
+      // forcing a JSON.parse on what is not JSON.
+      if (
+        anthropicResponse.stop_reason &&
+        STRUCTURED_OUTPUT_NON_PARSE_STOP_REASONS.has(
+          anthropicResponse.stop_reason,
+        )
+      ) {
+        return undefined;
+      }
+
+      const textBlock = anthropicResponse.content.find(
+        (block) => block.type === "text",
+      ) as Anthropic.TextBlock | undefined;
+      if (!textBlock) return undefined;
+
+      try {
+        const parsed = JSON.parse(textBlock.text);
+        return parsed as JsonObject;
+      } catch {
+        return undefined;
+      }
+    }
+
+    // Fallback path: legacy fake-tool emulation
     const lastBlock =
       anthropicResponse.content[anthropicResponse.content.length - 1];
     if (

--- a/packages/llm/src/operate/adapters/AnthropicAdapter.ts
+++ b/packages/llm/src/operate/adapters/AnthropicAdapter.ts
@@ -38,17 +38,19 @@ import { BaseProviderAdapter } from "./ProviderAdapter.interface.js";
 const STRUCTURED_OUTPUT_TOOL_NAME = "structured_output";
 
 /**
- * Local extension of the SDK's `MessageCreateParams` to carry the legacy
- * `output_format` field. SDK 0.71 only types `output_format` on the Beta
- * namespace, but the field is accepted by the GA endpoint per Anthropic's
- * structured-outputs docs (the deprecated beta header is no longer
- * required). When the SDK promotes the typed field to the top-level
- * `MessageCreateParams`, this extension can be removed.
+ * Local extension of the SDK's `MessageCreateParams` to carry
+ * `output_config.format` (Anthropic native structured outputs). The SDK 0.71
+ * shipped with the older `output_format` field which the API has since
+ * deprecated in favor of `output_config.format`. We send the new shape via
+ * an untyped passthrough so callers don't need a newer SDK; remove this
+ * extension once the SDK types `output_config` directly.
  */
 type AnthropicRequestParams = Anthropic.MessageCreateParams & {
-  output_format?: {
-    type: "json_schema";
-    schema: JsonObject;
+  output_config?: {
+    format: {
+      type: "json_schema";
+      schema: JsonObject;
+    };
   };
 };
 
@@ -342,10 +344,13 @@ function isTemperatureDeprecationError(error: unknown): boolean {
 }
 
 /**
- * Detect 400 errors that indicate the model itself does not support
- * `output_format`. Citations + structured output is also a 400 case but is a
- * caller error rather than a model-capability gap, so we explicitly skip it
- * to avoid masking the real problem under a tool-emulation retry.
+ * Detect 400 errors that indicate the model itself does not support native
+ * structured outputs (`output_config.format`). Citations + structured output
+ * is also a 400 case but is a caller error rather than a model-capability
+ * gap, so we explicitly skip it to avoid masking the real problem under a
+ * tool-emulation retry. The deprecated-`output_format` 400 (API renamed the
+ * field) is also explicitly excluded — that's a code-path bug, not a model
+ * gap; it should propagate so we notice and fix it.
  */
 function isStructuredOutputUnsupportedError(error: unknown): boolean {
   if (!error || typeof error !== "object") return false;
@@ -360,8 +365,9 @@ function isStructuredOutputUnsupportedError(error: unknown): boolean {
     (m): m is string => typeof m === "string",
   );
   if (messages.some((m) => /citation/i.test(m))) return false;
+  if (messages.some((m) => /deprecated/i.test(m))) return false;
   return messages.some((m) =>
-    /output_format|output_config|json[_ ]schema|structured/i.test(m),
+    /output_config|output_format|json[_ ]schema|structured/i.test(m),
   );
 }
 
@@ -507,7 +513,7 @@ export class AnthropicAdapter extends BaseProviderAdapter {
       : [];
     if (useFallbackStructuredOutput && request.format) {
       log.warn(
-        `[AnthropicAdapter] Using legacy structured_output tool fallback for model ${anthropicRequest.model as string}; native output_format previously rejected for this model.`,
+        `[AnthropicAdapter] Using legacy structured_output tool fallback for model ${anthropicRequest.model as string}; native output_config previously rejected for this model.`,
       );
       allTools.push({
         name: STRUCTURED_OUTPUT_TOOL_NAME,
@@ -534,13 +540,15 @@ export class AnthropicAdapter extends BaseProviderAdapter {
         : { type: "auto" };
     }
 
-    // Native structured output: send schema as `output_format`. The legacy
-    // tool-emulation path is engaged only as a runtime fallback for models
-    // the API has flagged as not supporting `output_format`.
+    // Native structured output: send schema as `output_config.format`. The
+    // legacy tool-emulation path is engaged only as a runtime fallback for
+    // models the API has flagged as not supporting native structured output.
     if (request.format && !useFallbackStructuredOutput) {
-      anthropicRequest.output_format = {
-        type: "json_schema",
-        schema: request.format,
+      anthropicRequest.output_config = {
+        format: {
+          type: "json_schema",
+          schema: request.format,
+        },
       };
     }
 
@@ -619,7 +627,7 @@ export class AnthropicAdapter extends BaseProviderAdapter {
   ): Promise<Anthropic.Message> {
     const anthropic = client as Anthropic;
     const anthropicRequest = request as AnthropicRequestParams;
-    const wantsStructuredOutput = Boolean(anthropicRequest.output_format);
+    const wantsStructuredOutput = Boolean(anthropicRequest.output_config);
     try {
       const response = (await anthropic.messages.create(
         anthropicRequest as Anthropic.MessageCreateParams,
@@ -650,13 +658,13 @@ export class AnthropicAdapter extends BaseProviderAdapter {
         return response;
       }
 
-      // If the model rejected `output_format`, cache it and retry with the
-      // legacy fake-tool emulation path.
+      // If the model rejected native structured output, cache it and retry
+      // via the legacy fake-tool emulation path.
       if (wantsStructuredOutput && isStructuredOutputUnsupportedError(error)) {
         const model = anthropicRequest.model as string;
         this.rememberModelRejectsStructuredOutput(model);
         log.warn(
-          `[AnthropicAdapter] Model ${model} rejected native output_format; falling back to legacy structured_output tool emulation.`,
+          `[AnthropicAdapter] Model ${model} rejected native output_config; falling back to legacy structured_output tool emulation.`,
         );
         const fallbackRequest =
           this.toFallbackStructuredOutputRequest(anthropicRequest);
@@ -673,13 +681,13 @@ export class AnthropicAdapter extends BaseProviderAdapter {
   /**
    * Rebuild a structured-output request without `output_format`, swapping in
    * the legacy fake-tool emulation. Used as a runtime fallback when a model
-   * rejects native `output_format`.
+   * rejects native `output_config.format`.
    */
   private toFallbackStructuredOutputRequest(
     request: AnthropicRequestParams,
   ): AnthropicRequestParams {
-    const { output_format, ...rest } = request;
-    if (!output_format) return request;
+    const { output_config, ...rest } = request;
+    if (!output_config) return request;
     const fallbackRequest: AnthropicRequestParams = { ...rest };
     const fakeTool = {
       name: STRUCTURED_OUTPUT_TOOL_NAME,
@@ -687,7 +695,7 @@ export class AnthropicAdapter extends BaseProviderAdapter {
         "Output a structured JSON object, " +
         "use this before your final response to give structured outputs to the user",
       input_schema: {
-        ...output_format.schema,
+        ...output_config.format.schema,
         type: "object",
       } as Anthropic.Messages.Tool.InputSchema,
       type: "custom" as const,
@@ -703,7 +711,7 @@ export class AnthropicAdapter extends BaseProviderAdapter {
     signal?: AbortSignal,
   ): AsyncIterable<LlmStreamChunk> {
     const anthropic = client as Anthropic;
-    // Preserve `output_format` when passing through to the SDK by typing
+    // Preserve `output_config` when passing through to the SDK by typing
     // through the local extension instead of the upstream
     // MessageCreateParams shape.
     let streamRequest = {

--- a/packages/llm/src/operate/adapters/GeminiAdapter.ts
+++ b/packages/llm/src/operate/adapters/GeminiAdapter.ts
@@ -1,4 +1,5 @@
 import type { GoogleGenAI } from "@google/genai";
+import log from "@jaypie/logger";
 import { JsonObject, NaturalSchema } from "@jaypie/types";
 import { z } from "zod/v4";
 
@@ -45,6 +46,37 @@ import {
 
 const STRUCTURED_OUTPUT_TOOL_NAME = "structured_output";
 
+// Gemini 3 family supports combining tools (function calling) with native
+// structured output via `responseJsonSchema`. Earlier Gemini families
+// (including 2.5 thinking) do not support the combo and fall back to the
+// legacy `structured_output` fake-tool emulation.
+const GEMINI_3_PATTERN = /^gemini-3/;
+
+/**
+ * Detect 4xx errors that indicate the model itself does not support the
+ * `responseJsonSchema` + tools combo. Triggers the runtime fallback to the
+ * fake-tool emulation path. Other 400s propagate.
+ */
+function isStructuredOutputComboUnsupportedError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const err = error as {
+    status?: number;
+    code?: number;
+    message?: string;
+    error?: { message?: string };
+  };
+  const status = err.status ?? err.code;
+  if (status !== 400) return false;
+  const messages = [err.message, err.error?.message].filter(
+    (m): m is string => typeof m === "string",
+  );
+  return messages.some((m) =>
+    /response[_ ]?json[_ ]?schema|response[_ ]?schema|response[_ ]?mime|function[_ ]?call|tools/i.test(
+      m,
+    ),
+  );
+}
+
 // Gemini uses HTTP status codes for error classification
 // Documented at: https://ai.google.dev/api/rest/v1beta/Status
 const RETRYABLE_STATUS_CODES = [
@@ -78,6 +110,24 @@ const NOT_RETRYABLE_STATUS_CODES = [
 export class GeminiAdapter extends BaseProviderAdapter {
   readonly name = PROVIDER.GEMINI.NAME;
   readonly defaultModel = PROVIDER.GEMINI.MODEL.DEFAULT;
+
+  // Session-level cache of Gemini 3 models observed to reject the native
+  // `responseJsonSchema` + tools combo. When a model is in this set,
+  // buildRequest engages the legacy fake-tool path instead.
+  private runtimeNoStructuredOutputComboModels = new Set<string>();
+
+  rememberModelRejectsStructuredOutputCombo(model: string): void {
+    this.runtimeNoStructuredOutputComboModels.add(model);
+  }
+
+  clearRuntimeNoStructuredOutputComboModels(): void {
+    this.runtimeNoStructuredOutputComboModels.clear();
+  }
+
+  private supportsStructuredOutputCombo(model: string): boolean {
+    if (this.runtimeNoStructuredOutputComboModels.has(model)) return false;
+    return GEMINI_3_PATTERN.test(model);
+  }
 
   //
   // Request Building
@@ -113,14 +163,39 @@ export class GeminiAdapter extends BaseProviderAdapter {
       }
     }
 
-    // Add tools if provided
-    if (request.tools && request.tools.length > 0) {
-      const functionDeclarations: GeminiFunctionDeclaration[] =
-        request.tools.map((tool) => ({
+    const hasUserTools = !!(request.tools && request.tools.length > 0);
+    const useNativeCombo =
+      Boolean(request.format) &&
+      hasUserTools &&
+      this.supportsStructuredOutputCombo(geminiRequest.model);
+
+    // When tools+format are combined and the model does not support the native
+    // combo, inject the legacy `structured_output` fake tool here so the model
+    // is forced to call it before its final answer.
+    const allTools: ProviderToolDefinition[] = request.tools
+      ? [...request.tools]
+      : [];
+    if (request.format && hasUserTools && !useNativeCombo) {
+      log.warn(
+        `[GeminiAdapter] Using legacy structured_output tool fallback for model ${geminiRequest.model}; native responseJsonSchema + tools combo is only available on Gemini 3.`,
+      );
+      allTools.push({
+        name: STRUCTURED_OUTPUT_TOOL_NAME,
+        description:
+          "Output a structured JSON object, " +
+          "use this before your final response to give structured outputs to the user",
+        parameters: request.format,
+      });
+    }
+
+    if (allTools.length > 0) {
+      const functionDeclarations: GeminiFunctionDeclaration[] = allTools.map(
+        (tool) => ({
           name: tool.name,
           description: tool.description,
           parameters: tool.parameters,
-        }));
+        }),
+      );
 
       geminiRequest.config = {
         ...geminiRequest.config,
@@ -128,11 +203,16 @@ export class GeminiAdapter extends BaseProviderAdapter {
       };
     }
 
-    // Add structured output format if provided (but NOT when tools are present)
-    // Gemini doesn't support combining function calling with responseMimeType: 'application/json'
-    // When tools are present, structured output is handled via the structured_output tool
-    if (request.format && !(request.tools && request.tools.length > 0)) {
-      const useJsonSchema = request.providerOptions?.useJsonSchema === true;
+    // Native structured output: send schema as `responseJsonSchema`
+    // (or `responseSchema` for Gemini 2.5+ no-tools path). The legacy
+    // fake-tool emulation only runs when format+tools is combined on a model
+    // that doesn't support the native combo.
+    const wantsNativeStructured =
+      Boolean(request.format) && (!hasUserTools || useNativeCombo);
+
+    if (wantsNativeStructured) {
+      const useJsonSchema =
+        useNativeCombo || request.providerOptions?.useJsonSchema === true;
 
       if (useJsonSchema) {
         geminiRequest.config = {
@@ -144,18 +224,18 @@ export class GeminiAdapter extends BaseProviderAdapter {
         geminiRequest.config = {
           ...geminiRequest.config,
           responseMimeType: "application/json",
-          responseSchema: jsonSchemaToOpenApi3(request.format),
+          responseSchema: jsonSchemaToOpenApi3(request.format!),
         };
       }
     }
 
-    // When format is specified with tools, add instruction to use structured_output tool
-    if (request.format && request.tools && request.tools.length > 0) {
+    // Legacy fake-tool path needs a system-prompt nudge so the model actually
+    // calls the synthetic tool before its final answer.
+    if (request.format && hasUserTools && !useNativeCombo) {
       const structuredOutputInstruction =
         "IMPORTANT: Before providing your final response, you MUST use the structured_output tool " +
         "to output your answer in the required JSON format.";
 
-      // Add to system instruction if it exists, otherwise create one
       const existingSystem = geminiRequest.config?.systemInstruction || "";
       geminiRequest.config = {
         ...geminiRequest.config,
@@ -186,9 +266,14 @@ export class GeminiAdapter extends BaseProviderAdapter {
 
   formatTools(
     toolkit: Toolkit,
-    outputSchema?: JsonObject,
+    // outputSchema is part of the interface contract but Gemini now handles
+    // structured output via `responseJsonSchema`/`responseSchema` (or the
+    // legacy fake-tool injected in buildRequest as a fallback). We no longer
+    // inject a synthetic structured-output tool here.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _outputSchema?: JsonObject,
   ): ProviderToolDefinition[] {
-    const tools: ProviderToolDefinition[] = toolkit.tools.map((tool) => ({
+    return toolkit.tools.map((tool) => ({
       name: tool.name,
       description: tool.description,
       parameters: {
@@ -196,19 +281,6 @@ export class GeminiAdapter extends BaseProviderAdapter {
         type: "object",
       } as JsonObject,
     }));
-
-    // Add structured output tool if schema is provided
-    if (outputSchema) {
-      tools.push({
-        name: STRUCTURED_OUTPUT_TOOL_NAME,
-        description:
-          "Output a structured JSON object, " +
-          "use this before your final response to give structured outputs to the user",
-        parameters: outputSchema,
-      });
-    }
-
-    return tools;
   }
 
   formatOutputSchema(
@@ -248,6 +320,9 @@ export class GeminiAdapter extends BaseProviderAdapter {
   ): Promise<GeminiRawResponse> {
     const genAI = client as GoogleGenAI;
     const geminiRequest = request as GeminiRequest;
+    const wantsNativeCombo =
+      !!geminiRequest.config?.responseJsonSchema &&
+      !!geminiRequest.config?.tools;
 
     try {
       // Cast config to any to bypass strict type checking between our internal types
@@ -261,8 +336,68 @@ export class GeminiAdapter extends BaseProviderAdapter {
       return response as unknown as GeminiRawResponse;
     } catch (error) {
       if (signal?.aborted) return undefined as unknown as GeminiRawResponse;
+
+      // If the model rejected the native responseJsonSchema + tools combo,
+      // cache it and retry with the legacy fake-tool emulation path.
+      if (wantsNativeCombo && isStructuredOutputComboUnsupportedError(error)) {
+        const model = geminiRequest.model;
+        this.rememberModelRejectsStructuredOutputCombo(model);
+        log.warn(
+          `[GeminiAdapter] Model ${model} rejected native responseJsonSchema + tools combo; falling back to legacy structured_output tool emulation.`,
+        );
+        const fallbackRequest =
+          this.toFallbackStructuredOutputRequest(geminiRequest);
+        const response = await genAI.models.generateContent({
+          model: fallbackRequest.model,
+          contents: fallbackRequest.contents as any,
+          config: fallbackRequest.config as any,
+        });
+        return response as unknown as GeminiRawResponse;
+      }
+
       throw error;
     }
+  }
+
+  /**
+   * Rebuild a Gemini 3 native-combo request without `responseJsonSchema`/
+   * `responseMimeType`, swapping in the legacy fake-tool emulation. Used as
+   * a runtime fallback when a Gemini 3 model rejects the combo.
+   */
+  private toFallbackStructuredOutputRequest(
+    request: GeminiRequest,
+  ): GeminiRequest {
+    if (!request.config?.responseJsonSchema) return request;
+    const schema = request.config.responseJsonSchema as JsonObject;
+    const newConfig: GeminiRequest["config"] = { ...request.config };
+    delete (newConfig as Record<string, unknown>).responseJsonSchema;
+    delete (newConfig as Record<string, unknown>).responseMimeType;
+
+    const fakeTool: GeminiFunctionDeclaration = {
+      name: STRUCTURED_OUTPUT_TOOL_NAME,
+      description:
+        "Output a structured JSON object, " +
+        "use this before your final response to give structured outputs to the user",
+      parameters: schema,
+    };
+    const existingDeclarations =
+      newConfig.tools?.[0]?.functionDeclarations ?? [];
+    newConfig.tools = [
+      { functionDeclarations: [...existingDeclarations, fakeTool] },
+    ];
+
+    const structuredOutputInstruction =
+      "IMPORTANT: Before providing your final response, you MUST use the structured_output tool " +
+      "to output your answer in the required JSON format.";
+    const existingSystem = newConfig.systemInstruction || "";
+    newConfig.systemInstruction = existingSystem
+      ? `${existingSystem}\n\n${structuredOutputInstruction}`
+      : structuredOutputInstruction;
+
+    return {
+      ...request,
+      config: newConfig,
+    };
   }
 
   async *executeStreamRequest(

--- a/packages/llm/src/operate/adapters/OpenRouterAdapter.ts
+++ b/packages/llm/src/operate/adapters/OpenRouterAdapter.ts
@@ -101,14 +101,36 @@ interface OpenRouterTool {
   };
 }
 
+interface OpenRouterJsonSchemaConfig {
+  name: string;
+  description?: string;
+  schema: JsonObject;
+  strict?: boolean;
+}
+
+type OpenRouterResponseFormat =
+  | { type: "json_schema"; json_schema: OpenRouterJsonSchemaConfig }
+  | { type: "json_object" }
+  | { type: "text" };
+
 interface OpenRouterRequest {
   model: string;
   messages: OpenRouterMessage[];
   tools?: OpenRouterTool[];
   tool_choice?: "auto" | "none" | "required";
-  response_format?: { type: "json_object" | "text" };
+  response_format?: OpenRouterResponseFormat;
   user?: string;
 }
+
+/**
+ * OpenRouter responses we annotate at receive time so downstream stateless
+ * methods (`hasStructuredOutput`, `extractStructuredOutput`) can tell whether
+ * the request asked for native structured output without re-threading the
+ * request.
+ */
+type AnnotatedOpenRouterResponse = OpenRouterResponse & {
+  __jaypieStructuredOutput?: boolean;
+};
 
 //
 //
@@ -116,6 +138,34 @@ interface OpenRouterRequest {
 //
 
 const STRUCTURED_OUTPUT_TOOL_NAME = "structured_output";
+
+const STRUCTURED_OUTPUT_SCHEMA_NAME = "response";
+
+/**
+ * Detect 4xx errors that indicate the model itself does not support
+ * `response_format: json_schema`. Mirrors the Anthropic pattern: we only
+ * trigger the fake-tool fallback when the failure is plausibly a capability
+ * gap, not a generic 400.
+ */
+function isStructuredOutputUnsupportedError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const err = error as {
+    status?: number;
+    statusCode?: number;
+    message?: string;
+    error?: { message?: string };
+  };
+  const status = err.status ?? err.statusCode;
+  if (status !== 400 && status !== 422) return false;
+  const messages = [err.message, err.error?.message].filter(
+    (m): m is string => typeof m === "string",
+  );
+  return messages.some((m) =>
+    /response_format|json[_ ]schema|structured[_ ]output|require[_ ]parameters/i.test(
+      m,
+    ),
+  );
+}
 
 /**
  * OpenRouter content part types (text only - images/files not supported)
@@ -174,6 +224,32 @@ function convertContentToOpenRouter(
 const RETRYABLE_STATUS_CODES = [408, 500, 502, 503, 524, 529];
 const RATE_LIMIT_STATUS_CODE = 429;
 
+/**
+ * Walk the JSON schema and force `additionalProperties: false` on every
+ * object node. Required by the OpenAI-style json_schema response_format
+ * (which OpenRouter accepts) when `strict: true`.
+ */
+function enforceAdditionalPropertiesFalse(schema: JsonObject): void {
+  const stack: JsonObject[] = [schema];
+  while (stack.length > 0) {
+    const node = stack.pop() as JsonObject;
+    if (node.type === "object") {
+      node.additionalProperties = false;
+    }
+    for (const value of Object.values(node)) {
+      if (Array.isArray(value)) {
+        for (const entry of value) {
+          if (entry && typeof entry === "object" && !Array.isArray(entry)) {
+            stack.push(entry as JsonObject);
+          }
+        }
+      } else if (value && typeof value === "object") {
+        stack.push(value as JsonObject);
+      }
+    }
+  }
+}
+
 //
 //
 // Main
@@ -188,6 +264,23 @@ const RATE_LIMIT_STATUS_CODE = 429;
 export class OpenRouterAdapter extends BaseProviderAdapter {
   readonly name = PROVIDER.OPENROUTER.NAME;
   readonly defaultModel = PROVIDER.OPENROUTER.MODEL.DEFAULT;
+
+  // Session-level cache of models observed to reject native
+  // `response_format: json_schema`. When a model is in this set, buildRequest
+  // engages the legacy fake-tool path instead of native structured output.
+  private runtimeNoStructuredOutputModels = new Set<string>();
+
+  rememberModelRejectsStructuredOutput(model: string): void {
+    this.runtimeNoStructuredOutputModels.add(model);
+  }
+
+  clearRuntimeNoStructuredOutputModels(): void {
+    this.runtimeNoStructuredOutputModels.clear();
+  }
+
+  private supportsStructuredOutput(model: string): boolean {
+    return !this.runtimeNoStructuredOutputModels.has(model);
+  }
 
   //
   // Request Building
@@ -217,8 +310,29 @@ export class OpenRouterAdapter extends BaseProviderAdapter {
       openRouterRequest.user = request.user;
     }
 
-    if (request.tools && request.tools.length > 0) {
-      openRouterRequest.tools = request.tools.map((tool) => ({
+    const useFallbackStructuredOutput =
+      Boolean(request.format) &&
+      !this.supportsStructuredOutput(openRouterRequest.model);
+
+    const allTools: ProviderToolDefinition[] = request.tools
+      ? [...request.tools]
+      : [];
+    if (useFallbackStructuredOutput && request.format) {
+      log.warn(
+        `[OpenRouterAdapter] Using legacy structured_output tool fallback for model ${openRouterRequest.model}; native response_format previously rejected for this model.`,
+      );
+      allTools.push({
+        name: STRUCTURED_OUTPUT_TOOL_NAME,
+        description:
+          "REQUIRED: You MUST call this tool to provide your final response. " +
+          "After gathering all necessary information (including results from other tools), " +
+          "call this tool with the structured data to complete the request.",
+        parameters: request.format,
+      });
+    }
+
+    if (allTools.length > 0) {
+      openRouterRequest.tools = allTools.map((tool) => ({
         type: "function" as const,
         function: {
           name: tool.name,
@@ -230,6 +344,20 @@ export class OpenRouterAdapter extends BaseProviderAdapter {
       // Use "auto" for tool_choice - many OpenRouter models don't support "required"
       // The structured_output tool prompt already emphasizes it must be called
       openRouterRequest.tool_choice = "auto";
+    }
+
+    // Native structured output: send schema as `response_format`. The legacy
+    // tool-emulation path is engaged only as a runtime fallback for models the
+    // API has flagged as not supporting native json_schema.
+    if (request.format && !useFallbackStructuredOutput) {
+      openRouterRequest.response_format = {
+        type: "json_schema",
+        json_schema: {
+          name: STRUCTURED_OUTPUT_SCHEMA_NAME,
+          schema: request.format,
+          strict: true,
+        },
+      };
     }
 
     if (request.providerOptions) {
@@ -247,28 +375,18 @@ export class OpenRouterAdapter extends BaseProviderAdapter {
 
   formatTools(
     toolkit: Toolkit,
-    outputSchema?: JsonObject,
+    // outputSchema is part of the interface contract but OpenRouter now uses
+    // native `response_format` (set in buildRequest), so we no longer inject a
+    // synthetic structured-output tool here. The legacy fake-tool injection
+    // happens in buildRequest only as a runtime fallback.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _outputSchema?: JsonObject,
   ): ProviderToolDefinition[] {
-    const tools: ProviderToolDefinition[] = toolkit.tools.map((tool) => ({
+    return toolkit.tools.map((tool) => ({
       name: tool.name,
       description: tool.description,
       parameters: tool.parameters as JsonObject,
     }));
-
-    // Add structured output tool if schema is provided
-    // (OpenRouter doesn't have native structured output like OpenAI, so use tool approach)
-    if (outputSchema) {
-      tools.push({
-        name: STRUCTURED_OUTPUT_TOOL_NAME,
-        description:
-          "REQUIRED: You MUST call this tool to provide your final response. " +
-          "After gathering all necessary information (including results from other tools), " +
-          "call this tool with the structured data to complete the request.",
-        parameters: outputSchema,
-      });
-    }
-
-    return tools;
   }
 
   formatOutputSchema(
@@ -299,6 +417,10 @@ export class OpenRouterAdapter extends BaseProviderAdapter {
       delete jsonSchema.$schema;
     }
 
+    // OpenRouter (and most backends behind it) require additionalProperties:
+    // false on every object when using strict json_schema response_format.
+    enforceAdditionalPropertiesFalse(jsonSchema);
+
     return jsonSchema;
   }
 
@@ -313,28 +435,110 @@ export class OpenRouterAdapter extends BaseProviderAdapter {
   ): Promise<OpenRouterResponse> {
     const openRouter = client as OpenRouter;
     const openRouterRequest = request as OpenRouterRequest;
+    const wantsStructuredOutput = Boolean(openRouterRequest.response_format);
 
     try {
-      const response = await openRouter.chat.send(
-        {
-          model: openRouterRequest.model,
-          messages: openRouterRequest.messages as Parameters<
-            typeof openRouter.chat.send
-          >[0]["messages"],
-          tools: openRouterRequest.tools as Parameters<
-            typeof openRouter.chat.send
-          >[0]["tools"],
-          toolChoice: openRouterRequest.tool_choice,
-          user: openRouterRequest.user,
-        },
+      const response = (await openRouter.chat.send(
+        this.toSdkChatParams(openRouterRequest) as Parameters<
+          typeof openRouter.chat.send
+        >[0],
         signal ? { signal } : undefined,
-      );
-
-      return response as unknown as OpenRouterResponse;
+      )) as AnnotatedOpenRouterResponse;
+      if (wantsStructuredOutput) {
+        response.__jaypieStructuredOutput = true;
+      }
+      return response;
     } catch (error) {
       if (signal?.aborted) return undefined as unknown as OpenRouterResponse;
+
+      // If the model rejected `response_format`, cache it and retry with the
+      // legacy fake-tool emulation path.
+      if (wantsStructuredOutput && isStructuredOutputUnsupportedError(error)) {
+        const model = openRouterRequest.model;
+        this.rememberModelRejectsStructuredOutput(model);
+        log.warn(
+          `[OpenRouterAdapter] Model ${model} rejected native response_format; falling back to legacy structured_output tool emulation.`,
+        );
+        const fallbackRequest =
+          this.toFallbackStructuredOutputRequest(openRouterRequest);
+        return (await openRouter.chat.send(
+          this.toSdkChatParams(fallbackRequest) as Parameters<
+            typeof openRouter.chat.send
+          >[0],
+          signal ? { signal } : undefined,
+        )) as OpenRouterResponse;
+      }
+
       throw error;
     }
+  }
+
+  /**
+   * Translate our internal snake_case `OpenRouterRequest` into the SDK's
+   * camelCase shape, forwarding only the fields we care about (the SDK
+   * silently strips unknown fields).
+   */
+  private toSdkChatParams(
+    openRouterRequest: OpenRouterRequest,
+  ): Record<string, unknown> {
+    const params: Record<string, unknown> = {
+      model: openRouterRequest.model,
+      messages: openRouterRequest.messages,
+      tools: openRouterRequest.tools,
+      toolChoice: openRouterRequest.tool_choice,
+      user: openRouterRequest.user,
+    };
+    if (openRouterRequest.response_format) {
+      const format = openRouterRequest.response_format;
+      if (format.type === "json_schema") {
+        params.responseFormat = {
+          type: "json_schema",
+          jsonSchema: format.json_schema,
+        };
+      } else {
+        params.responseFormat = format;
+      }
+    }
+    const temperature = (
+      openRouterRequest as unknown as { temperature?: number }
+    ).temperature;
+    if (temperature !== undefined) {
+      params.temperature = temperature;
+    }
+    return params;
+  }
+
+  /**
+   * Rebuild a structured-output request without `response_format`, swapping in
+   * the legacy fake-tool emulation. Used as a runtime fallback when a model
+   * rejects native json_schema.
+   */
+  private toFallbackStructuredOutputRequest(
+    request: OpenRouterRequest,
+  ): OpenRouterRequest {
+    if (
+      !request.response_format ||
+      request.response_format.type !== "json_schema"
+    ) {
+      return request;
+    }
+    const { response_format, ...rest } = request;
+    const fallbackRequest: OpenRouterRequest = { ...rest };
+    const schema = response_format.json_schema.schema;
+    const fakeTool: OpenRouterTool = {
+      type: "function" as const,
+      function: {
+        name: STRUCTURED_OUTPUT_TOOL_NAME,
+        description:
+          "REQUIRED: You MUST call this tool to provide your final response. " +
+          "After gathering all necessary information (including results from other tools), " +
+          "call this tool with the structured data to complete the request.",
+        parameters: schema,
+      },
+    };
+    fallbackRequest.tools = [...(fallbackRequest.tools ?? []), fakeTool];
+    fallbackRequest.tool_choice = "auto";
+    return fallbackRequest;
   }
 
   async *executeStreamRequest(
@@ -345,22 +549,18 @@ export class OpenRouterAdapter extends BaseProviderAdapter {
     const openRouter = client as OpenRouter;
     const openRouterRequest = request as OpenRouterRequest;
 
-    // Use chat.send with stream: true for streaming responses
-    const stream = await openRouter.chat.send(
-      {
-        model: openRouterRequest.model,
-        messages: openRouterRequest.messages as Parameters<
-          typeof openRouter.chat.send
-        >[0]["messages"],
-        tools: openRouterRequest.tools as Parameters<
-          typeof openRouter.chat.send
-        >[0]["tools"],
-        toolChoice: openRouterRequest.tool_choice,
-        user: openRouterRequest.user,
-        stream: true,
-      },
+    // Use chat.send with stream: true for streaming responses.
+    // Cast the result to AsyncIterable: when stream: true, the SDK returns a
+    // stream we can iterate, but the typed result is the union with the
+    // non-stream response.
+    const streamParams = {
+      ...this.toSdkChatParams(openRouterRequest),
+      stream: true,
+    };
+    const stream = (await openRouter.chat.send(
+      streamParams as Parameters<typeof openRouter.chat.send>[0],
       signal ? { signal } : undefined,
-    );
+    )) as AsyncIterable<unknown>;
 
     // Track current tool call being built
     let currentToolCall: {
@@ -722,7 +922,16 @@ export class OpenRouterAdapter extends BaseProviderAdapter {
   }
 
   override hasStructuredOutput(response: unknown): boolean {
-    const openRouterResponse = response as OpenRouterResponse;
+    const openRouterResponse = response as AnnotatedOpenRouterResponse;
+
+    // Native path: executeRequest annotates the response when we sent
+    // `response_format`, so we can detect intent statelessly.
+    if (openRouterResponse.__jaypieStructuredOutput) {
+      return this.extractStructuredOutput(response) !== undefined;
+    }
+
+    // Fallback path: legacy fake-tool emulation, kept for models that the
+    // runtime has cached as not supporting native `response_format`.
     const choice = openRouterResponse.choices[0];
 
     // SDK returns camelCase (toolCalls)
@@ -737,7 +946,22 @@ export class OpenRouterAdapter extends BaseProviderAdapter {
   }
 
   override extractStructuredOutput(response: unknown): JsonObject | undefined {
-    const openRouterResponse = response as OpenRouterResponse;
+    const openRouterResponse = response as AnnotatedOpenRouterResponse;
+
+    if (openRouterResponse.__jaypieStructuredOutput) {
+      const choice = openRouterResponse.choices[0];
+      const content = choice?.message?.content;
+      if (typeof content !== "string" || content.length === 0) {
+        return undefined;
+      }
+      try {
+        return JSON.parse(content) as JsonObject;
+      } catch {
+        return undefined;
+      }
+    }
+
+    // Fallback path: legacy fake-tool emulation
     const choice = openRouterResponse.choices[0];
 
     // SDK returns camelCase (toolCalls)

--- a/packages/llm/src/operate/adapters/__tests__/AnthropicAdapter.spec.ts
+++ b/packages/llm/src/operate/adapters/__tests__/AnthropicAdapter.spec.ts
@@ -438,7 +438,7 @@ describe("AnthropicAdapter", () => {
       });
 
       it("does not inject a structured_output tool when schema provided", () => {
-        // Native output_format replaces the legacy fake-tool injection.
+        // Native output_config.format replaces the legacy fake-tool injection.
         const toolkit = new Toolkit([
           {
             name: "test",
@@ -617,7 +617,7 @@ describe("AnthropicAdapter", () => {
     });
 
     describe("hasStructuredOutput", () => {
-      it("returns true when native output_format response is annotated", () => {
+      it("returns true when native output_config response is annotated", () => {
         const response = {
           __jaypieStructuredOutput: true,
           content: [{ type: "text", text: '{"name":"John"}' }],
@@ -677,7 +677,7 @@ describe("AnthropicAdapter", () => {
     });
 
     describe("extractStructuredOutput", () => {
-      it("parses JSON from native output_format text block", () => {
+      it("parses JSON from native output_config text block", () => {
         const response = {
           __jaypieStructuredOutput: true,
           content: [{ type: "text", text: '{"name":"John","age":30}' }],
@@ -1061,13 +1061,13 @@ describe("AnthropicAdapter", () => {
       anthropicAdapter.clearRuntimeNoStructuredOutputModels();
     });
 
-    it("retries with fake-tool emulation when output_format is rejected", async () => {
+    it("retries with fake-tool emulation when output_config is rejected", async () => {
       const { BadRequestError } = await import("@anthropic-ai/sdk");
       // @ts-expect-error Mock doesn't require constructor args
       const error = new BadRequestError();
       (error as unknown as { status: number }).status = 400;
       error.message =
-        '400 {"type":"error","error":{"type":"invalid_request_error","message":"`output_format` is not supported by this model."}}';
+        '400 {"type":"error","error":{"type":"invalid_request_error","message":"`output_config` is not supported by this model."}}';
 
       const successResponse = {
         content: [
@@ -1084,16 +1084,20 @@ describe("AnthropicAdapter", () => {
       const mockCreate = vi.fn();
       mockCreate.mockRejectedValueOnce(error as unknown as Error);
       mockCreate.mockResolvedValueOnce(successResponse);
-      const mockClient = { messages: { create: mockCreate } };
+      const mockClient = {
+        messages: { create: mockCreate },
+      };
 
       const request = {
         model: "claude-old-3",
         messages: [{ role: "user", content: "Hi" }],
         max_tokens: 1024,
         stream: false,
-        output_format: {
-          type: "json_schema",
-          schema: { type: "object", properties: {} },
+        output_config: {
+          format: {
+            type: "json_schema",
+            schema: { type: "object", properties: {} },
+          },
         },
       };
 
@@ -1103,11 +1107,11 @@ describe("AnthropicAdapter", () => {
       expect(mockCreate).toHaveBeenCalledTimes(2);
 
       const fallbackBody = mockCreate.mock.calls[1][0] as {
-        output_format?: unknown;
+        output_config?: unknown;
         tools?: { name: string }[];
         tool_choice?: { type: string };
       };
-      expect(fallbackBody.output_format).toBeUndefined();
+      expect(fallbackBody.output_config).toBeUndefined();
       expect(
         fallbackBody.tools?.some((t) => t.name === "structured_output"),
       ).toBe(true);
@@ -1119,7 +1123,7 @@ describe("AnthropicAdapter", () => {
       // @ts-expect-error Mock doesn't require constructor args
       const error = new BadRequestError();
       (error as unknown as { status: number }).status = 400;
-      error.message = "output_format is not supported";
+      error.message = "output_config is not supported";
 
       const mockCreate = vi.fn();
       mockCreate.mockRejectedValueOnce(error as unknown as Error);
@@ -1135,16 +1139,20 @@ describe("AnthropicAdapter", () => {
         stop_reason: "tool_use",
         usage: { input_tokens: 1, output_tokens: 1 },
       });
-      const mockClient = { messages: { create: mockCreate } };
+      const mockClient = {
+        messages: { create: mockCreate },
+      };
 
       await anthropicAdapter.executeRequest(mockClient, {
         model: "claude-legacy",
         messages: [],
         max_tokens: 1024,
         stream: false,
-        output_format: {
-          type: "json_schema",
-          schema: { type: "object", properties: {} },
+        output_config: {
+          format: {
+            type: "json_schema",
+            schema: { type: "object", properties: {} },
+          },
         },
       });
 
@@ -1155,11 +1163,11 @@ describe("AnthropicAdapter", () => {
       });
 
       const builtTyped = built as unknown as {
-        output_format?: unknown;
+        output_config?: unknown;
         tools?: { name: string }[];
         tool_choice?: { type: string };
       };
-      expect(builtTyped.output_format).toBeUndefined();
+      expect(builtTyped.output_config).toBeUndefined();
       expect(
         builtTyped.tools?.some((t) => t.name === "structured_output"),
       ).toBe(true);
@@ -1172,11 +1180,13 @@ describe("AnthropicAdapter", () => {
       const error = new BadRequestError();
       (error as unknown as { status: number }).status = 400;
       error.message =
-        "output_format is incompatible with citations enabled on this request";
+        "output_config is incompatible with citations enabled on this request";
 
       const mockCreate = vi.fn();
       mockCreate.mockRejectedValue(error as unknown as Error);
-      const mockClient = { messages: { create: mockCreate } };
+      const mockClient = {
+        messages: { create: mockCreate },
+      };
 
       let thrown: unknown;
       try {
@@ -1185,9 +1195,11 @@ describe("AnthropicAdapter", () => {
           messages: [],
           max_tokens: 1024,
           stream: false,
-          output_format: {
-            type: "json_schema",
-            schema: { type: "object", properties: {} },
+          output_config: {
+            format: {
+              type: "json_schema",
+              schema: { type: "object", properties: {} },
+            },
           },
         });
       } catch (e) {
@@ -1197,16 +1209,23 @@ describe("AnthropicAdapter", () => {
       expect(mockCreate).toHaveBeenCalledTimes(1);
     });
 
-    it("does not fall back when 400 is unrelated to output_format", async () => {
+    it("does not fall back when 400 says output_format is deprecated", async () => {
+      // The API renamed `output_format` to `output_config.format`. If
+      // adapter code somehow sends the old field, the API returns a 400
+      // mentioning "deprecated" — that's a code-path bug and should
+      // propagate, NOT silently engage the fake-tool fallback.
       const { BadRequestError } = await import("@anthropic-ai/sdk");
       // @ts-expect-error Mock doesn't require constructor args
       const error = new BadRequestError();
       (error as unknown as { status: number }).status = 400;
-      error.message = "some other bad-request reason";
+      error.message =
+        "output_format: This field is deprecated. Use 'output_config.format' instead.";
 
       const mockCreate = vi.fn();
       mockCreate.mockRejectedValue(error as unknown as Error);
-      const mockClient = { messages: { create: mockCreate } };
+      const mockClient = {
+        messages: { create: mockCreate },
+      };
 
       let thrown: unknown;
       try {
@@ -1215,9 +1234,45 @@ describe("AnthropicAdapter", () => {
           messages: [],
           max_tokens: 1024,
           stream: false,
-          output_format: {
-            type: "json_schema",
-            schema: { type: "object", properties: {} },
+          output_config: {
+            format: {
+              type: "json_schema",
+              schema: { type: "object", properties: {} },
+            },
+          },
+        });
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown).toBe(error);
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not fall back when 400 is unrelated to structured output", async () => {
+      const { BadRequestError } = await import("@anthropic-ai/sdk");
+      // @ts-expect-error Mock doesn't require constructor args
+      const error = new BadRequestError();
+      (error as unknown as { status: number }).status = 400;
+      error.message = "some other bad-request reason";
+
+      const mockCreate = vi.fn();
+      mockCreate.mockRejectedValue(error as unknown as Error);
+      const mockClient = {
+        messages: { create: mockCreate },
+      };
+
+      let thrown: unknown;
+      try {
+        await anthropicAdapter.executeRequest(mockClient, {
+          model: "claude-opus-4-7",
+          messages: [],
+          max_tokens: 1024,
+          stream: false,
+          output_config: {
+            format: {
+              type: "json_schema",
+              schema: { type: "object", properties: {} },
+            },
           },
         });
       } catch (e) {
@@ -1392,7 +1447,7 @@ describe("AnthropicAdapter", () => {
       expect(result.tool_choice).toEqual({ type: "auto" });
     });
 
-    it("emits output_format when format is provided", () => {
+    it("emits output_config.format when format is provided", () => {
       const request: OperateRequest = {
         model: PROVIDER.ANTHROPIC.MODEL.LARGE,
         messages: [],
@@ -1406,25 +1461,26 @@ describe("AnthropicAdapter", () => {
       const result = anthropicAdapter.buildRequest(request);
 
       const params = result as unknown as {
-        output_format?: {
-          type: string;
-          schema: { type: string };
+        output_config?: {
+          format: { type: string; schema: { type: string } };
         };
         tool_choice?: { type: string };
       };
-      expect(params.output_format).toEqual({
-        type: "json_schema",
-        schema: {
-          type: "object",
-          properties: { name: { type: "string" } },
-          additionalProperties: false,
+      expect(params.output_config).toEqual({
+        format: {
+          type: "json_schema",
+          schema: {
+            type: "object",
+            properties: { name: { type: "string" } },
+            additionalProperties: false,
+          },
         },
       });
       // No tool_choice forced when only structured output is requested
       expect(params.tool_choice).toBeUndefined();
     });
 
-    it("does not emit output_format when format is absent", () => {
+    it("does not emit output_config when format is absent", () => {
       const request: OperateRequest = {
         model: PROVIDER.ANTHROPIC.MODEL.LARGE,
         messages: [],
@@ -1432,8 +1488,8 @@ describe("AnthropicAdapter", () => {
 
       const result = anthropicAdapter.buildRequest(request);
 
-      const params = result as unknown as { output_format?: unknown };
-      expect(params.output_format).toBeUndefined();
+      const params = result as unknown as { output_config?: unknown };
+      expect(params.output_config).toBeUndefined();
     });
   });
 });

--- a/packages/llm/src/operate/adapters/__tests__/AnthropicAdapter.spec.ts
+++ b/packages/llm/src/operate/adapters/__tests__/AnthropicAdapter.spec.ts
@@ -437,7 +437,8 @@ describe("AnthropicAdapter", () => {
         expect(result[0].description).toBe("Test tool");
       });
 
-      it("adds structured output tool when schema provided", () => {
+      it("does not inject a structured_output tool when schema provided", () => {
+        // Native output_format replaces the legacy fake-tool injection.
         const toolkit = new Toolkit([
           {
             name: "test",
@@ -454,8 +455,120 @@ describe("AnthropicAdapter", () => {
 
         const result = anthropicAdapter.formatTools(toolkit, schema);
 
-        expect(result).toHaveLength(2);
-        expect(result[1].name).toBe("structured_output");
+        expect(result).toHaveLength(1);
+        expect(result[0].name).toBe("test");
+      });
+    });
+
+    describe("formatOutputSchema", () => {
+      // Inputs use type:"json_schema" so the adapter skips its Zod path
+      // and runs the input through the sanitizer directly.
+      it("forces additionalProperties:false on objects", () => {
+        const result = anthropicAdapter.formatOutputSchema({
+          type: "json_schema",
+          properties: { name: { type: "string" } },
+        });
+
+        expect(result.additionalProperties).toBe(false);
+      });
+
+      it("strips $schema", () => {
+        const result = anthropicAdapter.formatOutputSchema({
+          $schema: "http://json-schema.org/draft-07/schema#",
+          type: "json_schema",
+          properties: {},
+        });
+
+        expect(result.$schema).toBeUndefined();
+      });
+
+      it("moves unsupported numeric constraints into description", () => {
+        const result = anthropicAdapter.formatOutputSchema({
+          type: "json_schema",
+          properties: {
+            age: { type: "number", minimum: 0, maximum: 120 },
+          },
+        });
+
+        const age = (result.properties as { age: { description?: string } })
+          .age;
+        expect(age.description).toContain("minimum: 0");
+        expect(age.description).toContain("maximum: 120");
+        expect((age as Record<string, unknown>).minimum).toBeUndefined();
+        expect((age as Record<string, unknown>).maximum).toBeUndefined();
+      });
+
+      it("moves minLength and maxLength into description", () => {
+        const result = anthropicAdapter.formatOutputSchema({
+          type: "json_schema",
+          properties: {
+            name: { type: "string", minLength: 1, maxLength: 50 },
+          },
+        });
+
+        const name = (result.properties as { name: { description?: string } })
+          .name;
+        expect(name.description).toContain("minLength: 1");
+        expect(name.description).toContain("maxLength: 50");
+        expect((name as Record<string, unknown>).minLength).toBeUndefined();
+        expect((name as Record<string, unknown>).maxLength).toBeUndefined();
+      });
+
+      it("strips unsupported string formats but keeps supported ones", () => {
+        const result = anthropicAdapter.formatOutputSchema({
+          type: "json_schema",
+          properties: {
+            email: { type: "string", format: "email" },
+            ssn: { type: "string", format: "ssn" },
+          },
+        });
+
+        const props = result.properties as {
+          email: { format?: string };
+          ssn: { format?: string; description?: string };
+        };
+        expect(props.email.format).toBe("email");
+        expect(props.ssn.format).toBeUndefined();
+        expect(props.ssn.description).toContain("ssn");
+      });
+
+      it("passes minItems through only when 0 or 1", () => {
+        const result = anthropicAdapter.formatOutputSchema({
+          type: "json_schema",
+          properties: {
+            tags: { type: "array", items: { type: "string" }, minItems: 1 },
+            badItems: {
+              type: "array",
+              items: { type: "string" },
+              minItems: 5,
+            },
+          },
+        });
+
+        const props = result.properties as {
+          tags: { minItems?: number };
+          badItems: { minItems?: number; description?: string };
+        };
+        expect(props.tags.minItems).toBe(1);
+        expect(props.badItems.minItems).toBeUndefined();
+        expect(props.badItems.description).toContain("minItems: 5");
+      });
+
+      it("converts oneOf to anyOf at nested levels", () => {
+        const result = anthropicAdapter.formatOutputSchema({
+          type: "json_schema",
+          properties: {
+            value: {
+              oneOf: [{ type: "string" }, { type: "number" }],
+            },
+          },
+        });
+
+        const value = result.properties as {
+          value: { anyOf?: unknown; oneOf?: unknown };
+        };
+        expect(value.value.anyOf).toBeDefined();
+        expect(value.value.oneOf).toBeUndefined();
       });
     });
 
@@ -504,21 +617,26 @@ describe("AnthropicAdapter", () => {
     });
 
     describe("hasStructuredOutput", () => {
-      it("returns true when structured_output tool is used", () => {
+      it("returns true when native output_format response is annotated", () => {
         const response = {
-          content: [
-            {
-              type: "tool_use",
-              id: "123",
-              name: "structured_output",
-              input: { key: "value" },
-            },
-          ],
-          stop_reason: "tool_use",
+          __jaypieStructuredOutput: true,
+          content: [{ type: "text", text: '{"name":"John"}' }],
+          stop_reason: "end_turn",
           usage: { input_tokens: 10, output_tokens: 20 },
         };
 
         expect(anthropicAdapter.hasStructuredOutput(response)).toBe(true);
+      });
+
+      it("returns false on annotated response with refusal", () => {
+        const response = {
+          __jaypieStructuredOutput: true,
+          content: [{ type: "text", text: "I cannot help with that." }],
+          stop_reason: "refusal",
+          usage: { input_tokens: 10, output_tokens: 20 },
+        };
+
+        expect(anthropicAdapter.hasStructuredOutput(response)).toBe(false);
       });
 
       it("returns false for regular tool use", () => {
@@ -537,26 +655,79 @@ describe("AnthropicAdapter", () => {
 
         expect(anthropicAdapter.hasStructuredOutput(response)).toBe(false);
       });
+
+      describe("Fallback Path", () => {
+        it("returns true when legacy structured_output tool is used", () => {
+          const response = {
+            content: [
+              {
+                type: "tool_use",
+                id: "123",
+                name: "structured_output",
+                input: { key: "value" },
+              },
+            ],
+            stop_reason: "tool_use",
+            usage: { input_tokens: 10, output_tokens: 20 },
+          };
+
+          expect(anthropicAdapter.hasStructuredOutput(response)).toBe(true);
+        });
+      });
     });
 
     describe("extractStructuredOutput", () => {
-      it("extracts structured output from response", () => {
+      it("parses JSON from native output_format text block", () => {
         const response = {
-          content: [
-            {
-              type: "tool_use",
-              id: "123",
-              name: "structured_output",
-              input: { name: "John", age: 30 },
-            },
-          ],
-          stop_reason: "tool_use",
+          __jaypieStructuredOutput: true,
+          content: [{ type: "text", text: '{"name":"John","age":30}' }],
+          stop_reason: "end_turn",
           usage: { input_tokens: 10, output_tokens: 20 },
         };
 
-        const result = anthropicAdapter.extractStructuredOutput(response);
+        expect(anthropicAdapter.extractStructuredOutput(response)).toEqual({
+          name: "John",
+          age: 30,
+        });
+      });
 
-        expect(result).toEqual({ name: "John", age: 30 });
+      it("returns undefined when stop_reason is refusal", () => {
+        const response = {
+          __jaypieStructuredOutput: true,
+          content: [{ type: "text", text: "I cannot help with that." }],
+          stop_reason: "refusal",
+          usage: { input_tokens: 10, output_tokens: 20 },
+        };
+
+        expect(
+          anthropicAdapter.extractStructuredOutput(response),
+        ).toBeUndefined();
+      });
+
+      it("returns undefined when stop_reason is max_tokens", () => {
+        const response = {
+          __jaypieStructuredOutput: true,
+          content: [{ type: "text", text: '{"partial":' }],
+          stop_reason: "max_tokens",
+          usage: { input_tokens: 10, output_tokens: 20 },
+        };
+
+        expect(
+          anthropicAdapter.extractStructuredOutput(response),
+        ).toBeUndefined();
+      });
+
+      it("returns undefined on annotated response with invalid JSON", () => {
+        const response = {
+          __jaypieStructuredOutput: true,
+          content: [{ type: "text", text: "not json" }],
+          stop_reason: "end_turn",
+          usage: { input_tokens: 10, output_tokens: 20 },
+        };
+
+        expect(
+          anthropicAdapter.extractStructuredOutput(response),
+        ).toBeUndefined();
       });
 
       it("returns undefined for non-structured responses", () => {
@@ -569,6 +740,28 @@ describe("AnthropicAdapter", () => {
         const result = anthropicAdapter.extractStructuredOutput(response);
 
         expect(result).toBeUndefined();
+      });
+
+      describe("Fallback Path", () => {
+        it("extracts structured output from legacy tool_use block", () => {
+          const response = {
+            content: [
+              {
+                type: "tool_use",
+                id: "123",
+                name: "structured_output",
+                input: { name: "John", age: 30 },
+              },
+            ],
+            stop_reason: "tool_use",
+            usage: { input_tokens: 10, output_tokens: 20 },
+          };
+
+          expect(anthropicAdapter.extractStructuredOutput(response)).toEqual({
+            name: "John",
+            age: 30,
+          });
+        });
       });
     });
 
@@ -863,6 +1056,178 @@ describe("AnthropicAdapter", () => {
     });
   });
 
+  describe("Structured-output fallback", () => {
+    beforeEach(() => {
+      anthropicAdapter.clearRuntimeNoStructuredOutputModels();
+    });
+
+    it("retries with fake-tool emulation when output_format is rejected", async () => {
+      const { BadRequestError } = await import("@anthropic-ai/sdk");
+      // @ts-expect-error Mock doesn't require constructor args
+      const error = new BadRequestError();
+      (error as unknown as { status: number }).status = 400;
+      error.message =
+        '400 {"type":"error","error":{"type":"invalid_request_error","message":"`output_format` is not supported by this model."}}';
+
+      const successResponse = {
+        content: [
+          {
+            type: "tool_use",
+            id: "abc",
+            name: "structured_output",
+            input: { ok: true },
+          },
+        ],
+        stop_reason: "tool_use",
+        usage: { input_tokens: 1, output_tokens: 1 },
+      };
+      const mockCreate = vi.fn();
+      mockCreate.mockRejectedValueOnce(error as unknown as Error);
+      mockCreate.mockResolvedValueOnce(successResponse);
+      const mockClient = { messages: { create: mockCreate } };
+
+      const request = {
+        model: "claude-old-3",
+        messages: [{ role: "user", content: "Hi" }],
+        max_tokens: 1024,
+        stream: false,
+        output_format: {
+          type: "json_schema",
+          schema: { type: "object", properties: {} },
+        },
+      };
+
+      const result = await anthropicAdapter.executeRequest(mockClient, request);
+
+      expect(result as unknown).toBe(successResponse);
+      expect(mockCreate).toHaveBeenCalledTimes(2);
+
+      const fallbackBody = mockCreate.mock.calls[1][0] as {
+        output_format?: unknown;
+        tools?: { name: string }[];
+        tool_choice?: { type: string };
+      };
+      expect(fallbackBody.output_format).toBeUndefined();
+      expect(
+        fallbackBody.tools?.some((t) => t.name === "structured_output"),
+      ).toBe(true);
+      expect(fallbackBody.tool_choice).toEqual({ type: "any" });
+    });
+
+    it("caches the model so subsequent buildRequest uses fake-tool path", async () => {
+      const { BadRequestError } = await import("@anthropic-ai/sdk");
+      // @ts-expect-error Mock doesn't require constructor args
+      const error = new BadRequestError();
+      (error as unknown as { status: number }).status = 400;
+      error.message = "output_format is not supported";
+
+      const mockCreate = vi.fn();
+      mockCreate.mockRejectedValueOnce(error as unknown as Error);
+      mockCreate.mockResolvedValueOnce({
+        content: [
+          {
+            type: "tool_use",
+            id: "x",
+            name: "structured_output",
+            input: {},
+          },
+        ],
+        stop_reason: "tool_use",
+        usage: { input_tokens: 1, output_tokens: 1 },
+      });
+      const mockClient = { messages: { create: mockCreate } };
+
+      await anthropicAdapter.executeRequest(mockClient, {
+        model: "claude-legacy",
+        messages: [],
+        max_tokens: 1024,
+        stream: false,
+        output_format: {
+          type: "json_schema",
+          schema: { type: "object", properties: {} },
+        },
+      });
+
+      const built = anthropicAdapter.buildRequest({
+        model: "claude-legacy",
+        messages: [],
+        format: { type: "object", properties: {} },
+      });
+
+      const builtTyped = built as unknown as {
+        output_format?: unknown;
+        tools?: { name: string }[];
+        tool_choice?: { type: string };
+      };
+      expect(builtTyped.output_format).toBeUndefined();
+      expect(
+        builtTyped.tools?.some((t) => t.name === "structured_output"),
+      ).toBe(true);
+      expect(builtTyped.tool_choice).toEqual({ type: "any" });
+    });
+
+    it("does not fall back when 400 mentions citations", async () => {
+      const { BadRequestError } = await import("@anthropic-ai/sdk");
+      // @ts-expect-error Mock doesn't require constructor args
+      const error = new BadRequestError();
+      (error as unknown as { status: number }).status = 400;
+      error.message =
+        "output_format is incompatible with citations enabled on this request";
+
+      const mockCreate = vi.fn();
+      mockCreate.mockRejectedValue(error as unknown as Error);
+      const mockClient = { messages: { create: mockCreate } };
+
+      let thrown: unknown;
+      try {
+        await anthropicAdapter.executeRequest(mockClient, {
+          model: "claude-opus-4-7",
+          messages: [],
+          max_tokens: 1024,
+          stream: false,
+          output_format: {
+            type: "json_schema",
+            schema: { type: "object", properties: {} },
+          },
+        });
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown).toBe(error);
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not fall back when 400 is unrelated to output_format", async () => {
+      const { BadRequestError } = await import("@anthropic-ai/sdk");
+      // @ts-expect-error Mock doesn't require constructor args
+      const error = new BadRequestError();
+      (error as unknown as { status: number }).status = 400;
+      error.message = "some other bad-request reason";
+
+      const mockCreate = vi.fn();
+      mockCreate.mockRejectedValue(error as unknown as Error);
+      const mockClient = { messages: { create: mockCreate } };
+
+      let thrown: unknown;
+      try {
+        await anthropicAdapter.executeRequest(mockClient, {
+          model: "claude-opus-4-7",
+          messages: [],
+          max_tokens: 1024,
+          stream: false,
+          output_format: {
+            type: "json_schema",
+            schema: { type: "object", properties: {} },
+          },
+        });
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown).toBe(error);
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+    });
+  });
+
   // Specific Scenarios
   describe("Specific Scenarios", () => {
     it("uses default model when not specified", () => {
@@ -1009,14 +1374,14 @@ describe("AnthropicAdapter", () => {
       });
     });
 
-    it("sets tool_choice to any when structured output tool present", () => {
+    it("uses tool_choice:auto for real tools", () => {
       const request: OperateRequest = {
         model: PROVIDER.ANTHROPIC.MODEL.LARGE,
         messages: [],
         tools: [
           {
-            name: "structured_output",
-            description: "Structured output",
+            name: "search",
+            description: "Search",
             parameters: { type: "object" },
           },
         ],
@@ -1024,7 +1389,51 @@ describe("AnthropicAdapter", () => {
 
       const result = anthropicAdapter.buildRequest(request);
 
-      expect(result.tool_choice).toEqual({ type: "any" });
+      expect(result.tool_choice).toEqual({ type: "auto" });
+    });
+
+    it("emits output_format when format is provided", () => {
+      const request: OperateRequest = {
+        model: PROVIDER.ANTHROPIC.MODEL.LARGE,
+        messages: [],
+        format: {
+          type: "object",
+          properties: { name: { type: "string" } },
+          additionalProperties: false,
+        },
+      };
+
+      const result = anthropicAdapter.buildRequest(request);
+
+      const params = result as unknown as {
+        output_format?: {
+          type: string;
+          schema: { type: string };
+        };
+        tool_choice?: { type: string };
+      };
+      expect(params.output_format).toEqual({
+        type: "json_schema",
+        schema: {
+          type: "object",
+          properties: { name: { type: "string" } },
+          additionalProperties: false,
+        },
+      });
+      // No tool_choice forced when only structured output is requested
+      expect(params.tool_choice).toBeUndefined();
+    });
+
+    it("does not emit output_format when format is absent", () => {
+      const request: OperateRequest = {
+        model: PROVIDER.ANTHROPIC.MODEL.LARGE,
+        messages: [],
+      };
+
+      const result = anthropicAdapter.buildRequest(request);
+
+      const params = result as unknown as { output_format?: unknown };
+      expect(params.output_format).toBeUndefined();
     });
   });
 });

--- a/packages/llm/src/operate/adapters/__tests__/GeminiAdapter.spec.ts
+++ b/packages/llm/src/operate/adapters/__tests__/GeminiAdapter.spec.ts
@@ -163,6 +163,106 @@ describe("GeminiAdapter", () => {
         expect(result.config?.responseSchema).toBeUndefined();
       });
 
+      it("emits responseJsonSchema with tools on Gemini 3 (native combo)", () => {
+        const adapter = new GeminiAdapter();
+        const schema = {
+          type: "object",
+          properties: { name: { type: "string" } },
+        };
+        const request: OperateRequest = {
+          model: "gemini-3.1-pro-preview",
+          messages: [],
+          format: schema,
+          tools: [
+            {
+              name: "search",
+              description: "Search",
+              parameters: { type: "object" },
+            },
+          ],
+        };
+
+        const result = adapter.buildRequest(request);
+
+        expect(result.config?.responseMimeType).toBe("application/json");
+        expect(result.config?.responseJsonSchema).toEqual(schema);
+        expect(result.config?.tools).toHaveLength(1);
+        const declarations = result.config?.tools?.[0].functionDeclarations;
+        expect(declarations).toHaveLength(1);
+        expect(declarations?.[0].name).toBe("search");
+        // No fake structured_output tool, no nudge in systemInstruction
+        expect(declarations?.some((d) => d.name === "structured_output")).toBe(
+          false,
+        );
+        expect(result.config?.systemInstruction).toBeUndefined();
+      });
+
+      it("falls back to fake tool on Gemini 2.5 when format+tools combined", () => {
+        const adapter = new GeminiAdapter();
+        const schema = {
+          type: "object",
+          properties: { name: { type: "string" } },
+        };
+        const request: OperateRequest = {
+          model: "gemini-2.5-flash",
+          messages: [],
+          format: schema,
+          tools: [
+            {
+              name: "search",
+              description: "Search",
+              parameters: { type: "object" },
+            },
+          ],
+        };
+
+        const result = adapter.buildRequest(request);
+
+        // Native fields are NOT set (fake-tool path)
+        expect(result.config?.responseJsonSchema).toBeUndefined();
+        expect(result.config?.responseSchema).toBeUndefined();
+        expect(result.config?.responseMimeType).toBeUndefined();
+        // Fake tool was injected
+        const declarations = result.config?.tools?.[0].functionDeclarations;
+        expect(declarations).toHaveLength(2);
+        expect(declarations?.some((d) => d.name === "structured_output")).toBe(
+          true,
+        );
+        // System instruction nudge added
+        expect(result.config?.systemInstruction).toContain("structured_output");
+      });
+
+      it("uses fake tool when Gemini 3 model is cached as combo-unsupported", () => {
+        const adapter = new GeminiAdapter();
+        adapter.rememberModelRejectsStructuredOutputCombo(
+          "gemini-3.1-pro-preview",
+        );
+        const schema = {
+          type: "object",
+          properties: { name: { type: "string" } },
+        };
+        const request: OperateRequest = {
+          model: "gemini-3.1-pro-preview",
+          messages: [],
+          format: schema,
+          tools: [
+            {
+              name: "search",
+              description: "Search",
+              parameters: { type: "object" },
+            },
+          ],
+        };
+
+        const result = adapter.buildRequest(request);
+
+        expect(result.config?.responseJsonSchema).toBeUndefined();
+        const declarations = result.config?.tools?.[0].functionDeclarations;
+        expect(declarations?.some((d) => d.name === "structured_output")).toBe(
+          true,
+        );
+      });
+
       it("strips $schema and additionalProperties from responseSchema", () => {
         const request: OperateRequest = {
           model: PROVIDER.GEMINI.MODEL.SMALL,
@@ -381,7 +481,10 @@ describe("GeminiAdapter", () => {
         expect(result[0].description).toBe("Test tool");
       });
 
-      it("adds structured output tool when schema provided", () => {
+      it("does not inject a structured_output tool when schema provided", () => {
+        // Native responseJsonSchema/responseSchema replaces the fake-tool
+        // injection. The legacy fake tool is added only by buildRequest as a
+        // fallback when format+tools is combined on a non-Gemini-3 model.
         const toolkit = new Toolkit([
           {
             name: "test",
@@ -398,8 +501,9 @@ describe("GeminiAdapter", () => {
 
         const result = geminiAdapter.formatTools(toolkit, schema);
 
-        expect(result).toHaveLength(2);
-        expect(result[1].name).toBe("structured_output");
+        expect(result).toHaveLength(1);
+        expect(result[0].name).toBe("test");
+        expect(result.some((t) => t.name === "structured_output")).toBe(false);
       });
     });
 
@@ -965,6 +1069,145 @@ describe("GeminiAdapter", () => {
 
       expect(result.contents[0].role).toBe("user");
       expect(result.contents[0].parts?.[0].functionResponse).toBeDefined();
+    });
+  });
+
+  describe("Structured-output combo fallback", () => {
+    it("retries with fake tool when Gemini 3 model rejects native combo", async () => {
+      const adapter = new GeminiAdapter();
+      const schema = {
+        type: "object",
+        properties: { name: { type: "string" } },
+      };
+      const error = Object.assign(
+        new Error("responseJsonSchema is not supported with tools"),
+        { status: 400 },
+      );
+      const successResponse = {
+        candidates: [
+          {
+            content: {
+              role: "model" as const,
+              parts: [
+                {
+                  functionCall: {
+                    name: "structured_output",
+                    args: { name: "Jane" },
+                  },
+                },
+              ],
+            },
+            finishReason: "STOP",
+          },
+        ],
+        usageMetadata: {
+          promptTokenCount: 5,
+          candidatesTokenCount: 5,
+          totalTokenCount: 10,
+        },
+      };
+      const mockGenerateContent = vi
+        .fn()
+        .mockRejectedValueOnce(error)
+        .mockResolvedValueOnce(successResponse);
+      const mockClient = {
+        models: { generateContent: mockGenerateContent },
+      };
+      const request: OperateRequest = {
+        model: "gemini-3.1-pro-preview",
+        messages: [],
+        format: schema,
+        tools: [
+          {
+            name: "search",
+            description: "Search",
+            parameters: { type: "object" },
+          },
+        ],
+      };
+
+      const built = adapter.buildRequest(request);
+      expect(built.config?.responseJsonSchema).toBeDefined();
+
+      const result = await adapter.executeRequest(mockClient, built);
+
+      expect(mockGenerateContent).toHaveBeenCalledTimes(2);
+      const fallbackConfig = mockGenerateContent.mock.calls[1][0].config;
+      expect(fallbackConfig.responseJsonSchema).toBeUndefined();
+      expect(fallbackConfig.responseMimeType).toBeUndefined();
+      const declarations = fallbackConfig.tools?.[0].functionDeclarations;
+      expect(
+        declarations?.some(
+          (d: { name: string }) => d.name === "structured_output",
+        ),
+      ).toBe(true);
+      expect(fallbackConfig.systemInstruction).toContain("structured_output");
+      expect(result).toBe(successResponse);
+    });
+
+    it("caches the model so subsequent calls use the fake tool up-front", () => {
+      const adapter = new GeminiAdapter();
+      adapter.rememberModelRejectsStructuredOutputCombo(
+        "gemini-3.1-pro-preview",
+      );
+      const schema = {
+        type: "object",
+        properties: { name: { type: "string" } },
+      };
+      const request: OperateRequest = {
+        model: "gemini-3.1-pro-preview",
+        messages: [],
+        format: schema,
+        tools: [
+          {
+            name: "search",
+            description: "Search",
+            parameters: { type: "object" },
+          },
+        ],
+      };
+
+      const built = adapter.buildRequest(request);
+
+      expect(built.config?.responseJsonSchema).toBeUndefined();
+      const declarations = built.config?.tools?.[0].functionDeclarations;
+      expect(declarations?.some((d) => d.name === "structured_output")).toBe(
+        true,
+      );
+    });
+
+    it("does not retry on unrelated 400 errors", async () => {
+      const adapter = new GeminiAdapter();
+      const schema = {
+        type: "object",
+        properties: { name: { type: "string" } },
+      };
+      const error = Object.assign(new Error("invalid api key"), {
+        status: 400,
+      });
+      const mockGenerateContent = vi.fn().mockRejectedValue(error);
+      const mockClient = {
+        models: { generateContent: mockGenerateContent },
+      };
+      const request: OperateRequest = {
+        model: "gemini-3.1-pro-preview",
+        messages: [],
+        format: schema,
+        tools: [
+          {
+            name: "search",
+            description: "Search",
+            parameters: { type: "object" },
+          },
+        ],
+      };
+
+      const built = adapter.buildRequest(request);
+
+      await expect(adapter.executeRequest(mockClient, built)).rejects.toThrow(
+        "invalid api key",
+      );
+      expect(mockGenerateContent).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/llm/src/operate/adapters/__tests__/OpenRouterAdapter.spec.ts
+++ b/packages/llm/src/operate/adapters/__tests__/OpenRouterAdapter.spec.ts
@@ -183,6 +183,85 @@ describe("OpenRouterAdapter", () => {
         ]);
       });
 
+      it("emits response_format json_schema when format is provided", () => {
+        const adapter = new OpenRouterAdapter();
+        const schema = {
+          type: "object",
+          properties: { name: { type: "string" } },
+        };
+        const request: OperateRequest = {
+          model: PROVIDER.OPENROUTER.MODEL.DEFAULT,
+          messages: [
+            {
+              content: "Hello",
+              role: LlmMessageRole.User,
+              type: LlmMessageType.Message,
+            },
+          ],
+          format: schema,
+        };
+
+        const result = adapter.buildRequest(request);
+
+        expect(result.response_format).toEqual({
+          type: "json_schema",
+          json_schema: {
+            name: "response",
+            schema,
+            strict: true,
+          },
+        });
+        expect(result.tools).toBeUndefined();
+      });
+
+      it("does not emit response_format when format is absent", () => {
+        const request: OperateRequest = {
+          model: PROVIDER.OPENROUTER.MODEL.DEFAULT,
+          messages: [
+            {
+              content: "Hello",
+              role: LlmMessageRole.User,
+              type: LlmMessageType.Message,
+            },
+          ],
+        };
+
+        const result = openRouterAdapter.buildRequest(request);
+
+        expect(result.response_format).toBeUndefined();
+      });
+
+      it("uses legacy structured_output tool when model is cached as unsupported", () => {
+        const adapter = new OpenRouterAdapter();
+        adapter.rememberModelRejectsStructuredOutput(
+          PROVIDER.OPENROUTER.MODEL.DEFAULT,
+        );
+        const schema = {
+          type: "object",
+          properties: { name: { type: "string" } },
+        };
+        const request: OperateRequest = {
+          model: PROVIDER.OPENROUTER.MODEL.DEFAULT,
+          messages: [
+            {
+              content: "Hello",
+              role: LlmMessageRole.User,
+              type: LlmMessageType.Message,
+            },
+          ],
+          format: schema,
+        };
+
+        const result = adapter.buildRequest(request);
+
+        expect(result.response_format).toBeUndefined();
+        expect(result.tools).toBeDefined();
+        expect(
+          result.tools!.some((t) => t.function.name === "structured_output"),
+        ).toBe(true);
+        expect(result.tool_choice).toBe("auto");
+      });
+
       it("handles FunctionCallOutput messages from StreamLoop (issue #165)", () => {
         const request: OperateRequest = {
           model: PROVIDER.OPENROUTER.MODEL.DEFAULT,
@@ -397,7 +476,9 @@ describe("OpenRouterAdapter", () => {
         expect(result[0].description).toBe("Test tool");
       });
 
-      it("adds structured output tool when schema provided", () => {
+      it("does not inject a structured_output tool when schema provided", () => {
+        // Native response_format replaces the fake-tool injection.
+        // The legacy fake tool is only added in buildRequest as a fallback.
         const toolkit = new Toolkit([
           {
             name: "test",
@@ -414,8 +495,9 @@ describe("OpenRouterAdapter", () => {
 
         const result = openRouterAdapter.formatTools(toolkit, schema);
 
-        expect(result).toHaveLength(2);
-        expect(result[1].name).toBe("structured_output");
+        expect(result).toHaveLength(1);
+        expect(result[0].name).toBe("test");
+        expect(result.some((t) => t.name === "structured_output")).toBe(false);
       });
     });
 
@@ -520,50 +602,35 @@ describe("OpenRouterAdapter", () => {
     });
 
     describe("hasStructuredOutput", () => {
-      it("returns true when structured_output tool is used", () => {
+      it("returns true when native annotation is set with parseable JSON content", () => {
         const response = {
           choices: [
             {
               message: {
                 role: "assistant",
-                content: null,
-                toolCalls: [
-                  {
-                    id: "call-123",
-                    type: "function",
-                    function: {
-                      name: "structured_output",
-                      arguments: '{"key":"value"}',
-                    },
-                  },
-                ],
+                content: '{"name":"John"}',
               },
-              finishReason: "toolCalls",
+              finishReason: "stop",
             },
           ],
+          __jaypieStructuredOutput: true,
         };
 
         expect(openRouterAdapter.hasStructuredOutput(response)).toBe(true);
       });
 
-      it("returns false for regular tool use", () => {
+      it("returns false when native annotation is set but content is not JSON", () => {
         const response = {
           choices: [
             {
               message: {
                 role: "assistant",
-                content: null,
-                toolCalls: [
-                  {
-                    id: "call-123",
-                    type: "function",
-                    function: { name: "other_tool", arguments: "{}" },
-                  },
-                ],
+                content: "I cannot comply with that request.",
               },
-              finishReason: "toolCalls",
+              finishReason: "stop",
             },
           ],
+          __jaypieStructuredOutput: true,
         };
 
         expect(openRouterAdapter.hasStructuredOutput(response)).toBe(false);
@@ -584,35 +651,115 @@ describe("OpenRouterAdapter", () => {
 
         expect(openRouterAdapter.hasStructuredOutput(response)).toBe(false);
       });
+
+      describe("Fallback Path", () => {
+        it("returns true when structured_output tool is used", () => {
+          const response = {
+            choices: [
+              {
+                message: {
+                  role: "assistant",
+                  content: null,
+                  toolCalls: [
+                    {
+                      id: "call-123",
+                      type: "function",
+                      function: {
+                        name: "structured_output",
+                        arguments: '{"key":"value"}',
+                      },
+                    },
+                  ],
+                },
+                finishReason: "toolCalls",
+              },
+            ],
+          };
+
+          expect(openRouterAdapter.hasStructuredOutput(response)).toBe(true);
+        });
+
+        it("returns false for regular tool use", () => {
+          const response = {
+            choices: [
+              {
+                message: {
+                  role: "assistant",
+                  content: null,
+                  toolCalls: [
+                    {
+                      id: "call-123",
+                      type: "function",
+                      function: { name: "other_tool", arguments: "{}" },
+                    },
+                  ],
+                },
+                finishReason: "toolCalls",
+              },
+            ],
+          };
+
+          expect(openRouterAdapter.hasStructuredOutput(response)).toBe(false);
+        });
+      });
     });
 
     describe("extractStructuredOutput", () => {
-      it("extracts structured output from response", () => {
+      it("parses message content as JSON when native annotation is set", () => {
         const response = {
           choices: [
             {
               message: {
                 role: "assistant",
-                content: null,
-                toolCalls: [
-                  {
-                    id: "call-123",
-                    type: "function",
-                    function: {
-                      name: "structured_output",
-                      arguments: '{"name":"John","age":30}',
-                    },
-                  },
-                ],
+                content: '{"name":"John","age":30}',
               },
-              finishReason: "toolCalls",
+              finishReason: "stop",
             },
           ],
+          __jaypieStructuredOutput: true,
         };
 
         const result = openRouterAdapter.extractStructuredOutput(response);
 
         expect(result).toEqual({ name: "John", age: 30 });
+      });
+
+      it("returns undefined when native content is not parseable JSON", () => {
+        const response = {
+          choices: [
+            {
+              message: {
+                role: "assistant",
+                content: "not valid json",
+              },
+              finishReason: "stop",
+            },
+          ],
+          __jaypieStructuredOutput: true,
+        };
+
+        const result = openRouterAdapter.extractStructuredOutput(response);
+
+        expect(result).toBeUndefined();
+      });
+
+      it("returns undefined when native content is empty", () => {
+        const response = {
+          choices: [
+            {
+              message: {
+                role: "assistant",
+                content: "",
+              },
+              finishReason: "stop",
+            },
+          ],
+          __jaypieStructuredOutput: true,
+        };
+
+        const result = openRouterAdapter.extractStructuredOutput(response);
+
+        expect(result).toBeUndefined();
       });
 
       it("returns undefined for non-structured responses", () => {
@@ -633,20 +780,96 @@ describe("OpenRouterAdapter", () => {
         expect(result).toBeUndefined();
       });
 
-      it("returns undefined for invalid JSON", () => {
-        const response = {
+      describe("Fallback Path", () => {
+        it("extracts structured output from response", () => {
+          const response = {
+            choices: [
+              {
+                message: {
+                  role: "assistant",
+                  content: null,
+                  toolCalls: [
+                    {
+                      id: "call-123",
+                      type: "function",
+                      function: {
+                        name: "structured_output",
+                        arguments: '{"name":"John","age":30}',
+                      },
+                    },
+                  ],
+                },
+                finishReason: "toolCalls",
+              },
+            ],
+          };
+
+          const result = openRouterAdapter.extractStructuredOutput(response);
+
+          expect(result).toEqual({ name: "John", age: 30 });
+        });
+
+        it("returns undefined for invalid JSON", () => {
+          const response = {
+            choices: [
+              {
+                message: {
+                  role: "assistant",
+                  content: null,
+                  toolCalls: [
+                    {
+                      id: "call-123",
+                      type: "function",
+                      function: {
+                        name: "structured_output",
+                        arguments: "not valid json",
+                      },
+                    },
+                  ],
+                },
+                finishReason: "toolCalls",
+              },
+            ],
+          };
+
+          const result = openRouterAdapter.extractStructuredOutput(response);
+
+          expect(result).toBeUndefined();
+        });
+      });
+    });
+
+    describe("Structured-output fallback", () => {
+      it("retries with fake tool when model rejects native response_format", async () => {
+        const adapter = new OpenRouterAdapter();
+        const schema = {
+          type: "object",
+          properties: { name: { type: "string" } },
+        };
+        const error = Object.assign(
+          new Error("response_format not supported"),
+          {
+            status: 400,
+          },
+        );
+        const successResponse = {
+          id: "resp-1",
+          object: "chat.completion",
+          created: 0,
+          model: PROVIDER.OPENROUTER.MODEL.DEFAULT,
           choices: [
             {
+              index: 0,
               message: {
-                role: "assistant",
+                role: "assistant" as const,
                 content: null,
                 toolCalls: [
                   {
-                    id: "call-123",
-                    type: "function",
+                    id: "call-1",
+                    type: "function" as const,
                     function: {
                       name: "structured_output",
-                      arguments: "not valid json",
+                      arguments: '{"name":"Jane"}',
                     },
                   },
                 ],
@@ -655,10 +878,88 @@ describe("OpenRouterAdapter", () => {
             },
           ],
         };
+        const mockSend = vi
+          .fn()
+          .mockRejectedValueOnce(error)
+          .mockResolvedValueOnce(successResponse);
+        const mockClient = { chat: { send: mockSend } };
+        const request: OperateRequest = {
+          model: PROVIDER.OPENROUTER.MODEL.DEFAULT,
+          messages: [
+            {
+              content: "Hi",
+              role: LlmMessageRole.User,
+              type: LlmMessageType.Message,
+            },
+          ],
+          format: schema,
+        };
 
-        const result = openRouterAdapter.extractStructuredOutput(response);
+        const built = adapter.buildRequest(request);
+        expect(built.response_format).toBeDefined();
 
-        expect(result).toBeUndefined();
+        const result = await adapter.executeRequest(mockClient, built);
+
+        expect(mockSend).toHaveBeenCalledTimes(2);
+        const fallbackCallParams = mockSend.mock.calls[1][0];
+        expect(fallbackCallParams.responseFormat).toBeUndefined();
+        expect(fallbackCallParams.tools).toBeDefined();
+        expect(
+          fallbackCallParams.tools.some(
+            (t: { function: { name: string } }) =>
+              t.function.name === "structured_output",
+          ),
+        ).toBe(true);
+        expect(result).toBe(successResponse);
+      });
+
+      it("caches the model so subsequent calls use the fallback up-front", async () => {
+        const adapter = new OpenRouterAdapter();
+        adapter.rememberModelRejectsStructuredOutput(
+          PROVIDER.OPENROUTER.MODEL.DEFAULT,
+        );
+        const schema = {
+          type: "object",
+          properties: { name: { type: "string" } },
+        };
+        const request: OperateRequest = {
+          model: PROVIDER.OPENROUTER.MODEL.DEFAULT,
+          messages: [],
+          format: schema,
+        };
+
+        const built = adapter.buildRequest(request);
+
+        expect(built.response_format).toBeUndefined();
+        expect(built.tools).toBeDefined();
+        expect(
+          built.tools!.some((t) => t.function.name === "structured_output"),
+        ).toBe(true);
+      });
+
+      it("does not fall back on unrelated 400 errors", async () => {
+        const adapter = new OpenRouterAdapter();
+        const schema = {
+          type: "object",
+          properties: { name: { type: "string" } },
+        };
+        const error = Object.assign(new Error("invalid api key"), {
+          status: 400,
+        });
+        const mockSend = vi.fn().mockRejectedValue(error);
+        const mockClient = { chat: { send: mockSend } };
+        const request: OperateRequest = {
+          model: PROVIDER.OPENROUTER.MODEL.DEFAULT,
+          messages: [],
+          format: schema,
+        };
+
+        const built = adapter.buildRequest(request);
+
+        await expect(adapter.executeRequest(mockClient, built)).rejects.toThrow(
+          "invalid api key",
+        );
+        expect(mockSend).toHaveBeenCalledTimes(1);
       });
     });
 

--- a/packages/llm/src/providers/anthropic/__tests__/AnthropicProvider.spec.ts
+++ b/packages/llm/src/providers/anthropic/__tests__/AnthropicProvider.spec.ts
@@ -243,7 +243,7 @@ describe("AnthropicProvider", () => {
 
   describe("Features", () => {
     describe("Structured Output", () => {
-      it("uses native output_format for structured output", async () => {
+      it("uses native output_config.format for structured output", async () => {
         const mockResponse = {
           stop_reason: "end_turn",
           content: [
@@ -283,12 +283,14 @@ describe("AnthropicProvider", () => {
         });
 
         const call = mockCreate.mock.calls[0][0] as {
-          output_format?: { type: string; schema: { type: string } };
+          output_config?: {
+            format: { type: string; schema: { type: string } };
+          };
           system?: string;
         };
-        expect(call.output_format).toBeDefined();
-        expect(call.output_format?.type).toBe("json_schema");
-        expect(call.output_format?.schema.type).toBe("object");
+        expect(call.output_config).toBeDefined();
+        expect(call.output_config?.format.type).toBe("json_schema");
+        expect(call.output_config?.format.schema.type).toBe("object");
         // No system stuffed by default; user did not provide one
         expect(call.system).toBeUndefined();
       });

--- a/packages/llm/src/providers/anthropic/__tests__/AnthropicProvider.spec.ts
+++ b/packages/llm/src/providers/anthropic/__tests__/AnthropicProvider.spec.ts
@@ -138,6 +138,7 @@ describe("AnthropicProvider", () => {
 
     it("throws error when JSON response does not match schema", async () => {
       const mockResponse = {
+        stop_reason: "end_turn",
         content: [
           {
             type: "text",
@@ -170,7 +171,7 @@ describe("AnthropicProvider", () => {
           response: GreetingFormat,
         }),
       ).rejects.toThrowError(
-        "Failed to parse structured response from Anthropic",
+        "JSON response from Anthropic does not match schema",
       );
     });
   });
@@ -242,8 +243,9 @@ describe("AnthropicProvider", () => {
 
   describe("Features", () => {
     describe("Structured Output", () => {
-      it("uses tool calling for structured output", async () => {
+      it("uses native output_format for structured output", async () => {
         const mockResponse = {
+          stop_reason: "end_turn",
           content: [
             {
               type: "text",
@@ -280,21 +282,21 @@ describe("AnthropicProvider", () => {
           name: "World",
         });
 
-        expect(mockCreate).toHaveBeenCalledWith({
-          messages: [
-            { role: PROVIDER.ANTHROPIC.ROLE.USER, content: "Hello, World" },
-          ],
-          model: expect.any(String),
-          max_tokens: PROVIDER.ANTHROPIC.MAX_TOKENS.DEFAULT,
-          system: expect.any(String),
-        });
+        const call = mockCreate.mock.calls[0][0] as {
+          output_format?: { type: string; schema: { type: string } };
+          system?: string;
+        };
+        expect(call.output_format).toBeDefined();
+        expect(call.output_format?.type).toBe("json_schema");
+        expect(call.output_format?.schema.type).toBe("object");
+        // No system stuffed by default; user did not provide one
+        expect(call.system).toBeUndefined();
       });
 
-      it("throws error when tool call result is not found", async () => {
+      it("throws when text block contains invalid JSON", async () => {
         const mockResponse = {
-          content: [
-            { type: "text", text: "Invalid response without tool call" },
-          ],
+          stop_reason: "end_turn",
+          content: [{ type: "text", text: "Invalid response without JSON" }],
         };
 
         const mockCreate = vi.fn().mockResolvedValue(mockResponse);
@@ -320,6 +322,60 @@ describe("AnthropicProvider", () => {
         ).rejects.toThrowError(
           "Failed to parse structured response from Anthropic",
         );
+      });
+
+      it("throws when stop_reason is refusal", async () => {
+        const mockResponse = {
+          stop_reason: "refusal",
+          content: [{ type: "text", text: "I cannot help with that." }],
+        };
+
+        const mockCreate = vi.fn().mockResolvedValue(mockResponse);
+        vi.mocked(Anthropic).mockImplementation(
+          () =>
+            ({
+              messages: {
+                create: mockCreate,
+              },
+            }) as any,
+        );
+
+        const provider = new AnthropicProvider();
+        const GreetingFormat = z.object({
+          salutation: z.string(),
+          name: z.string(),
+        });
+
+        await expect(
+          provider.send("Hello", { response: GreetingFormat }),
+        ).rejects.toThrowError("refusal");
+      });
+
+      it("throws when stop_reason is max_tokens", async () => {
+        const mockResponse = {
+          stop_reason: "max_tokens",
+          content: [{ type: "text", text: '{"partial":' }],
+        };
+
+        const mockCreate = vi.fn().mockResolvedValue(mockResponse);
+        vi.mocked(Anthropic).mockImplementation(
+          () =>
+            ({
+              messages: {
+                create: mockCreate,
+              },
+            }) as any,
+        );
+
+        const provider = new AnthropicProvider();
+        const GreetingFormat = z.object({
+          salutation: z.string(),
+          name: z.string(),
+        });
+
+        await expect(
+          provider.send("Hello", { response: GreetingFormat }),
+        ).rejects.toThrowError("max_tokens");
       });
 
       it("operate returns structured output with history", async () => {

--- a/packages/llm/src/providers/anthropic/utils.ts
+++ b/packages/llm/src/providers/anthropic/utils.ts
@@ -119,7 +119,8 @@ export async function createTextCompletion(
   return text;
 }
 
-// Structured output completion
+// Structured output completion using Anthropic's native `output_format` field.
+// Returns a JsonObject parsed and validated against the caller's Zod schema.
 export async function createStructuredCompletion(
   client: Anthropic,
   messages: Anthropic.MessageParam[],
@@ -127,66 +128,71 @@ export async function createStructuredCompletion(
   responseSchema: z.ZodType | NaturalSchema,
   systemMessage?: string,
 ): Promise<JsonObject> {
-  log.trace("Using structured output");
+  log.trace("Using native structured output");
 
-  // Get the JSON schema for the response
   const schema =
     responseSchema instanceof z.ZodType
       ? responseSchema
       : naturalZodSchema(responseSchema as NaturalSchema);
 
-  // Set system message with JSON instructions
-  const defaultSystemPrompt =
-    "You will be responding with structured JSON data. " +
-    "Format your entire response as a valid JSON object with the following structure: " +
-    JSON.stringify(z.toJSONSchema(schema));
-
-  const systemPrompt = systemMessage || defaultSystemPrompt;
-
-  try {
-    // Use standard Anthropic API to get response
-    const params: Anthropic.MessageCreateParams = {
-      model,
-      messages,
-      max_tokens: PROVIDER.ANTHROPIC.MAX_TOKENS.DEFAULT,
-      system: systemPrompt,
+  // Type extension: `output_format` is on Beta types in @anthropic-ai/sdk
+  // 0.71 but is accepted by the GA endpoint per Anthropic's docs (the
+  // deprecated beta header is no longer required).
+  type StructuredOutputParams = Anthropic.MessageCreateParams & {
+    output_format?: {
+      type: "json_schema";
+      schema: JsonObject;
     };
+  };
 
-    const response = await client.messages.create(params);
-
-    // Extract text from response
-    const firstContent = response.content[0];
-    const responseText =
-      firstContent && "text" in firstContent ? firstContent.text : "";
-
-    // Find JSON in response
-    const jsonMatch =
-      responseText.match(/```json\s*([\s\S]*?)\s*```/) ||
-      responseText.match(/\{[\s\S]*\}/);
-
-    if (jsonMatch) {
-      try {
-        // Parse the JSON response
-        const jsonStr = jsonMatch[1] || jsonMatch[0];
-        const result = JSON.parse(jsonStr);
-        if (!schema.parse(result)) {
-          throw new Error(
-            `JSON response from Anthropic does not match schema: ${responseText}`,
-          );
-        }
-        log.trace("Received structured response", { result });
-        return result;
-      } catch {
-        throw new Error(
-          `Failed to parse JSON response from Anthropic: ${responseText}`,
-        );
-      }
-    }
-
-    // If we can't extract JSON
-    throw new Error("Failed to parse structured response from Anthropic");
-  } catch (error: unknown) {
-    log.error("Error creating structured completion", { error });
-    throw error;
+  const jsonSchema = z.toJSONSchema(schema) as JsonObject;
+  const params: StructuredOutputParams = {
+    model,
+    messages,
+    max_tokens: PROVIDER.ANTHROPIC.MAX_TOKENS.DEFAULT,
+    output_format: { type: "json_schema", schema: jsonSchema },
+  };
+  if (systemMessage) {
+    params.system = systemMessage;
   }
+
+  const response = (await client.messages.create(
+    params as Anthropic.MessageCreateParams,
+  )) as Anthropic.Message;
+
+  if (response.stop_reason === "refusal") {
+    throw new Error(
+      "Anthropic refused the structured-output request (stop_reason=refusal)",
+    );
+  }
+  if (response.stop_reason === "max_tokens") {
+    throw new Error(
+      "Anthropic structured-output response was truncated (stop_reason=max_tokens); increase max_tokens",
+    );
+  }
+
+  const textBlock = response.content.find(
+    (block): block is Anthropic.TextBlock => block.type === "text",
+  );
+  if (!textBlock) {
+    throw new Error("Failed to parse structured response from Anthropic");
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(textBlock.text);
+  } catch {
+    throw new Error(
+      "Failed to parse structured response from Anthropic: " + textBlock.text,
+    );
+  }
+
+  const validation = schema.safeParse(parsed);
+  if (!validation.success) {
+    throw new Error(
+      `JSON response from Anthropic does not match schema: ${textBlock.text}`,
+    );
+  }
+  log.trace("Received structured response", { result: validation.data });
+  return validation.data as JsonObject;
 }

--- a/packages/llm/src/providers/anthropic/utils.ts
+++ b/packages/llm/src/providers/anthropic/utils.ts
@@ -119,8 +119,9 @@ export async function createTextCompletion(
   return text;
 }
 
-// Structured output completion using Anthropic's native `output_format` field.
-// Returns a JsonObject parsed and validated against the caller's Zod schema.
+// Structured output completion using Anthropic's native `output_config.format`
+// field. Returns a JsonObject parsed and validated against the caller's
+// Zod schema.
 export async function createStructuredCompletion(
   client: Anthropic,
   messages: Anthropic.MessageParam[],
@@ -135,13 +136,15 @@ export async function createStructuredCompletion(
       ? responseSchema
       : naturalZodSchema(responseSchema as NaturalSchema);
 
-  // Type extension: `output_format` is on Beta types in @anthropic-ai/sdk
-  // 0.71 but is accepted by the GA endpoint per Anthropic's docs (the
-  // deprecated beta header is no longer required).
+  // Type extension: SDK 0.71 doesn't type `output_config` on
+  // `MessageCreateParams`. The GA endpoint accepts the field; the older
+  // `output_format` field is now deprecated.
   type StructuredOutputParams = Anthropic.MessageCreateParams & {
-    output_format?: {
-      type: "json_schema";
-      schema: JsonObject;
+    output_config?: {
+      format: {
+        type: "json_schema";
+        schema: JsonObject;
+      };
     };
   };
 
@@ -150,7 +153,9 @@ export async function createStructuredCompletion(
     model,
     messages,
     max_tokens: PROVIDER.ANTHROPIC.MAX_TOKENS.DEFAULT,
-    output_format: { type: "json_schema", schema: jsonSchema },
+    output_config: {
+      format: { type: "json_schema", schema: jsonSchema },
+    },
   };
   if (systemMessage) {
     params.system = systemMessage;

--- a/packages/llm/test/client.ts
+++ b/packages/llm/test/client.ts
@@ -17,8 +17,14 @@ const QUESTION = "Roll five six-sided dice";
 
 async function main(provider: string) {
   try {
-    const model = new Llm(provider as any);
-    console.log(`\n============ Provider: "${provider}"`);
+    const overrideModel = process.env.APP_MODEL;
+    const model = new Llm(
+      provider as any,
+      overrideModel ? { model: overrideModel } : {},
+    );
+    console.log(
+      `\n============ Provider: "${provider}"${overrideModel ? ` (${overrideModel})` : ""}`,
+    );
 
     let toolCalled = false;
     let correctParams = false;

--- a/packages/llm/test/matrix.ts
+++ b/packages/llm/test/matrix.ts
@@ -21,7 +21,8 @@
 // OPENAI_API_KEY, GOOGLE_API_KEY, OPENROUTER_API_KEY, XAI_API_KEY).
 //
 import { config } from "dotenv";
-import { dirname, join } from "path";
+import { existsSync } from "fs";
+import { dirname, join, resolve } from "path";
 import { fileURLToPath } from "url";
 
 import { Llm, LlmOperateInput, toolkit } from "../src/index.js";
@@ -33,9 +34,26 @@ import {
   ModelConfig,
 } from "./models.js";
 
-config();
-
 const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Walk up from this file to find the nearest .env (handles being invoked via
+// `npm run -w packages/llm`, which sets cwd to the package and would
+// otherwise miss the repo-root .env).
+function loadEnv(): void {
+  let dir = __dirname;
+  for (let i = 0; i < 6; i++) {
+    const candidate = join(dir, ".env");
+    if (existsSync(candidate)) {
+      config({ path: candidate });
+      return;
+    }
+    const parent = resolve(dir, "..");
+    if (parent === dir) break;
+    dir = parent;
+  }
+  config();
+}
+loadEnv();
 const PDF_PATH = join(__dirname, "fixtures/page.pdf");
 const IMAGE_PATH = join(__dirname, "fixtures/page.png");
 const REQUIRED_DOC_STRINGS = [

--- a/packages/llm/test/matrix.ts
+++ b/packages/llm/test/matrix.ts
@@ -1,0 +1,459 @@
+/* eslint-disable no-console */
+//
+// Smoke-test matrix: runs each model in `models.ts` through every capability
+// (plain, tools, structured, both, pdf, image) and prints a grid of
+// outcomes. Non-zero exit when any cell mismatches its expected outcome.
+//
+// Usage:
+//   npm run test:matrix -w packages/llm
+//   LOG_LEVEL=warn npm run test:matrix -w packages/llm   # quiet trace/debug
+//   APP_MODELS=claude-sonnet-4-5,gpt-4o npm run test:matrix -w packages/llm
+//   APP_CAPABILITIES=plain,tools npm run test:matrix -w packages/llm
+//
+// Env:
+//   APP_MODELS       comma-separated override for the configured model list
+//   APP_CAPABILITIES comma-separated subset of capabilities to run
+//   APP_USER         user tag forwarded to provider calls
+//   LOG_LEVEL        set to "warn" or higher to silence Jaypie trace/debug
+//
+// This script makes real API calls. It needs the relevant *_API_KEY env vars
+// for whichever providers your model list touches (ANTHROPIC_API_KEY,
+// OPENAI_API_KEY, GOOGLE_API_KEY, OPENROUTER_API_KEY, XAI_API_KEY).
+//
+import { config } from "dotenv";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+import { Llm, LlmOperateInput, toolkit } from "../src/index.js";
+import {
+  CAPABILITIES,
+  Capability,
+  ExpectedOutcome,
+  MODELS,
+  ModelConfig,
+} from "./models.js";
+
+config();
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PDF_PATH = join(__dirname, "fixtures/page.pdf");
+const IMAGE_PATH = join(__dirname, "fixtures/page.png");
+const REQUIRED_DOC_STRINGS = [
+  "mock page",
+  "intentionally blank",
+  "mit license",
+];
+const USER = process.env.APP_USER || "[matrix] Jaypie User";
+
+//
+//
+// Outcome types
+//
+
+type ActualOutcome = "ok" | "warn" | "skip" | "fail";
+
+interface CellResult {
+  actual: ActualOutcome;
+  expected: ExpectedOutcome;
+  matches: boolean;
+  warnings: string[];
+  detail?: string;
+}
+
+//
+//
+// Warning capture
+//
+
+/**
+ * Run `fn` while capturing anything sent to console.warn (which is what
+ * @jaypie/logger's log.warn ultimately calls). Returns both the result and
+ * the captured warning lines so the matrix can flag fallback paths that
+ * engaged silently.
+ */
+async function captureWarnings<T>(
+  fn: () => Promise<T>,
+): Promise<{ result: T; warnings: string[] }> {
+  const warnings: string[] = [];
+  const original = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(
+      args.map((a) => (typeof a === "string" ? a : String(a))).join(" "),
+    );
+  };
+  try {
+    const result = await fn();
+    return { result, warnings };
+  } finally {
+    console.warn = original;
+  }
+}
+
+//
+//
+// Capability runners
+//
+// Each runner returns a CellResult-shaped object minus expected/matches —
+// the matrix runner fills those in based on per-model expectations.
+//
+
+interface CapabilityResult {
+  ok: boolean;
+  detail?: string;
+}
+
+async function runPlain(llm: Llm): Promise<CapabilityResult> {
+  const result = await llm.operate(
+    "Reply with one word: 'pong'. No punctuation.",
+    { user: USER },
+  );
+  if (result.error) return { ok: false, detail: String(result.error) };
+  if (typeof result.content !== "string" || result.content.length === 0) {
+    return {
+      ok: false,
+      detail: `expected non-empty string, got ${typeof result.content}`,
+    };
+  }
+  return { ok: true };
+}
+
+async function runTools(llm: Llm): Promise<CapabilityResult> {
+  let toolCalled = false;
+  const result = await llm.operate("Roll five six-sided dice.", {
+    tools: toolkit,
+    user: USER,
+    hooks: {
+      beforeEachTool: (tool) => {
+        if (tool.toolName === "roll") toolCalled = true;
+      },
+    },
+  });
+  if (result.error) return { ok: false, detail: String(result.error) };
+  if (!toolCalled) return { ok: false, detail: "roll tool was not called" };
+  return { ok: true };
+}
+
+async function runStructured(llm: Llm): Promise<CapabilityResult> {
+  const result = await llm.operate("List exactly three primary colors.", {
+    format: { colors: [String] },
+    user: USER,
+  });
+  if (result.error) return { ok: false, detail: String(result.error) };
+  const content = result.content as { colors?: unknown } | string | undefined;
+  if (!content || typeof content !== "object") {
+    return { ok: false, detail: `expected object, got ${typeof content}` };
+  }
+  if (!Array.isArray(content.colors) || content.colors.length === 0) {
+    return { ok: false, detail: "colors array missing or empty" };
+  }
+  return { ok: true };
+}
+
+async function runBoth(llm: Llm): Promise<CapabilityResult> {
+  let toolCalled = false;
+  const result = await llm.operate(
+    "Roll five six-sided dice and return the rolls and total.",
+    {
+      tools: toolkit,
+      format: { values: String, total: Number },
+      user: USER,
+      hooks: {
+        beforeEachTool: (tool) => {
+          if (tool.toolName === "roll") toolCalled = true;
+        },
+      },
+    },
+  );
+  if (result.error) return { ok: false, detail: String(result.error) };
+  if (!toolCalled) return { ok: false, detail: "roll tool was not called" };
+  const content = result.content as
+    | { values?: unknown; total?: unknown }
+    | string
+    | undefined;
+  if (!content || typeof content !== "object") {
+    return { ok: false, detail: `expected object, got ${typeof content}` };
+  }
+  if (typeof content.total !== "number") {
+    return { ok: false, detail: "total missing or not a number" };
+  }
+  return { ok: true };
+}
+
+function checkDocStrings(content: unknown): CapabilityResult {
+  if (typeof content !== "string" || content.length === 0) {
+    return {
+      ok: false,
+      detail: `expected non-empty string, got ${typeof content}`,
+    };
+  }
+  const lower = content.toLowerCase();
+  const missing = REQUIRED_DOC_STRINGS.filter((s) => !lower.includes(s));
+  if (missing.length > 0) {
+    return { ok: false, detail: `missing strings: ${missing.join(", ")}` };
+  }
+  return { ok: true };
+}
+
+async function runPdf(llm: Llm): Promise<CapabilityResult> {
+  const input: LlmOperateInput = [
+    "Extract the text from this PDF document.",
+    { file: PDF_PATH },
+  ];
+  const result = await llm.operate(input, { user: USER });
+  if (result.error) return { ok: false, detail: String(result.error) };
+  return checkDocStrings(result.content);
+}
+
+async function runImage(llm: Llm): Promise<CapabilityResult> {
+  const input: LlmOperateInput = [
+    "Extract the text from this image.",
+    { image: IMAGE_PATH },
+  ];
+  const result = await llm.operate(input, { user: USER });
+  if (result.error) return { ok: false, detail: String(result.error) };
+  return checkDocStrings(result.content);
+}
+
+const RUNNERS: Record<Capability, (llm: Llm) => Promise<CapabilityResult>> = {
+  plain: runPlain,
+  tools: runTools,
+  structured: runStructured,
+  both: runBoth,
+  pdf: runPdf,
+  image: runImage,
+};
+
+//
+//
+// Matrix runner
+//
+
+function expectedFor(
+  model: ModelConfig,
+  capability: Capability,
+): ExpectedOutcome {
+  return model.expect?.[capability] ?? "ok";
+}
+
+function classifyActual(
+  capability: CapabilityResult,
+  warnings: string[],
+): ActualOutcome {
+  if (!capability.ok) return "fail";
+  if (warnings.length > 0) return "warn";
+  return "ok";
+}
+
+async function runCell(
+  model: ModelConfig,
+  capability: Capability,
+): Promise<CellResult> {
+  const expected = expectedFor(model, capability);
+
+  if (expected === "skip") {
+    return { actual: "skip", expected, matches: true, warnings: [] };
+  }
+
+  const llm = new Llm(model.provider, { model: model.model });
+  let outcome: CapabilityResult;
+  let warnings: string[] = [];
+  try {
+    const captured = await captureWarnings(() => RUNNERS[capability](llm));
+    outcome = captured.result;
+    warnings = captured.warnings;
+  } catch (error) {
+    outcome = {
+      ok: false,
+      detail: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  const actual = classifyActual(outcome, warnings);
+  const matches = matchesExpected(actual, expected);
+  return {
+    actual,
+    expected,
+    matches,
+    warnings,
+    detail: outcome.detail,
+  };
+}
+
+function matchesExpected(
+  actual: ActualOutcome,
+  expected: ExpectedOutcome,
+): boolean {
+  if (expected === "skip") return actual === "skip";
+  if (expected === "fail") return actual === "fail";
+  if (expected === "ok") return actual === "ok"; // warnings count as a mismatch
+  if (expected === "warn") return actual === "warn"; // missing the warning is a mismatch
+  return false;
+}
+
+//
+//
+// Output formatting
+//
+
+const SYMBOLS: Record<ActualOutcome, string> = {
+  ok: "✅",
+  warn: "⚠️",
+  fail: "❌",
+  skip: "—",
+};
+
+function cellSymbol(cell: CellResult): string {
+  const sym = SYMBOLS[cell.actual];
+  return cell.matches ? sym : `${sym}!`;
+}
+
+function formatTable(
+  models: readonly ModelConfig[],
+  capabilities: readonly Capability[],
+  rows: Map<string, Map<Capability, CellResult>>,
+): string {
+  const labelOf = (m: ModelConfig) => m.label || m.model;
+  const labelWidth = Math.max(
+    ...models.map((m) => labelOf(m).length),
+    "model".length,
+  );
+  const colWidth = (c: Capability) => Math.max(c.length, 4);
+
+  const header = [
+    "model".padEnd(labelWidth),
+    ...capabilities.map((c) => c.padStart(colWidth(c))),
+  ].join("  ");
+  const sep = "─".repeat(header.length);
+
+  const lines = [header, sep];
+  for (const model of models) {
+    const cells = rows.get(labelOf(model));
+    if (!cells) continue;
+    const row = [
+      labelOf(model).padEnd(labelWidth),
+      ...capabilities.map((c) => {
+        const cell = cells.get(c);
+        if (!cell) return "?".padStart(colWidth(c));
+        return cellSymbol(cell).padStart(colWidth(c));
+      }),
+    ].join("  ");
+    lines.push(row);
+  }
+  lines.push(sep);
+  lines.push(
+    "Legend: ✅ ok   ⚠️ warn   ❌ fail   — skip   `!` mismatch vs expected",
+  );
+  return lines.join("\n");
+}
+
+function formatIssues(
+  models: readonly ModelConfig[],
+  rows: Map<string, Map<Capability, CellResult>>,
+): string[] {
+  const issues: string[] = [];
+  for (const model of models) {
+    const label = model.label || model.model;
+    const cells = rows.get(label);
+    if (!cells) continue;
+    for (const [cap, cell] of cells) {
+      if (cell.matches && cell.warnings.length === 0) continue;
+      const parts = [`[${label} / ${cap}]`];
+      if (!cell.matches) {
+        parts.push(`expected=${cell.expected}, got=${cell.actual}`);
+      }
+      if (cell.detail) parts.push(`detail=${cell.detail}`);
+      if (cell.warnings.length > 0) {
+        parts.push(`warnings=${cell.warnings.length}`);
+        for (const w of cell.warnings) parts.push(`  • ${w}`);
+      }
+      issues.push(parts.join(" "));
+    }
+  }
+  return issues;
+}
+
+//
+//
+// Main
+//
+
+function selectModels(): readonly ModelConfig[] {
+  const env = process.env.APP_MODELS;
+  if (!env) return MODELS;
+  const ids = env
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return ids.map((id) => {
+    const existing = MODELS.find((m) => m.model === id);
+    return existing ?? { model: id, expect: {} };
+  });
+}
+
+function selectCapabilities(): readonly Capability[] {
+  const env = process.env.APP_CAPABILITIES;
+  if (!env) return CAPABILITIES;
+  const wanted = new Set(env.split(",").map((s) => s.trim().toLowerCase()));
+  return CAPABILITIES.filter((c) => wanted.has(c));
+}
+
+async function main(): Promise<void> {
+  const models = selectModels();
+  const capabilities = selectCapabilities();
+
+  console.log("\n========================================");
+  console.log("       LLM CAPABILITY MATRIX");
+  console.log("========================================");
+  console.log(`Models: ${models.length}`);
+  console.log(`Capabilities: ${capabilities.join(", ")}\n`);
+
+  const rows = new Map<string, Map<Capability, CellResult>>();
+
+  for (const model of models) {
+    const label = model.label || model.model;
+    console.log(`▸ ${label}`);
+    const cells = new Map<Capability, CellResult>();
+    for (const capability of capabilities) {
+      process.stdout.write(`  ${capability} … `);
+      const cell = await runCell(model, capability);
+      cells.set(capability, cell);
+      const status = cellSymbol(cell);
+      const note = cell.detail ? ` (${cell.detail})` : "";
+      console.log(`${status}${note}`);
+    }
+    rows.set(label, cells);
+  }
+
+  console.log("\n========================================");
+  console.log("       MATRIX");
+  console.log("========================================\n");
+  console.log(formatTable(models, capabilities, rows));
+
+  const issues = formatIssues(models, rows);
+  if (issues.length > 0) {
+    console.log("\n========================================");
+    console.log("       ISSUES");
+    console.log("========================================");
+    for (const line of issues) console.log(line);
+  }
+
+  // Exit non-zero if any cell mismatched its expected outcome
+  let mismatches = 0;
+  for (const cells of rows.values()) {
+    for (const cell of cells.values()) {
+      if (!cell.matches) mismatches++;
+    }
+  }
+
+  console.log("\n========================================");
+  if (mismatches === 0) {
+    console.log(`🎉 Matrix passed: every cell matched expectation.`);
+  } else {
+    console.error(`💀 ${mismatches} cell(s) mismatched expectation.`);
+    process.exit(1);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/packages/llm/test/models.ts
+++ b/packages/llm/test/models.ts
@@ -49,37 +49,46 @@ export const CAPABILITIES: readonly Capability[] = [
 /**
  * Default model list. Edit freely. The harness honors APP_MODELS
  * (comma-separated model ids) to override at runtime without editing.
+ *
+ * Includes the major (non-mini/flash/lite) models in the GPT-5, Gemini 3,
+ * and Claude Sonnet 4 / Opus 4 lines, plus every model id referenced by
+ * `src/constants.ts` (smaller variants, xAI Grok line, OpenRouter routes).
+ *
+ * Defaults assume "ok" everywhere; only known limitations are pinned.
+ * After the first run, refine `expect` per cell based on what your account
+ * actually has access to.
  */
 export const MODELS: readonly ModelConfig[] = [
-  // Anthropic
-  {
-    model: "claude-sonnet-4-5",
-    expect: {},
-  },
-  // OpenAI
-  {
-    model: "gpt-4o",
-    expect: {},
-  },
-  // Gemini 2.5 — tools+structured combo falls back to the legacy fake tool
-  {
-    model: "gemini-2.5-flash",
-    expect: { both: "warn" },
-  },
-  // Gemini 3 — supports the native combo
-  {
-    model: "gemini-3.1-pro-preview",
-    expect: {},
-  },
-  // xAI
-  {
-    model: "grok-4",
-    expect: {},
-  },
-  // OpenRouter — file/image uploads not supported by the adapter
-  {
-    model: "openrouter:openai/gpt-4o",
-    label: "openrouter→openai/gpt-4o",
-    expect: { pdf: "skip", image: "skip" },
-  },
+  // ─── Anthropic Sonnet 4 ──────────────────────────────────────────────
+  // Note: Anthropic does not expose bare-name aliases like `claude-sonnet-4`
+  // or `claude-opus-4` — only the dated/versioned ids resolve.
+  { model: "claude-sonnet-4-5" },
+  { model: "claude-sonnet-4-6" }, // constants ANTHROPIC.DEFAULT/SMALL
+
+  // ─── Anthropic Opus 4 ────────────────────────────────────────────────
+  { model: "claude-opus-4-1" },
+  { model: "claude-opus-4-5" },
+  { model: "claude-opus-4-7" }, // constants ANTHROPIC.LARGE
+
+  // ─── Anthropic Haiku 4 ───────────────────────────────────────────────
+  { model: "claude-haiku-4-5" }, // constants ANTHROPIC.TINY
+
+  // ─── OpenAI GPT-5 ────────────────────────────────────────────────────
+  { model: "gpt-5" },
+  { model: "gpt-5.1" },
+  { model: "gpt-5-pro" },
+  { model: "gpt-5.4" }, // constants OPENAI.DEFAULT
+  { model: "gpt-5.4-mini" }, // constants OPENAI.SMALL
+  { model: "gpt-5.4-nano" }, // constants OPENAI.TINY
+  { model: "gpt-5.5" }, // constants OPENAI.LARGE
+
+  // ─── Google Gemini 3 ─────────────────────────────────────────────────
+  { model: "gemini-3.1-pro-preview" }, // constants GEMINI.DEFAULT/LARGE
+  { model: "gemini-3-flash-preview" }, // constants GEMINI.SMALL
+  { model: "gemini-3.1-flash-lite-preview" }, // constants GEMINI.TINY
+
+  // ─── xAI Grok 4 ──────────────────────────────────────────────────────
+  { model: "grok-4.20-0309-reasoning" }, // constants XAI.DEFAULT/LARGE
+  { model: "grok-4.20-0309-non-reasoning" }, // constants XAI.SMALL
+  { model: "grok-4-1-fast-non-reasoning" }, // constants XAI.TINY
 ];

--- a/packages/llm/test/models.ts
+++ b/packages/llm/test/models.ts
@@ -1,0 +1,85 @@
+//
+// Model matrix configuration for `test/matrix.ts`.
+//
+// Edit this list with the models you actually want to verify. Each row is one
+// model id; the optional `provider` field is only needed when the model id is
+// ambiguous (e.g., when sending an OpenAI-named model through OpenRouter).
+//
+// `expect` documents the *expected* outcome per capability. The harness
+// compares actual outcomes to these and flags mismatches:
+//
+//   "ok"   — capability works and produces no warnings
+//   "warn" — capability works but is expected to emit a fallback log.warn
+//            (e.g., gemini-2.5 + tools+structured engages the legacy fake-tool path)
+//   "skip" — capability is not exercised (e.g., OpenRouter cannot upload files)
+//   "fail" — capability is expected to fail outright
+//
+// Any capability not listed in `expect` defaults to "ok".
+
+export type Capability =
+  | "plain"
+  | "tools"
+  | "structured"
+  | "both"
+  | "pdf"
+  | "image";
+
+export type ExpectedOutcome = "ok" | "warn" | "skip" | "fail";
+
+export interface ModelConfig {
+  /** Model id, e.g. "claude-sonnet-4-5" or "openai/gpt-4o" (when provider="openrouter") */
+  model: string;
+  /** Optional explicit provider; auto-detected from the model id when omitted */
+  provider?: string;
+  /** Friendly label for the matrix output; defaults to `model` */
+  label?: string;
+  /** Per-capability expected outcomes; missing entries default to "ok" */
+  expect?: Partial<Record<Capability, ExpectedOutcome>>;
+}
+
+export const CAPABILITIES: readonly Capability[] = [
+  "plain",
+  "tools",
+  "structured",
+  "both",
+  "pdf",
+  "image",
+] as const;
+
+/**
+ * Default model list. Edit freely. The harness honors APP_MODELS
+ * (comma-separated model ids) to override at runtime without editing.
+ */
+export const MODELS: readonly ModelConfig[] = [
+  // Anthropic
+  {
+    model: "claude-sonnet-4-5",
+    expect: {},
+  },
+  // OpenAI
+  {
+    model: "gpt-4o",
+    expect: {},
+  },
+  // Gemini 2.5 — tools+structured combo falls back to the legacy fake tool
+  {
+    model: "gemini-2.5-flash",
+    expect: { both: "warn" },
+  },
+  // Gemini 3 — supports the native combo
+  {
+    model: "gemini-3.1-pro-preview",
+    expect: {},
+  },
+  // xAI
+  {
+    model: "grok-4",
+    expect: {},
+  },
+  // OpenRouter — file/image uploads not supported by the adapter
+  {
+    model: "openrouter:openai/gpt-4o",
+    label: "openrouter→openai/gpt-4o",
+    expect: { pdf: "skip", image: "skip" },
+  },
+];

--- a/packages/llm/test/reasoning.ts
+++ b/packages/llm/test/reasoning.ts
@@ -23,9 +23,16 @@ const REASONING_MODELS = {
 // Test Functions
 //
 
+function inferProvider(model: string): string {
+  if (model.startsWith("claude")) return "anthropic";
+  if (model.startsWith("gemini")) return "gemini";
+  if (model.startsWith("grok")) return "xai";
+  return "openai";
+}
+
 async function testReasoningExtraction(): Promise<boolean> {
-  const provider = "openai";
-  const model = REASONING_MODELS.openai;
+  const model = process.env.APP_MODEL || REASONING_MODELS.openai;
+  const provider = inferProvider(model);
 
   try {
     console.log(

--- a/packages/llm/test/structured.ts
+++ b/packages/llm/test/structured.ts
@@ -166,9 +166,12 @@ function tryParseJson(content: unknown): StructuredResult | null {
 
 async function testProvider(provider: string, model: string): Promise<boolean> {
   try {
-    console.log(`\n============ Structured JSON Test: ${provider} (${model})`);
+    const effectiveModel = process.env.APP_MODEL || model;
+    console.log(
+      `\n============ Structured JSON Test: ${provider} (${effectiveModel})`,
+    );
 
-    const llm = new Llm(provider, { model });
+    const llm = new Llm(provider, { model: effectiveModel });
 
     const result = await llm.operate(REQUEST, {
       format: FORMAT,

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.49",
+  "version": "0.8.50",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.48",
+  "version": "0.8.49",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/jaypie/1.2.43.md
+++ b/packages/mcp/release-notes/jaypie/1.2.43.md
@@ -1,0 +1,12 @@
+---
+version: 1.2.43
+date: 2026-04-29
+summary: Pull in @jaypie/llm 1.2.31 (native structured outputs across all providers)
+---
+
+## Changes
+
+- Bumped `@jaypie/llm` peer-dep range to `^1.2.31`, exposing:
+  - Anthropic, OpenAI, Gemini 3, and xAI all use native structured outputs by default (no more `structured_output` fake-tool emulation in the happy path).
+  - Per-provider runtime fallback that engages the legacy fake-tool path transparently when a model rejects native structured output, with a `log.warn` so silent degradations don't hide.
+  - Anthropic specifically: native field is `output_config.format` (the earlier `output_format` was deprecated by the API).

--- a/packages/mcp/release-notes/llm/1.2.30.md
+++ b/packages/mcp/release-notes/llm/1.2.30.md
@@ -1,0 +1,29 @@
+---
+version: 1.2.30
+date: 2026-04-28
+summary: Anthropic provider uses native structured outputs in place of the structured_output fake-tool emulation
+---
+
+## Changes
+
+- `AnthropicAdapter` (`operate()`/`stream()`):
+  - When `format` is set, the request body now includes `output_format: { type: "json_schema", schema }` instead of injecting a synthetic `structured_output` tool with `tool_choice: "any"`.
+  - JSON schemas are sanitized for Anthropic's grammar compiler: objects always get `additionalProperties: false`, unsupported numeric/string/array constraints (`minimum`, `maxLength`, `multipleOf`, …) are appended to `description` rather than sent to the API, unsupported string formats are stripped, and `minItems` is preserved only when 0 or 1.
+  - Responses to structured-output requests are parsed from the first `text` content block (guaranteed valid JSON by the Anthropic grammar). `stop_reason: "refusal"` and `stop_reason: "max_tokens"` are recognized and surface as text rather than triggering a parse error.
+  - Streaming structured outputs now arrive as `LlmStreamChunkType.Text` deltas (consumers concat to assemble JSON), instead of a single `ToolCall` chunk.
+- `AnthropicProvider.send(message, { response })`: the system prompt is no longer stuffed with the JSON schema, and the regex JSON extraction is gone. The native `output_format` field handles the contract.
+- A runtime fallback re-engages the legacy fake-tool emulation transparently when a model rejects `output_format` (cached per model in `runtimeNoStructuredOutputModels`). Citations-related 400s are explicitly excluded so they propagate instead of being masked by a retry.
+
+## Why
+
+Anthropic launched native structured outputs publicly on 2025-11-14 (now GA on Claude 4.5+). The previous tool-emulation hack predates the feature. Native:
+- Removes a fragile regex extraction in `provider.send`.
+- Removes the synthetic `structured_output` tool from the operate loop.
+- Returns guaranteed-valid JSON via grammar-constrained generation rather than relying on the model to comply with a system-prompt instruction.
+- Keeps a fallback path for any model that does not (yet) support `output_format`.
+
+## Notes
+
+- Streaming consumers that previously branched on a `tool_call` chunk to receive structured output will now see `text` chunks. Concatenate to assemble the final JSON, or use `operate()` for the parsed object.
+- Schema constraints not supported by Anthropic's grammar (regex `pattern`, `minLength`, numeric ranges, recursion) are stripped at request time. The original constraints are still enforced client-side by the caller's Zod schema during result validation.
+- Gemini and OpenRouter still use the fake-tool emulation pattern; native migration for those adapters is a separate task.

--- a/packages/mcp/release-notes/llm/1.2.30.md
+++ b/packages/mcp/release-notes/llm/1.2.30.md
@@ -7,12 +7,12 @@ summary: Anthropic provider uses native structured outputs in place of the struc
 ## Changes
 
 - `AnthropicAdapter` (`operate()`/`stream()`):
-  - When `format` is set, the request body now includes `output_format: { type: "json_schema", schema }` instead of injecting a synthetic `structured_output` tool with `tool_choice: "any"`.
+  - When `format` is set, the request body now includes `output_config: { format: { type: "json_schema", schema } }` instead of injecting a synthetic `structured_output` tool with `tool_choice: "any"`.
   - JSON schemas are sanitized for Anthropic's grammar compiler: objects always get `additionalProperties: false`, unsupported numeric/string/array constraints (`minimum`, `maxLength`, `multipleOf`, …) are appended to `description` rather than sent to the API, unsupported string formats are stripped, and `minItems` is preserved only when 0 or 1.
   - Responses to structured-output requests are parsed from the first `text` content block (guaranteed valid JSON by the Anthropic grammar). `stop_reason: "refusal"` and `stop_reason: "max_tokens"` are recognized and surface as text rather than triggering a parse error.
   - Streaming structured outputs now arrive as `LlmStreamChunkType.Text` deltas (consumers concat to assemble JSON), instead of a single `ToolCall` chunk.
-- `AnthropicProvider.send(message, { response })`: the system prompt is no longer stuffed with the JSON schema, and the regex JSON extraction is gone. The native `output_format` field handles the contract.
-- A runtime fallback re-engages the legacy fake-tool emulation transparently when a model rejects `output_format` (cached per model in `runtimeNoStructuredOutputModels`). Citations-related 400s are explicitly excluded so they propagate instead of being masked by a retry.
+- `AnthropicProvider.send(message, { response })`: the system prompt is no longer stuffed with the JSON schema, and the regex JSON extraction is gone. The native `output_config.format` field handles the contract.
+- A runtime fallback re-engages the legacy fake-tool emulation transparently when a model rejects `output_config` (cached per model in `runtimeNoStructuredOutputModels`). Citations-related 400s and `output_format`-deprecation 400s are explicitly excluded so they propagate instead of being masked by a retry.
 
 ## Why
 
@@ -20,7 +20,7 @@ Anthropic launched native structured outputs publicly on 2025-11-14 (now GA on C
 - Removes a fragile regex extraction in `provider.send`.
 - Removes the synthetic `structured_output` tool from the operate loop.
 - Returns guaranteed-valid JSON via grammar-constrained generation rather than relying on the model to comply with a system-prompt instruction.
-- Keeps a fallback path for any model that does not (yet) support `output_format`.
+- Keeps a fallback path for any model that does not (yet) support `output_config`.
 
 ## Notes
 

--- a/packages/mcp/release-notes/llm/1.2.31.md
+++ b/packages/mcp/release-notes/llm/1.2.31.md
@@ -1,0 +1,33 @@
+---
+version: 1.2.31
+date: 2026-04-29
+summary: OpenRouter and Gemini adapters drop the structured_output fake-tool hack in favor of native response_format / responseJsonSchema (with runtime fallback for unsupported models)
+---
+
+## Changes
+
+- `OpenRouterAdapter` (`operate()`/`stream()`):
+  - When `format` is set, the request body now includes `response_format: { type: "json_schema", json_schema: { name, schema, strict: true } }` instead of injecting a synthetic `structured_output` tool.
+  - `formatTools` no longer injects the synthetic tool. The legacy fake tool is added in `buildRequest` only as a runtime fallback for models cached as not supporting native `response_format`.
+  - `formatOutputSchema` now forces `additionalProperties: false` on every object (required for `strict: true`).
+  - `executeRequest` annotates the response with a `__jaypieStructuredOutput` flag so `hasStructuredOutput` / `extractStructuredOutput` can detect intent statelessly. The native path parses `choices[0].message.content` as JSON; the fallback path keeps the existing tool-call extraction.
+  - 400/422 errors mentioning `response_format`/`json_schema`/`structured_output`/`require_parameters` cache the model in `runtimeNoStructuredOutputModels` and trigger a one-shot retry via the legacy fake-tool path. Unrelated 4xx propagate.
+  - `log.warn` at both fallback entry points (initial cached-model build and 4xx retry).
+- `GeminiAdapter` (`operate()`/`stream()`):
+  - Format **and** tools combined now uses native `responseJsonSchema` + tools when the model id matches `^gemini-3` (Gemini 3 preview). Gemini 2.5 (including thinking) and earlier keep the `structured_output` fake-tool emulation with the system-prompt nudge.
+  - `formatTools` no longer injects the synthetic structured_output tool; the fake tool is added in `buildRequest` only when the runtime falls back.
+  - 400 errors mentioning `responseJsonSchema`/`responseSchema`/`responseMime`/`function_call`/`tools` cache the model in `runtimeNoStructuredOutputComboModels` and trigger a one-shot retry via the legacy fake-tool path.
+  - `log.warn` at both fallback entry points.
+
+## Why
+
+OpenRouter exposes the OpenAI-style structured-outputs shape end-to-end, and Gemini 3 launched as a preview supporting tools + `responseJsonSchema` together. The `structured_output` fake-tool emulation predates both. Native:
+- Returns guaranteed-valid JSON via grammar-constrained generation rather than relying on the model to comply with a system-prompt instruction.
+- Removes the synthetic tool from the operate-loop tool list (cleaner traces, no risk of the model ignoring the nudge).
+- Keeps a fallback path that re-engages the fake-tool emulation transparently when a model rejects the native field.
+
+## Notes
+
+- Anthropic was migrated in 1.2.30; with this release, all four LLM providers (Anthropic, OpenAI, OpenRouter, Gemini) use native structured outputs by default. xAI inherits from `OpenAiAdapter` and was already native.
+- Gemini 2.5 thinking models stay on the fake-tool path because the combo is unreliable on 2.5; this matches Google's documentation that the combo is a Gemini 3 preview feature.
+- Streaming consumers that previously branched on a `tool_call` chunk to receive structured output from OpenRouter/Gemini will now see `text` chunks. Concatenate to assemble the final JSON, or use `operate()` for the parsed object.

--- a/packages/mcp/release-notes/mcp/0.8.49.md
+++ b/packages/mcp/release-notes/mcp/0.8.49.md
@@ -1,0 +1,9 @@
+---
+version: 0.8.49
+date: 2026-04-28
+summary: Add release notes for @jaypie/llm 1.2.30 (Anthropic native structured outputs)
+---
+
+## Changes
+
+- Added `release-notes/llm/1.2.30.md` covering the Anthropic provider's switch from the `structured_output` fake-tool emulation to Anthropic's native `output_format` structured outputs (with a runtime fallback to the legacy path for unsupported models).

--- a/packages/mcp/release-notes/mcp/0.8.50.md
+++ b/packages/mcp/release-notes/mcp/0.8.50.md
@@ -1,0 +1,9 @@
+---
+version: 0.8.50
+date: 2026-04-29
+summary: Add release notes for @jaypie/llm 1.2.31 (OpenRouter and Gemini native structured outputs)
+---
+
+## Changes
+
+- Added `release-notes/llm/1.2.31.md` covering the OpenRouter and Gemini adapters' migration from the `structured_output` fake-tool emulation to native `response_format: json_schema` (OpenRouter) and `responseJsonSchema` + tools (Gemini 3), with a runtime fallback for unsupported models.


### PR DESCRIPTION
## Summary

- Migrates Anthropic, OpenRouter, and Gemini 3 from the `structured_output` fake-tool emulation to each provider's native structured-output field (Anthropic `output_config.format`, OpenRouter OpenAI-style `response_format: json_schema`, Gemini 3 native `responseJsonSchema` + tools combo). xAI inherits OpenAI's already-native path. All four providers now run native by default with a per-provider runtime fallback that re-engages the legacy fake-tool path with `log.warn` if a model rejects the native field.
- Adds a `test/matrix.ts` capability harness — 6 capabilities × N models, with `log.warn` capture so silent fallback engagements surface — and switches the CI `LLM Client Test` job to run it. The harness is what caught the original Anthropic field-name bug (`output_format` → `output_config.format`) before merge.
- Versions: `@jaypie/llm` 1.2.29 → 1.2.31, `@jaypie/mcp` 0.8.48 → 0.8.50, `jaypie` 1.2.42 → 1.2.43 (peer-dep range bump).

## Test plan

- [x] `npm run typecheck -w packages/llm` (clean)
- [x] `npm run test -w packages/llm` (797 passing, 1 todo)
- [x] `npm run typecheck -w packages/mcp` and `npm run test -w packages/mcp` (clean)
- [x] `npm run test -w packages/jaypie` (clean after dep bump)
- [x] **Live capability matrix**: 19 models × 6 capabilities = 114 real calls, all ✅ green, no unexpected warnings (Anthropic Sonnet 4 / Opus 4 / Haiku 4, OpenAI GPT-5 line, Gemini 3 Pro/Flash/Flash-Lite, xAI Grok 4)
- [x] CI NPM Check green on this branch (lint, typecheck, unit tests on Node 24 + 25, capability matrix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)