### PR TITLE
fix(dynamodb): serialize Date values to ISO strings (#331)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28486,7 +28486,7 @@
     },
     "packages/dynamodb": {
       "name": "@jaypie/dynamodb",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.726.1",
@@ -29471,7 +29471,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.52",
+      "version": "0.8.53",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.4",

--- a/packages/dynamodb/package.json
+++ b/packages/dynamodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/dynamodb",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"

--- a/packages/dynamodb/src/__tests__/entities.spec.ts
+++ b/packages/dynamodb/src/__tests__/entities.spec.ts
@@ -138,6 +138,47 @@ describe("Entity Operations", () => {
       expect(result.indexModel).toBe("record");
       expect(result.indexModelAlias).toBe("record#my-alias");
     });
+
+    it("serializes top-level Date values to ISO strings", async () => {
+      const expiresAt = new Date("2026-05-02T19:45:28.000Z");
+      const entity = {
+        ...createTestEntity(),
+        expiresAt,
+      } as StorableEntity;
+      const result = (await createEntity({ entity })) as StorableEntity & {
+        expiresAt?: unknown;
+      };
+      expect(result.expiresAt).toBe(expiresAt.toISOString());
+      const cmd = mockSend.mock.calls[0][0];
+      expect(cmd.input.Item.expiresAt).toBe(expiresAt.toISOString());
+    });
+
+    it("serializes nested Date values inside state to ISO strings", async () => {
+      const lastUsedAt = new Date("2026-05-02T19:45:28.000Z");
+      const entity = {
+        ...createTestEntity(),
+        state: { lastUsedAt, nested: { when: lastUsedAt } },
+      } as StorableEntity;
+      await createEntity({ entity });
+      const cmd = mockSend.mock.calls[0][0];
+      expect(cmd.input.Item.state.lastUsedAt).toBe(lastUsedAt.toISOString());
+      expect(cmd.input.Item.state.nested.when).toBe(lastUsedAt.toISOString());
+    });
+
+    it("serializes Date values inside arrays to ISO strings", async () => {
+      const a = new Date("2026-05-02T19:45:28.000Z");
+      const b = new Date("2026-05-03T19:45:28.000Z");
+      const entity = {
+        ...createTestEntity(),
+        state: { times: [a, b] },
+      } as StorableEntity;
+      await createEntity({ entity });
+      const cmd = mockSend.mock.calls[0][0];
+      expect(cmd.input.Item.state.times).toEqual([
+        a.toISOString(),
+        b.toISOString(),
+      ]);
+    });
   });
 
   describe("updateEntity", () => {
@@ -168,6 +209,18 @@ describe("Entity Operations", () => {
       };
       expect(result.indexModel).toBe("record");
       expect(result.indexModelType).toBe("record#note");
+    });
+
+    it("serializes Date values to ISO strings", async () => {
+      const expiresAt = new Date("2026-05-02T19:45:28.000Z");
+      const entity = {
+        ...createTestEntity(),
+        expiresAt,
+      } as StorableEntity;
+      const result = (await updateEntity({ entity })) as StorableEntity & {
+        expiresAt?: unknown;
+      };
+      expect(result.expiresAt).toBe(expiresAt.toISOString());
     });
   });
 

--- a/packages/dynamodb/src/keyBuilders.ts
+++ b/packages/dynamodb/src/keyBuilders.ts
@@ -42,10 +42,36 @@ export function calculateScope(parent?: ParentReference): string {
 }
 
 /**
+ * Recursively convert Date instances to ISO 8601 strings.
+ * `@aws-sdk/util-dynamodb` cannot marshall Date instances natively
+ * (`convertClassInstanceToMap` would marshal them to empty maps, losing data).
+ */
+function serializeDates<T>(value: T): T {
+  if (value instanceof Date) {
+    return value.toISOString() as unknown as T;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => serializeDates(item)) as unknown as T;
+  }
+  if (value && typeof value === "object") {
+    const result: Record<string, unknown> = {};
+    for (const [key, item] of Object.entries(
+      value as Record<string, unknown>,
+    )) {
+      result[key] = serializeDates(item);
+    }
+    return result as unknown as T;
+  }
+  return value;
+}
+
+/**
  * Auto-populate GSI index keys on an entity and advance its write timestamps.
  *
  * - Bumps `updatedAt` to now on every call.
  * - Backfills `createdAt` to the same now if not already set.
+ * - Serializes any `Date` instances on the entity to ISO 8601 strings so the
+ *   DynamoDB document client can marshall them.
  * - Populates GSI attributes (pk composite and sk composite when applicable)
  *   using the indexes registered for the entity's model.
  *
@@ -62,9 +88,10 @@ export function indexEntity<T extends StorableEntity>(
   suffix?: string,
 ): T {
   const now = new Date().toISOString();
+  const serialized = serializeDates(entity);
   const bumped = {
-    ...entity,
-    createdAt: entity.createdAt ?? now,
+    ...serialized,
+    createdAt: serialized.createdAt ?? now,
     updatedAt: now,
   } as T;
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.52",
+  "version": "0.8.53",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/dynamodb/0.6.1.md
+++ b/packages/mcp/release-notes/dynamodb/0.6.1.md
@@ -1,0 +1,20 @@
+---
+version: 0.6.1
+date: 2026-05-02
+summary: Auto-serialize Date instances to ISO 8601 strings on write so entities with Date-typed fields no longer crash the marshaller
+---
+
+## Fixed
+
+- **Date values on entities**. `createEntity`, `updateEntity`, `deleteEntity`,
+  `archiveEntity`, `transactWriteEntities`, and `seedEntities` would throw
+  `Unsupported type passed: ...` from `@aws-sdk/util-dynamodb` whenever a
+  field held a `Date` instance — even though Jaypie entity timestamp types
+  are typed `Date | null`. The fix: `indexEntity` now walks the entity (top
+  level, nested objects, arrays) and converts any `Date` to
+  `value.toISOString()` before timestamps and GSI keys are populated.
+
+  Reads still return ISO strings, not `Date` instances. If you want a
+  `Date` back, hydrate at the boundary (`new Date(entity.expiresAt)`).
+
+  Issue: [#331](https://github.com/finlaysonstudio/jaypie/issues/331)


### PR DESCRIPTION
## Summary
- `createEntity`/`updateEntity` (and every write path that goes through `indexEntity`) threw `Unsupported type passed: ...` from `@aws-sdk/util-dynamodb` whenever an entity field held a `Date` instance — even though Jaypie entity timestamps are typed `Date | null`.
- `indexEntity` now recursively walks the entity (top-level fields, nested objects, arrays) and converts any `Date` to `value.toISOString()` before timestamps and GSI keys are populated. Centralizing in `indexEntity` covers `createEntity`, `updateEntity`, `deleteEntity`, `archiveEntity`, `transactWriteEntities`, `seedEntities`, and `@jaypie/testkit/mock` (which delegates to the real `indexEntity`).
- Reads still return ISO strings, not `Date` instances. Hydrate at the boundary if a `Date` is required (`new Date(entity.expiresAt)`).
- Bumps `@jaypie/dynamodb` to 0.6.1 and `@jaypie/mcp` to 0.8.53 (release note added).

Closes #331

## Test plan
- [x] New tests in `packages/dynamodb/src/__tests__/entities.spec.ts` cover top-level Dates, nested objects, arrays, and `updateEntity`
- [x] All 172 dynamodb tests pass
- [x] typecheck, build, lint clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)