### PR TITLE
feat(llm): temperature capability + OpenAI temperature-deprecation handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29214,7 +29214,7 @@
       "license": "MIT"
     },
     "packages/jaypie": {
-      "version": "1.2.43",
+      "version": "1.2.44",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "^1.2.8",
@@ -29239,7 +29239,7 @@
         "typescript-eslint": "^8.46.1"
       },
       "peerDependencies": {
-        "@jaypie/llm": "^1.2.31",
+        "@jaypie/llm": "^1.2.32",
         "@jaypie/mongoose": "^1.2.2"
       },
       "peerDependenciesMeta": {
@@ -29348,7 +29348,7 @@
     },
     "packages/llm": {
       "name": "@jaypie/llm",
-      "version": "1.2.31",
+      "version": "1.2.32",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "*",
@@ -29471,7 +29471,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.50",
+      "version": "0.8.51",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.4",

--- a/packages/jaypie/package.json
+++ b/packages/jaypie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jaypie",
-  "version": "1.2.43",
+  "version": "1.2.44",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"
@@ -54,7 +54,7 @@
     "typescript-eslint": "^8.46.1"
   },
   "peerDependencies": {
-    "@jaypie/llm": "^1.2.31",
+    "@jaypie/llm": "^1.2.32",
     "@jaypie/mongoose": "^1.2.2"
   },
   "peerDependenciesMeta": {

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/llm",
-  "version": "1.2.31",
+  "version": "1.2.32",
   "description": "Large language model utilities",
   "repository": {
     "type": "git",

--- a/packages/llm/src/operate/adapters/OpenAiAdapter.ts
+++ b/packages/llm/src/operate/adapters/OpenAiAdapter.ts
@@ -78,6 +78,30 @@ const NOT_RETRYABLE_ERROR_TYPES = [
   UnprocessableEntityError,
 ];
 
+// Models known not to accept `temperature`.
+// Patterns (not exact names) so dated variants and future releases are covered
+// without code changes — OpenAI is removing temperature on newer reasoning
+// models.
+const MODELS_WITHOUT_TEMPERATURE: RegExp[] = [
+  /^gpt-5\.5/, // gpt-5.5 series deprecated temperature
+  /^o\d/, // o-series reasoning models (o1, o3, o4, ...)
+];
+
+function isTemperatureDeprecationError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  if (
+    !(error instanceof BadRequestError) &&
+    (error as { status?: number }).status !== 400
+  ) {
+    return false;
+  }
+  const messages = [
+    (error as { message?: string }).message,
+    (error as { error?: { message?: string } }).error?.message,
+  ].filter((m): m is string => typeof m === "string");
+  return messages.some((m) => m.toLowerCase().includes("temperature"));
+}
+
 //
 //
 // Main
@@ -91,6 +115,23 @@ const NOT_RETRYABLE_ERROR_TYPES = [
 export class OpenAiAdapter extends BaseProviderAdapter {
   readonly name = PROVIDER.OPENAI.NAME;
   readonly defaultModel = PROVIDER.OPENAI.MODEL.DEFAULT;
+
+  // Session-level cache of models observed to reject `temperature` at runtime.
+  // Populated by executeRequest on 400 errors so repeat calls skip the param.
+  private runtimeNoTemperatureModels = new Set<string>();
+
+  rememberModelRejectsTemperature(model: string): void {
+    this.runtimeNoTemperatureModels.add(model);
+  }
+
+  clearRuntimeNoTemperatureModels(): void {
+    this.runtimeNoTemperatureModels.clear();
+  }
+
+  private supportsTemperature(model: string): boolean {
+    if (this.runtimeNoTemperatureModels.has(model)) return false;
+    return !MODELS_WITHOUT_TEMPERATURE.some((pattern) => pattern.test(model));
+  }
 
   //
   // Request Building
@@ -141,6 +182,14 @@ export class OpenAiAdapter extends BaseProviderAdapter {
     // First-class temperature takes precedence over providerOptions
     if (request.temperature !== undefined) {
       openaiRequest.temperature = request.temperature;
+    }
+
+    // Strip temperature for models that don't support it (denylist + runtime cache)
+    if (
+      openaiRequest.temperature !== undefined &&
+      !this.supportsTemperature(openaiRequest.model as string)
+    ) {
+      delete openaiRequest.temperature;
     }
 
     return openaiRequest;
@@ -212,14 +261,30 @@ export class OpenAiAdapter extends BaseProviderAdapter {
     signal?: AbortSignal,
   ): Promise<unknown> {
     const openai = client as OpenAI;
+    const openaiRequest = request as Record<string, unknown>;
+    type CreateParams = Parameters<typeof openai.responses.create>[0];
     try {
       return await openai.responses.create(
-        // @ts-expect-error OpenAI SDK types don't match our request format exactly
-        request,
+        openaiRequest as CreateParams,
         signal ? { signal } : undefined,
       );
     } catch (error) {
       if (signal?.aborted) return undefined;
+
+      // If the model rejected `temperature`, cache it and retry without the param
+      if (
+        openaiRequest.temperature !== undefined &&
+        isTemperatureDeprecationError(error)
+      ) {
+        this.rememberModelRejectsTemperature(openaiRequest.model as string);
+        const retryRequest = { ...openaiRequest };
+        delete retryRequest.temperature;
+        return await openai.responses.create(
+          retryRequest as CreateParams,
+          signal ? { signal } : undefined,
+        );
+      }
+
       throw error;
     }
   }

--- a/packages/llm/src/operate/adapters/__tests__/OpenAiAdapter.spec.ts
+++ b/packages/llm/src/operate/adapters/__tests__/OpenAiAdapter.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { OpenAiAdapter, openAiAdapter } from "../OpenAiAdapter.js";
 import { PROVIDER } from "../../../constants.js";
@@ -651,6 +651,142 @@ describe("OpenAiAdapter", () => {
       const result = openAiAdapter.parseResponse(response);
 
       expect(result.content).toBe("Answer");
+    });
+  });
+
+  // Temperature deprecation
+  describe("Temperature deprecation", () => {
+    beforeEach(() => {
+      openAiAdapter.clearRuntimeNoTemperatureModels();
+    });
+
+    it("strips temperature for denylisted models in buildRequest", () => {
+      const request: OperateRequest = {
+        model: "gpt-5.5",
+        messages: [],
+        temperature: 0,
+      };
+
+      const result = openAiAdapter.buildRequest(request) as Record<
+        string,
+        unknown
+      >;
+
+      expect(result.temperature).toBeUndefined();
+    });
+
+    it("retries without temperature when OpenAI rejects it with 400", async () => {
+      const { BadRequestError } = await import("openai");
+      // @ts-expect-error Mock doesn't require constructor args
+      const error = new BadRequestError();
+      (error as unknown as { status: number }).status = 400;
+      error.message =
+        "400 Unsupported parameter: 'temperature' is not supported with this model.";
+
+      const successResponse = {
+        output: [
+          { type: "message", content: [{ type: "output_text", text: "Hi" }] },
+        ],
+        usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+      };
+      const mockCreate = vi.fn();
+      mockCreate.mockRejectedValueOnce(error as unknown as Error);
+      mockCreate.mockResolvedValueOnce(successResponse);
+      const mockClient = { responses: { create: mockCreate } };
+      const request = {
+        model: "gpt-future-no-temp",
+        input: [],
+        temperature: 0,
+      };
+
+      const result = await openAiAdapter.executeRequest(mockClient, request);
+
+      expect(result as unknown).toBe(successResponse);
+      expect(mockCreate).toHaveBeenCalledTimes(2);
+      const retryRequest = mockCreate.mock.calls[1][0] as {
+        temperature?: number;
+      };
+      expect(retryRequest.temperature).toBeUndefined();
+    });
+
+    it("caches the model so subsequent buildRequest strips temperature", async () => {
+      const { BadRequestError } = await import("openai");
+      // @ts-expect-error Mock doesn't require constructor args
+      const error = new BadRequestError();
+      (error as unknown as { status: number }).status = 400;
+      error.message = "Unsupported parameter: 'temperature' …";
+
+      const mockCreate = vi.fn();
+      mockCreate.mockRejectedValueOnce(error as unknown as Error);
+      mockCreate.mockResolvedValueOnce({
+        output: [
+          { type: "message", content: [{ type: "output_text", text: "Hi" }] },
+        ],
+        usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+      });
+      const mockClient = { responses: { create: mockCreate } };
+      await openAiAdapter.executeRequest(mockClient, {
+        model: "gpt-mystery",
+        input: [],
+        temperature: 0.5,
+      });
+
+      const result = openAiAdapter.buildRequest({
+        model: "gpt-mystery",
+        messages: [],
+        temperature: 0.5,
+      }) as Record<string, unknown>;
+
+      expect(result.temperature).toBeUndefined();
+    });
+
+    it("does not retry on 400 unrelated to temperature", async () => {
+      const { BadRequestError } = await import("openai");
+      // @ts-expect-error Mock doesn't require constructor args
+      const error = new BadRequestError();
+      (error as unknown as { status: number }).status = 400;
+      error.message = "some other bad-request reason";
+
+      const mockCreate = vi.fn();
+      mockCreate.mockRejectedValue(error as unknown as Error);
+      const mockClient = { responses: { create: mockCreate } };
+
+      let thrown: unknown;
+      try {
+        await openAiAdapter.executeRequest(mockClient, {
+          model: "gpt-5.4",
+          input: [],
+          temperature: 0.2,
+        });
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown).toBe(error);
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not retry when request has no temperature", async () => {
+      const { BadRequestError } = await import("openai");
+      // @ts-expect-error Mock doesn't require constructor args
+      const error = new BadRequestError();
+      (error as unknown as { status: number }).status = 400;
+      error.message = "'temperature' is not supported with this model.";
+
+      const mockCreate = vi.fn();
+      mockCreate.mockRejectedValue(error as unknown as Error);
+      const mockClient = { responses: { create: mockCreate } };
+
+      let thrown: unknown;
+      try {
+        await openAiAdapter.executeRequest(mockClient, {
+          model: "gpt-5.5",
+          input: [],
+        });
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown).toBe(error);
+      expect(mockCreate).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/llm/test/matrix.ts
+++ b/packages/llm/test/matrix.ts
@@ -232,6 +232,21 @@ async function runImage(llm: Llm): Promise<CapabilityResult> {
   return checkDocStrings(result.content);
 }
 
+async function runTemperature(llm: Llm): Promise<CapabilityResult> {
+  const result = await llm.operate(
+    "Reply with one word: 'pong'. No punctuation.",
+    { temperature: 0, user: USER },
+  );
+  if (result.error) return { ok: false, detail: String(result.error) };
+  if (typeof result.content !== "string" || result.content.length === 0) {
+    return {
+      ok: false,
+      detail: `expected non-empty string, got ${typeof result.content}`,
+    };
+  }
+  return { ok: true };
+}
+
 const RUNNERS: Record<Capability, (llm: Llm) => Promise<CapabilityResult>> = {
   plain: runPlain,
   tools: runTools,
@@ -239,6 +254,7 @@ const RUNNERS: Record<Capability, (llm: Llm) => Promise<CapabilityResult>> = {
   both: runBoth,
   pdf: runPdf,
   image: runImage,
+  temperature: runTemperature,
 };
 
 //

--- a/packages/llm/test/models.ts
+++ b/packages/llm/test/models.ts
@@ -22,7 +22,8 @@ export type Capability =
   | "structured"
   | "both"
   | "pdf"
-  | "image";
+  | "image"
+  | "temperature";
 
 export type ExpectedOutcome = "ok" | "warn" | "skip" | "fail";
 
@@ -44,6 +45,7 @@ export const CAPABILITIES: readonly Capability[] = [
   "both",
   "pdf",
   "image",
+  "temperature",
 ] as const;
 
 /**

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.50",
+  "version": "0.8.51",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/jaypie/1.2.44.md
+++ b/packages/mcp/release-notes/jaypie/1.2.44.md
@@ -1,0 +1,11 @@
+---
+version: 1.2.44
+date: 2026-04-29
+summary: Pull in @jaypie/llm 1.2.32 (OpenAI temperature-deprecation handling)
+---
+
+## Changes
+
+- Bumped `@jaypie/llm` peer-dep range to `^1.2.32`, exposing:
+  - The OpenAI adapter strips `temperature` for denylisted models (`^gpt-5\.5`, `^o\d`) and transparently retries without the param when the API returns `400 Unsupported parameter: 'temperature' …`.
+  - Capability matrix now exercises `temperature` across every configured model.

--- a/packages/mcp/release-notes/llm/1.2.32.md
+++ b/packages/mcp/release-notes/llm/1.2.32.md
@@ -1,0 +1,23 @@
+---
+version: 1.2.32
+date: 2026-04-29
+summary: OpenAI adapter strips/retries on temperature deprecation; matrix gains a temperature capability
+---
+
+## Changes
+
+- `OpenAiAdapter` (`operate()`/`stream()`) now mirrors the Anthropic adapter's temperature-deprecation handling:
+  - `MODELS_WITHOUT_TEMPERATURE` regex denylist (`^gpt-5\.5`, `^o\d`) is checked in `buildRequest` and `temperature` is stripped before the request is sent.
+  - Session-level `runtimeNoTemperatureModels` Set populated by `executeRequest` when the API returns `400 Unsupported parameter: 'temperature' …`. Subsequent calls for the same model strip the param up-front via `supportsTemperature`.
+  - `executeRequest` catches the 400, caches the model, and transparently retries without `temperature`. Unrelated 400s and 400s on requests without `temperature` still propagate.
+  - `clearRuntimeNoTemperatureModels()` exposed for tests.
+- Capability matrix (`test/matrix.ts`, `test/models.ts`) gains a `temperature` capability that runs a basic prompt with `temperature: 0` and verifies a non-empty response. Runs across every model in the matrix.
+
+## Why
+
+`gpt-5.5` rejects `temperature` outright (`400 Unsupported parameter`). Every prior adapter that hit this returned an unrecoverable error to the caller. Matching the Anthropic pattern lets the OpenAI adapter handle the deprecation transparently — first call for an unknown model pays one round-trip to learn; denylisted models pay nothing — so callers can pass `temperature` portably across the model line.
+
+## Notes
+
+- The denylist regex is forward-compatible: any future `gpt-5.5.*` or o-series variant strips automatically. Other models that newly deprecate the param fall into the runtime-cache path on first 400.
+- Streaming (`executeStreamRequest`) does not retry on temperature errors; it relies on the denylist + warmed runtime cache from prior `operate()` calls. Models not yet in the cache will surface the 400 to the streaming consumer.

--- a/packages/mcp/release-notes/mcp/0.8.51.md
+++ b/packages/mcp/release-notes/mcp/0.8.51.md
@@ -1,0 +1,10 @@
+---
+version: 0.8.51
+date: 2026-04-29
+summary: Add release notes for @jaypie/llm 1.2.32 and jaypie 1.2.44 (OpenAI temperature-deprecation handling)
+---
+
+## Changes
+
+- Added `release-notes/llm/1.2.32.md` covering the OpenAI adapter's temperature-deprecation strip-and-retry path and the new `temperature` capability in the matrix harness.
+- Added `release-notes/jaypie/1.2.44.md` for the corresponding `jaypie` peer-dep bump to `@jaypie/llm` `^1.2.32`.


### PR DESCRIPTION
## Summary

- Adds a `temperature` capability to the LLM capability matrix that runs a basic prompt with `temperature: 0` and verifies a non-empty response across every configured model.
- Mirrors the Anthropic adapter's temperature-deprecation pattern in `OpenAiAdapter`: a regex denylist (`^gpt-5\.5`, `^o\d`) plus a session-level runtime cache populated from `400 Unsupported parameter: 'temperature' …` errors. `buildRequest` strips the param up-front for known/learned models; `executeRequest` catches the 400, caches the model, and transparently retries without `temperature`. Confirmed live: `gpt-5.5` now returns `"pong"` instead of failing.
- Releases `@jaypie/llm` 1.2.32, `jaypie` 1.2.44 (peer-dep range bumped), `@jaypie/mcp` 0.8.51 (release notes added).

## Test plan

- [x] `npm run typecheck/build/test/format -w packages/{llm,jaypie,mcp}` all green
- [x] New unit tests in `OpenAiAdapter.spec.ts` cover: denylist strip, retry-on-400, runtime-cache persistence, no retry on unrelated 400, no retry without temperature
- [x] Live capability matrix run (CI "LLM Capability Matrix" job) — gpt-5.5 + temperature ✅