### PR TITLE
feat(llm): OpenRouter parity, collective matrix, Gemini tool-result Struct fix

### DIFF
--- a/.github/workflows/npm-check.yml
+++ b/.github/workflows/npm-check.yml
@@ -84,7 +84,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24
-          cache: 'npm'
+          cache: "npm"
       - name: Install dependencies
         if: steps.changes.outputs.llm == 'true'
         run: npm install
@@ -98,4 +98,5 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.CICD_ANTHROPIC_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.CICD_GEMINI_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.CICD_OPENAI_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.CICD_OPENROUTER_API_KEY }}
           XAI_API_KEY: ${{ secrets.CICD_XAI_API_KEY }}

--- a/.github/workflows/npm-deploy.yml
+++ b/.github/workflows/npm-deploy.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 24
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
       - run: npm ci
       - run: npm run build
       - name: Publish dev packages
@@ -168,7 +168,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24
-          cache: 'npm'
+          cache: "npm"
       - name: Install dependencies
         run: npm install
       - name: Build
@@ -180,4 +180,27 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.CICD_ANTHROPIC_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.CICD_GEMINI_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.CICD_OPENAI_API_KEY }}
+          XAI_API_KEY: ${{ secrets.CICD_XAI_API_KEY }}
+  test-llm-matrix:
+    name: LLM Capability Matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+      - name: Use Node.js 24
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: "npm"
+      - name: Install dependencies
+        run: npm install
+      - name: Build
+        run: npm run build
+      - name: Run LLM Capability Matrix
+        run: LOG_LEVEL=warn npm run test:llm:matrix
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.CICD_ANTHROPIC_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.CICD_GEMINI_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.CICD_OPENAI_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.CICD_OPENROUTER_API_KEY }}
           XAI_API_KEY: ${{ secrets.CICD_XAI_API_KEY }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -29214,7 +29214,7 @@
       "license": "MIT"
     },
     "packages/jaypie": {
-      "version": "1.2.44",
+      "version": "1.2.45",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "^1.2.8",
@@ -29239,7 +29239,7 @@
         "typescript-eslint": "^8.46.1"
       },
       "peerDependencies": {
-        "@jaypie/llm": "^1.2.32",
+        "@jaypie/llm": "^1.2.33",
         "@jaypie/mongoose": "^1.2.2"
       },
       "peerDependenciesMeta": {
@@ -29348,7 +29348,7 @@
     },
     "packages/llm": {
       "name": "@jaypie/llm",
-      "version": "1.2.32",
+      "version": "1.2.33",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "*",
@@ -29471,7 +29471,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.51",
+      "version": "0.8.52",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.4",

--- a/packages/jaypie/package.json
+++ b/packages/jaypie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jaypie",
-  "version": "1.2.44",
+  "version": "1.2.45",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"
@@ -54,7 +54,7 @@
     "typescript-eslint": "^8.46.1"
   },
   "peerDependencies": {
-    "@jaypie/llm": "^1.2.32",
+    "@jaypie/llm": "^1.2.33",
     "@jaypie/mongoose": "^1.2.2"
   },
   "peerDependenciesMeta": {

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/llm",
-  "version": "1.2.32",
+  "version": "1.2.33",
   "description": "Large language model utilities",
   "repository": {
     "type": "git",

--- a/packages/llm/src/operate/adapters/GeminiAdapter.ts
+++ b/packages/llm/src/operate/adapters/GeminiAdapter.ts
@@ -573,13 +573,24 @@ export class GeminiAdapter extends BaseProviderAdapter {
     toolCall: StandardToolCall,
     result: StandardToolResult,
   ): GeminiPart {
-    // Gemini expects the response to be the actual result object, not wrapped in "result"
-    // The output from StandardToolResult is JSON-stringified, so we need to parse it
+    // Gemini's `function_response.response` is a protobuf Struct, which only
+    // accepts plain objects. Some models (e.g. gemini-3.1-pro) accept scalar
+    // values silently; gemini-3.1-flash-lite rejects them. Parse the output
+    // and wrap any non-object value (string, number, boolean, array, null)
+    // in `{ result: value }` so every tool result is a valid Struct.
     let responseData: Record<string, unknown>;
     try {
-      responseData = JSON.parse(result.output);
+      const parsed = JSON.parse(result.output);
+      if (
+        parsed !== null &&
+        typeof parsed === "object" &&
+        !Array.isArray(parsed)
+      ) {
+        responseData = parsed as Record<string, unknown>;
+      } else {
+        responseData = { result: parsed };
+      }
     } catch {
-      // If parsing fails, wrap the output as a string result
       responseData = { result: result.output };
     }
 

--- a/packages/llm/src/operate/adapters/OpenRouterAdapter.ts
+++ b/packages/llm/src/operate/adapters/OpenRouterAdapter.ts
@@ -167,15 +167,50 @@ function isStructuredOutputUnsupportedError(error: unknown): boolean {
   );
 }
 
-/**
- * OpenRouter content part types (text only - images/files not supported)
- */
-type OpenRouterContentPart = { type: "text"; text: string };
+// OpenRouter routes that don't accept `temperature`. Patterns match the
+// vendor-prefixed route id (e.g. `openai/gpt-5.5`) so dated variants are
+// covered without code changes.
+const MODELS_WITHOUT_TEMPERATURE: RegExp[] = [
+  /^openai\/gpt-5\.5/,
+  /^openai\/o\d/,
+  /^anthropic\/claude-opus-4-[789]/,
+  /^anthropic\/claude-opus-[5-9]/,
+];
+
+function isTemperatureDeprecationError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const err = error as {
+    status?: number;
+    statusCode?: number;
+    message?: string;
+    error?: { message?: string };
+  };
+  const status = err.status ?? err.statusCode;
+  if (status !== 400) return false;
+  const messages = [err.message, err.error?.message].filter(
+    (m): m is string => typeof m === "string",
+  );
+  return messages.some((m) => m.toLowerCase().includes("temperature"));
+}
 
 /**
- * Convert standardized content items to OpenRouter format
- * Note: OpenRouter does not support native file/image uploads.
- * Images and files are discarded with a warning.
+ * OpenRouter content part types. OpenRouter follows the OpenAI Chat
+ * Completions multimodal schema and forwards `image_url` and `file` parts
+ * to vision/PDF-capable backends. The SDK accepts camelCase fields at the
+ * input boundary (`imageUrl`, `fileData`) and transforms to snake_case on
+ * the wire.
+ */
+type OpenRouterContentPart =
+  | { type: "text"; text: string }
+  | { type: "image_url"; imageUrl: { url: string } }
+  | { type: "file"; file: { filename?: string; fileData: string } };
+
+/**
+ * Convert standardized content items to OpenRouter format. Images become
+ * `image_url` parts and files become `file` parts; both pass through to
+ * OpenRouter which routes to the selected backend. Backends that don't
+ * support the modality 4xx — that's a model-capability mismatch, surfaced
+ * by the call rather than silently dropped here.
  */
 function convertContentToOpenRouter(
   content: string | LlmInputContent[],
@@ -187,24 +222,40 @@ function convertContentToOpenRouter(
   const parts: OpenRouterContentPart[] = [];
 
   for (const item of content) {
-    // Text content - pass through
     if (item.type === LlmMessageType.InputText) {
       parts.push({ type: "text", text: item.text });
       continue;
     }
 
-    // Image content - warn and discard
     if (item.type === LlmMessageType.InputImage) {
-      log.warn("OpenRouter does not support image uploads; image discarded");
+      const url = item.image_url ?? "";
+      if (!url) {
+        log.warn(
+          "OpenRouter image content missing image_url; image discarded",
+        );
+        continue;
+      }
+      parts.push({ type: "image_url", imageUrl: { url } });
       continue;
     }
 
-    // File/Document content - warn and discard
     if (item.type === LlmMessageType.InputFile) {
-      log.warn(
-        { filename: item.filename },
-        "OpenRouter does not support file uploads; file discarded",
-      );
+      const fileData =
+        typeof item.file_data === "string" ? item.file_data : "";
+      if (!fileData) {
+        log.warn(
+          { filename: item.filename },
+          "OpenRouter file content missing file_data; file discarded",
+        );
+        continue;
+      }
+      parts.push({
+        type: "file",
+        file: {
+          filename: item.filename,
+          fileData,
+        },
+      });
       continue;
     }
 
@@ -212,7 +263,7 @@ function convertContentToOpenRouter(
     log.warn({ item }, "Unknown content type for OpenRouter; discarded");
   }
 
-  // If no text parts remain, return empty string to avoid empty array
+  // If no parts remain, return empty string to avoid empty array
   if (parts.length === 0) {
     return "";
   }
@@ -280,6 +331,23 @@ export class OpenRouterAdapter extends BaseProviderAdapter {
 
   private supportsStructuredOutput(model: string): boolean {
     return !this.runtimeNoStructuredOutputModels.has(model);
+  }
+
+  // Session-level cache of routes observed to reject `temperature`. Populated
+  // by executeRequest on 400 errors so repeat calls skip the param.
+  private runtimeNoTemperatureModels = new Set<string>();
+
+  rememberModelRejectsTemperature(model: string): void {
+    this.runtimeNoTemperatureModels.add(model);
+  }
+
+  clearRuntimeNoTemperatureModels(): void {
+    this.runtimeNoTemperatureModels.clear();
+  }
+
+  private supportsTemperature(model: string): boolean {
+    if (this.runtimeNoTemperatureModels.has(model)) return false;
+    return !MODELS_WITHOUT_TEMPERATURE.some((pattern) => pattern.test(model));
   }
 
   //
@@ -370,6 +438,18 @@ export class OpenRouterAdapter extends BaseProviderAdapter {
         request.temperature;
     }
 
+    // Strip temperature for routes that don't support it (denylist + runtime cache)
+    const requestRecord = openRouterRequest as unknown as Record<
+      string,
+      unknown
+    >;
+    if (
+      requestRecord.temperature !== undefined &&
+      !this.supportsTemperature(openRouterRequest.model)
+    ) {
+      delete requestRecord.temperature;
+    }
+
     return openRouterRequest;
   }
 
@@ -404,12 +484,19 @@ export class OpenRouterAdapter extends BaseProviderAdapter {
       jsonSchema = structuredClone(schema) as JsonObject;
       jsonSchema.type = "object"; // Normalize type
     } else {
-      // Convert NaturalSchema to JSON schema through Zod
+      // Convert NaturalSchema to JSON schema through Zod. Re-spread into a
+      // plain object: Zod v4's z.toJSONSchema returns an object that carries
+      // a non-configurable `~standard` Standard-Schema interop marker as a
+      // non-enumerable own property. Anthropic's output_config.format
+      // validation is strict and rejects unknown properties when OpenRouter
+      // forwards the schema, so we drop the marker here. JSON.stringify
+      // already skips it but the OpenRouter SDK enumerates own properties
+      // during serialization.
       const zodSchema =
         schema instanceof z.ZodType
           ? schema
           : naturalZodSchema(schema as NaturalSchema);
-      jsonSchema = z.toJSONSchema(zodSchema) as JsonObject;
+      jsonSchema = { ...(z.toJSONSchema(zodSchema) as JsonObject) };
     }
 
     // Remove $schema property (can cause issues with some providers)
@@ -450,6 +537,31 @@ export class OpenRouterAdapter extends BaseProviderAdapter {
       return response;
     } catch (error) {
       if (signal?.aborted) return undefined as unknown as OpenRouterResponse;
+
+      // If the route rejected `temperature` (e.g., openai/gpt-5.5 forwarding),
+      // cache it and retry without the param.
+      const requestRecord = openRouterRequest as unknown as Record<
+        string,
+        unknown
+      >;
+      if (
+        requestRecord.temperature !== undefined &&
+        isTemperatureDeprecationError(error)
+      ) {
+        this.rememberModelRejectsTemperature(openRouterRequest.model);
+        const retryRequest = { ...openRouterRequest } as OpenRouterRequest;
+        delete (retryRequest as unknown as Record<string, unknown>).temperature;
+        const response = (await openRouter.chat.send(
+          this.toSdkChatParams(retryRequest) as Parameters<
+            typeof openRouter.chat.send
+          >[0],
+          signal ? { signal } : undefined,
+        )) as AnnotatedOpenRouterResponse;
+        if (wantsStructuredOutput) {
+          response.__jaypieStructuredOutput = true;
+        }
+        return response;
+      }
 
       // If the model rejected `response_format`, cache it and retry with the
       // legacy fake-tool emulation path.

--- a/packages/llm/src/operate/adapters/__tests__/GeminiAdapter.spec.ts
+++ b/packages/llm/src/operate/adapters/__tests__/GeminiAdapter.spec.ts
@@ -529,6 +529,87 @@ describe("GeminiAdapter", () => {
           result: "success",
         });
       });
+
+      it("wraps scalar string outputs in { result } so the protobuf Struct accepts them", () => {
+        // The `time` tool returns an ISO string — JSON.parse keeps it as a
+        // string, but Gemini's function_response.response is a Struct and
+        // gemini-3.1-flash-lite rejects scalars with INVALID_ARGUMENT.
+        const toolCall = {
+          callId: "call-1",
+          name: "time",
+          arguments: "{}",
+          raw: {},
+        };
+        const result = {
+          callId: "call-1",
+          output: '"2026-04-30T16:51:14.420Z"',
+          success: true,
+        };
+
+        const formatted = geminiAdapter.formatToolResult(toolCall, result);
+
+        expect(formatted.functionResponse?.response).toEqual({
+          result: "2026-04-30T16:51:14.420Z",
+        });
+      });
+
+      it("wraps array outputs in { result } so they pass Struct validation", () => {
+        const toolCall = {
+          callId: "call-2",
+          name: "roll",
+          arguments: "{}",
+          raw: {},
+        };
+        const result = {
+          callId: "call-2",
+          output: "[1, 2, 3]",
+          success: true,
+        };
+
+        const formatted = geminiAdapter.formatToolResult(toolCall, result);
+
+        expect(formatted.functionResponse?.response).toEqual({
+          result: [1, 2, 3],
+        });
+      });
+
+      it("wraps numeric outputs in { result }", () => {
+        const toolCall = {
+          callId: "call-3",
+          name: "random",
+          arguments: "{}",
+          raw: {},
+        };
+        const result = {
+          callId: "call-3",
+          output: "42",
+          success: true,
+        };
+
+        const formatted = geminiAdapter.formatToolResult(toolCall, result);
+
+        expect(formatted.functionResponse?.response).toEqual({ result: 42 });
+      });
+
+      it("falls back to { result } when output is not valid JSON", () => {
+        const toolCall = {
+          callId: "call-4",
+          name: "raw",
+          arguments: "{}",
+          raw: {},
+        };
+        const result = {
+          callId: "call-4",
+          output: "plain text",
+          success: true,
+        };
+
+        const formatted = geminiAdapter.formatToolResult(toolCall, result);
+
+        expect(formatted.functionResponse?.response).toEqual({
+          result: "plain text",
+        });
+      });
     });
 
     describe("isComplete", () => {

--- a/packages/llm/test/matrix.ts
+++ b/packages/llm/test/matrix.ts
@@ -336,8 +336,25 @@ const SYMBOLS: Record<ActualOutcome, string> = {
   skip: "—",
 };
 
-function cellSymbol(cell: CellResult): string {
-  const sym = SYMBOLS[cell.actual];
+function isOpenRouterModel(model: ModelConfig): boolean {
+  return model.provider === "openrouter";
+}
+
+function displayActual(cell: CellResult, openrouter: boolean): ActualOutcome {
+  // OpenRouter is evaluated as a collective; surface individual failures as
+  // warnings so a single flaky route does not paint the cell red.
+  if (openrouter && cell.actual === "fail") return "warn";
+  return cell.actual;
+}
+
+function cellSymbol(cell: CellResult, openrouter: boolean): string {
+  const actual = displayActual(cell, openrouter);
+  const sym = SYMBOLS[actual];
+  // OpenRouter cells skip the mismatch indicator (collective evaluation).
+  // Otherwise, suppress `!` when the actual outcome is already a failure —
+  // the ❌ glyph conveys the problem on its own.
+  if (openrouter) return sym;
+  if (actual === "fail") return sym;
   return cell.matches ? sym : `${sym}!`;
 }
 
@@ -363,12 +380,13 @@ function formatTable(
   for (const model of models) {
     const cells = rows.get(labelOf(model));
     if (!cells) continue;
+    const openrouter = isOpenRouterModel(model);
     const row = [
       labelOf(model).padEnd(labelWidth),
       ...capabilities.map((c) => {
         const cell = cells.get(c);
         if (!cell) return "?".padStart(colWidth(c));
-        return cellSymbol(cell).padStart(colWidth(c));
+        return cellSymbol(cell, openrouter).padStart(colWidth(c));
       }),
     ].join("  ");
     lines.push(row);
@@ -376,6 +394,9 @@ function formatTable(
   lines.push(sep);
   lines.push(
     "Legend: ✅ ok   ⚠️ warn   ❌ fail   — skip   `!` mismatch vs expected",
+  );
+  lines.push(
+    "OpenRouter rows: failures display as ⚠️ and pass/fail collectively (row+column majority).",
   );
   return lines.join("\n");
 }
@@ -389,11 +410,13 @@ function formatIssues(
     const label = model.label || model.model;
     const cells = rows.get(label);
     if (!cells) continue;
+    const openrouter = isOpenRouterModel(model);
     for (const [cap, cell] of cells) {
       if (cell.matches && cell.warnings.length === 0) continue;
       const parts = [`[${label} / ${cap}]`];
       if (!cell.matches) {
-        parts.push(`expected=${cell.expected}, got=${cell.actual}`);
+        const tag = openrouter ? "openrouter-fail" : "mismatch";
+        parts.push(`${tag} expected=${cell.expected}, got=${cell.actual}`);
       }
       if (cell.detail) parts.push(`detail=${cell.detail}`);
       if (cell.warnings.length > 0) {
@@ -404,6 +427,96 @@ function formatIssues(
     }
   }
   return issues;
+}
+
+//
+//
+// OpenRouter collective evaluation
+//
+// OpenRouter routes are flaky and capability support varies by backend.
+// Rather than gate CI on individual cells, we accept the block as long as
+// the *majority* of every row (per model) AND every column (per capability)
+// is a success (ok or warn). Skips are excluded from the denominator.
+//
+
+interface AxisResult {
+  ok: number;
+  total: number;
+  passed: boolean;
+}
+
+interface OpenRouterEvaluation {
+  passed: boolean;
+  rows: Map<string, AxisResult>;
+  columns: Map<Capability, AxisResult>;
+}
+
+function isCellSuccess(cell: CellResult): boolean {
+  return cell.actual === "ok" || cell.actual === "warn";
+}
+
+function evaluateAxis(cells: readonly CellResult[]): AxisResult {
+  let ok = 0;
+  let total = 0;
+  for (const cell of cells) {
+    if (cell.actual === "skip") continue;
+    total++;
+    if (isCellSuccess(cell)) ok++;
+  }
+  // Strict majority: ok must outnumber failures. An empty axis (all skipped)
+  // is treated as a pass.
+  const passed = total === 0 || ok * 2 > total;
+  return { ok, total, passed };
+}
+
+function evaluateOpenRouter(
+  models: readonly ModelConfig[],
+  capabilities: readonly Capability[],
+  rows: Map<string, Map<Capability, CellResult>>,
+): OpenRouterEvaluation | null {
+  const orModels = models.filter(isOpenRouterModel);
+  if (orModels.length === 0) return null;
+
+  const rowResults = new Map<string, AxisResult>();
+  for (const model of orModels) {
+    const label = model.label || model.model;
+    const cellsMap = rows.get(label);
+    if (!cellsMap) continue;
+    const cells = capabilities
+      .map((c) => cellsMap.get(c))
+      .filter((c): c is CellResult => Boolean(c));
+    rowResults.set(label, evaluateAxis(cells));
+  }
+
+  const colResults = new Map<Capability, AxisResult>();
+  for (const cap of capabilities) {
+    const cells: CellResult[] = [];
+    for (const model of orModels) {
+      const cell = rows.get(model.label || model.model)?.get(cap);
+      if (cell) cells.push(cell);
+    }
+    colResults.set(cap, evaluateAxis(cells));
+  }
+
+  const passed =
+    Array.from(rowResults.values()).every((r) => r.passed) &&
+    Array.from(colResults.values()).every((c) => c.passed);
+
+  return { passed, rows: rowResults, columns: colResults };
+}
+
+function formatOpenRouterReport(evaluation: OpenRouterEvaluation): string[] {
+  const lines: string[] = [];
+  lines.push("OpenRouter (evaluated as a collective):");
+  for (const [label, result] of evaluation.rows) {
+    const status = result.passed ? "✅" : "❌";
+    lines.push(`  ${status} row ${label}: ${result.ok}/${result.total} ok`);
+  }
+  for (const [cap, result] of evaluation.columns) {
+    const status = result.passed ? "✅" : "❌";
+    lines.push(`  ${status} col ${cap}: ${result.ok}/${result.total} ok`);
+  }
+  return lines;
 }
 
 //
@@ -445,13 +558,14 @@ async function main(): Promise<void> {
 
   for (const model of models) {
     const label = model.label || model.model;
+    const openrouter = isOpenRouterModel(model);
     console.log(`▸ ${label}`);
     const cells = new Map<Capability, CellResult>();
     for (const capability of capabilities) {
       process.stdout.write(`  ${capability} … `);
       const cell = await runCell(model, capability);
       cells.set(capability, cell);
-      const status = cellSymbol(cell);
+      const status = cellSymbol(cell, openrouter);
       const note = cell.detail ? ` (${cell.detail})` : "";
       console.log(`${status}${note}`);
     }
@@ -471,19 +585,42 @@ async function main(): Promise<void> {
     for (const line of issues) console.log(line);
   }
 
-  // Exit non-zero if any cell mismatched its expected outcome
+  // OpenRouter cells are evaluated as a collective rather than per-cell.
+  const openrouterEvaluation = evaluateOpenRouter(models, capabilities, rows);
+  if (openrouterEvaluation) {
+    console.log("\n========================================");
+    console.log("       OPENROUTER");
+    console.log("========================================");
+    for (const line of formatOpenRouterReport(openrouterEvaluation)) {
+      console.log(line);
+    }
+  }
+
+  // Exit non-zero if any non-OpenRouter cell mismatched its expected
+  // outcome, or if the OpenRouter block failed its majority threshold.
   let mismatches = 0;
-  for (const cells of rows.values()) {
+  for (const model of models) {
+    if (isOpenRouterModel(model)) continue;
+    const cells = rows.get(model.label || model.model);
+    if (!cells) continue;
     for (const cell of cells.values()) {
       if (!cell.matches) mismatches++;
     }
   }
 
   console.log("\n========================================");
-  if (mismatches === 0) {
+  const openrouterFailed = openrouterEvaluation
+    ? !openrouterEvaluation.passed
+    : false;
+  if (mismatches === 0 && !openrouterFailed) {
     console.log(`🎉 Matrix passed: every cell matched expectation.`);
   } else {
-    console.error(`💀 ${mismatches} cell(s) mismatched expectation.`);
+    if (mismatches > 0) {
+      console.error(`💀 ${mismatches} cell(s) mismatched expectation.`);
+    }
+    if (openrouterFailed) {
+      console.error(`💀 OpenRouter block failed: row/column majority not met.`);
+    }
     process.exit(1);
   }
 }

--- a/packages/llm/test/models.ts
+++ b/packages/llm/test/models.ts
@@ -11,7 +11,7 @@
 //   "ok"   — capability works and produces no warnings
 //   "warn" — capability works but is expected to emit a fallback log.warn
 //            (e.g., gemini-2.5 + tools+structured engages the legacy fake-tool path)
-//   "skip" — capability is not exercised (e.g., OpenRouter cannot upload files)
+//   "skip" — capability is not exercised (e.g., model is text-only)
 //   "fail" — capability is expected to fail outright
 //
 // Any capability not listed in `expect` defaults to "ok".
@@ -93,4 +93,14 @@ export const MODELS: readonly ModelConfig[] = [
   { model: "grok-4.20-0309-reasoning" }, // constants XAI.DEFAULT/LARGE
   { model: "grok-4.20-0309-non-reasoning" }, // constants XAI.SMALL
   { model: "grok-4-1-fast-non-reasoning" }, // constants XAI.TINY
+
+  // ─── OpenRouter routes ───────────────────────────────────────────────
+  // OpenRouter forwards image_url and file content parts to the selected
+  // backend. Models without the relevant modality 4xx, which the harness
+  // surfaces as a fail — refine `expect` per cell after the first run.
+  { model: "anthropic/claude-sonnet-4.6", provider: "openrouter" },
+  { model: "google/gemini-3.1-pro-preview", provider: "openrouter" },
+  { model: "moonshotai/kimi-k2.6", provider: "openrouter" },
+  { model: "openai/gpt-5.5", provider: "openrouter" },
+  { model: "x-ai/grok-4.20", provider: "openrouter" },
 ];

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.51",
+  "version": "0.8.52",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/jaypie/1.2.45.md
+++ b/packages/mcp/release-notes/jaypie/1.2.45.md
@@ -1,0 +1,9 @@
+---
+version: 1.2.45
+date: 2026-04-30
+summary: Bump @jaypie/llm peer-dep range to ^1.2.33 (OpenRouter image/file pass-through + temperature strip-and-retry)
+---
+
+## Changes
+
+- `peerDependencies["@jaypie/llm"]` bumped from `^1.2.32` to `^1.2.33` so consumers pull in the OpenRouter image/file pass-through, the temperature strip-and-retry path, and the Zod v4 `~standard` marker fix in `formatOutputSchema`.

--- a/packages/mcp/release-notes/llm/1.2.33.md
+++ b/packages/mcp/release-notes/llm/1.2.33.md
@@ -1,10 +1,14 @@
 ---
 version: 1.2.33
 date: 2026-04-30
-summary: OpenRouter image/file pass-through, temperature strip-and-retry, and a Zod v4 ~standard marker fix; matrix harness now evaluates OpenRouter as a collective
+summary: OpenRouter image/file pass-through, temperature strip-and-retry, Zod v4 ~standard marker fix, Gemini scalar tool-result wrapping; matrix harness now evaluates OpenRouter as a collective
 ---
 
 ## Changes
+
+### Gemini adapter
+
+- `formatToolResult` now wraps non-object tool outputs (strings, numbers, booleans, arrays, null) in `{ result: value }` before assigning to `function_response.response`. Gemini's protobuf `Struct` only accepts plain objects; gemini-3.1-pro-preview was lenient about it, but gemini-3.1-flash-lite-preview rejected scalars with `INVALID_ARGUMENT`. The built-in `time` tool (and any tool returning a bare value) now works on every Gemini 3 model.
 
 ### OpenRouter adapter
 

--- a/packages/mcp/release-notes/llm/1.2.33.md
+++ b/packages/mcp/release-notes/llm/1.2.33.md
@@ -1,0 +1,24 @@
+---
+version: 1.2.33
+date: 2026-04-30
+summary: OpenRouter image/file pass-through, temperature strip-and-retry, and a Zod v4 ~standard marker fix; matrix harness now evaluates OpenRouter as a collective
+---
+
+## Changes
+
+### OpenRouter adapter
+
+- Image and file content parts now pass through to OpenRouter as `image_url` and `file` parts (camelCase at the SDK input boundary, transformed to snake_case on the wire). The previous behavior dropped images/files with a warning. Backends that don't support a modality 4xx — that's a model-capability mismatch surfaced by the call rather than silently lost.
+- New strip-and-retry pattern for routes that reject `temperature` (for example `openai/gpt-5.5`). A vendor-prefixed denylist plus a session runtime cache mirrors the OpenAI adapter: the param is stripped pre-flight on known routes and on any 400 mentioning "temperature" the route is cached and the request retried without the param.
+- `formatOutputSchema` now drops the non-enumerable `~standard` Standard-Schema interop marker that Zod v4's `z.toJSONSchema()` attaches to its output. Anthropic's strict `output_config.format` rejects unknown properties, so when OpenRouter forwards the schema to an Anthropic backend the marker has to be stripped — accomplished by re-spreading into a plain object since the property is non-configurable.
+
+### Capability matrix harness (`test/matrix.ts`)
+
+- OpenRouter rows are evaluated as a collective rather than per-cell. Individual cell failures display as ⚠️ (not ❌) and the block passes as long as every row (per model) and every column (per capability) has a strict majority of ok cells. Skipped cells are excluded from the denominator.
+- The `!` mismatch indicator is now suppressed whenever the actual outcome is a failure — the ❌ glyph already conveys the issue.
+- `models.ts` adds five OpenRouter routes: `anthropic/claude-sonnet-4.6`, `google/gemini-3.1-pro-preview`, `moonshotai/kimi-k2.6`, `openai/gpt-5.5`, `x-ai/grok-4.20`.
+
+### CI
+
+- `npm-check.yml` `test-llm-matrix` job now passes `OPENROUTER_API_KEY` (sourced from `CICD_OPENROUTER_API_KEY`).
+- `npm-deploy.yml` adds a `test-llm-matrix` job mirroring `test-llm-client`, also wired to `CICD_OPENROUTER_API_KEY`. Runs on every push to `main` and on `deploy-*`/`dev-*`/`rc-*` tags.

--- a/packages/mcp/release-notes/mcp/0.8.52.md
+++ b/packages/mcp/release-notes/mcp/0.8.52.md
@@ -1,0 +1,10 @@
+---
+version: 0.8.52
+date: 2026-04-30
+summary: Add release notes for @jaypie/llm 1.2.33 and jaypie 1.2.45 (OpenRouter image/file + temperature handling, collective matrix evaluation)
+---
+
+## Changes
+
+- Added `release-notes/llm/1.2.33.md` covering OpenRouter image/file pass-through, the temperature strip-and-retry pattern, the Zod v4 `~standard` marker fix in `formatOutputSchema`, and the matrix harness's collective OpenRouter evaluation.
+- Added `release-notes/jaypie/1.2.45.md` for the corresponding `jaypie` peer-dep bump to `@jaypie/llm` `^1.2.33`.

--- a/packages/mcp/release-notes/mcp/0.8.52.md
+++ b/packages/mcp/release-notes/mcp/0.8.52.md
@@ -1,10 +1,10 @@
 ---
 version: 0.8.52
 date: 2026-04-30
-summary: Add release notes for @jaypie/llm 1.2.33 and jaypie 1.2.45 (OpenRouter image/file + temperature handling, collective matrix evaluation)
+summary: Add release notes for @jaypie/llm 1.2.33 and jaypie 1.2.45 (OpenRouter image/file + temperature handling, Gemini scalar tool-result wrapping, collective matrix evaluation)
 ---
 
 ## Changes
 
-- Added `release-notes/llm/1.2.33.md` covering OpenRouter image/file pass-through, the temperature strip-and-retry pattern, the Zod v4 `~standard` marker fix in `formatOutputSchema`, and the matrix harness's collective OpenRouter evaluation.
+- Added `release-notes/llm/1.2.33.md` covering OpenRouter image/file pass-through, the temperature strip-and-retry pattern, the Zod v4 `~standard` marker fix in `formatOutputSchema`, the Gemini `function_response.response` Struct wrapping fix, and the matrix harness's collective OpenRouter evaluation.
 - Added `release-notes/jaypie/1.2.45.md` for the corresponding `jaypie` peer-dep bump to `@jaypie/llm` `^1.2.33`.


### PR DESCRIPTION
## Summary

Bumps `@jaypie/llm` 1.2.33, `jaypie` 1.2.45, `@jaypie/mcp` 0.8.52.

- **OpenRouter image/file pass-through** — image and PDF parts now forward to the selected backend instead of being dropped.
- **OpenRouter temperature strip-and-retry** — denylist + session runtime cache for routes that 400 on `temperature` (e.g. `openai/gpt-5.5`).
- **OpenRouter Zod v4 `~standard` marker fix** — `formatOutputSchema` re-spreads `z.toJSONSchema()` output so the non-enumerable Standard-Schema marker is dropped, allowing Anthropic backends (which strictly validate `output_config.format`) to accept Zod-derived schemas via OpenRouter.
- **Capability matrix collective evaluation** — OpenRouter rows pass/fail as a block (strict majority of every row and column), individual cell failures display as ⚠️, and the `!` mismatch indicator is suppressed when the actual outcome is already a failure. Five new OpenRouter routes added.
- **Gemini scalar tool-result wrapping** — `formatToolResult` now wraps non-object tool outputs in `{ result: value }` so Gemini's protobuf `Struct` accepts them (previously gemini-3.1-pro-preview was lenient about scalars; gemini-3.1-flash-lite-preview rejected them as `INVALID_ARGUMENT`). Caught by the matrix's `gemini-3.1-flash-lite-preview / both` cell.
- **CI** — matrix runs in `npm-check` (conditional on `packages/llm/**` changes) and `npm-deploy` (every main/tag push), with `OPENROUTER_API_KEY` wired in.

## Test plan

- [x] `npm run typecheck -w packages/llm` clean
- [x] `npm run lint -w packages/llm` 0 errors
- [x] `npm test -w packages/llm` 806 tests pass (4 new GeminiAdapter scalar-wrapping tests)
- [x] `npm test -w packages/jaypie -w packages/mcp` clean
- [x] NPM Check workflow run 25178325646 — all jobs green including capability matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)