### PR TITLE
feat: JaypieWebDeploymentBucket adopts JaypieDistribution defaults; eslint resolver fix (#333)

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,14 +646,12 @@ export class MyStack extends JaypieStack {
 
 #### `JaypieWebDeploymentBucket`
 
-S3 bucket optimized for static website deployment with CloudFront distribution, custom domain support, and automated deployment workflows.
+S3 + CloudFront + ACM + Route53 for static sites, with security headers, WAFv2, and access logging on by default (same override mechanisms as `JaypieDistribution`). Setting `CDK_ENV_REPO` also provisions a scoped GitHub OIDC deploy role.
 
 ```typescript
 const webBucket = new JaypieWebDeploymentBucket(this, "WebSite", {
-  domainName: "www.example.com",
-  certificateArn: "arn:aws:acm:us-east-1:123456789012:certificate/abc123",
-  indexDocument: "index.html",
-  errorDocument: "404.html",
+  host: "www.example.com",
+  zone: "example.com",
 });
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28561,7 +28561,7 @@
     },
     "packages/eslint": {
       "name": "@jaypie/eslint",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "MIT",
       "dependencies": {
         "@eslint/js": "^10.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28389,7 +28389,7 @@
     },
     "packages/constructs": {
       "name": "@jaypie/constructs",
-      "version": "1.2.51",
+      "version": "1.2.52",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*",
@@ -29471,7 +29471,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.53",
+      "version": "0.8.54",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.4",

--- a/packages/constructs/package.json
+++ b/packages/constructs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/constructs",
-  "version": "1.2.51",
+  "version": "1.2.52",
   "description": "CDK constructs for Jaypie applications",
   "repository": {
     "type": "git",

--- a/packages/constructs/src/JaypieStaticWebBucket.ts
+++ b/packages/constructs/src/JaypieStaticWebBucket.ts
@@ -1,7 +1,7 @@
 import { Construct } from "constructs";
 
 import { CDK } from "./constants";
-import { constructEnvName, envHostname } from "./helpers";
+import { constructEnvName, envHostname, HostConfig } from "./helpers";
 import {
   JaypieWebDeploymentBucket,
   JaypieWebDeploymentBucketProps,
@@ -12,10 +12,11 @@ export interface JaypieStaticWebBucketProps extends Omit<
   "host" | "name" | "roleTag"
 > {
   /**
-   * The domain name for the website
+   * The domain name for the website. Accepts a string or a HostConfig
+   * object resolved via envHostname().
    * @default envHostname({ subdomain: "static" })
    */
-  host?: string;
+  host?: string | HostConfig;
   /**
    * Optional bucket name
    * @default constructEnvName("static")

--- a/packages/constructs/src/JaypieWebDeploymentBucket.ts
+++ b/packages/constructs/src/JaypieWebDeploymentBucket.ts
@@ -28,6 +28,8 @@ import { ConfigurationError } from "@jaypie/errors";
 import { CDK } from "./constants";
 import {
   constructEnvName,
+  envHostname,
+  HostConfig,
   isProductionEnv,
   isValidHostname,
   isValidSubdomain,
@@ -75,10 +77,24 @@ export interface JaypieWebDeploymentBucketProps extends s3.BucketProps {
    */
   destination?: LambdaDestination | boolean;
   /**
-   * The domain name for the website
+   * The domain name for the website.
+   *
+   * Supports both string and config object:
+   * - String: used directly as the domain name (e.g., "app.example.com")
+   * - Object: passed to envHostname() to construct the domain name
+   *   - { subdomain, domain, env, component }
+   *
    * @default mergeDomain(CDK_ENV_WEB_SUBDOMAIN, CDK_ENV_WEB_HOSTED_ZONE || CDK_ENV_HOSTED_ZONE)
+   *
+   * @example
+   * // Direct string
+   * host: "app.example.com"
+   *
+   * @example
+   * // Config object - resolves using envHostname()
+   * host: { subdomain: "app" }
    */
-  host?: string;
+  host?: string | HostConfig;
   /**
    * External log bucket for CloudFront access logs.
    * - IBucket: Use existing bucket directly
@@ -201,8 +217,16 @@ export class JaypieWebDeploymentBucket extends Construct implements s3.IBucket {
     }
 
     // Determine host from props or environment
-    let host: string | undefined = propsHost;
-    if (!host) {
+    let host: string | undefined;
+    if (typeof propsHost === "string") {
+      host = propsHost;
+    } else if (typeof propsHost === "object") {
+      try {
+        host = envHostname(propsHost);
+      } catch {
+        host = undefined;
+      }
+    } else {
       try {
         host =
           process.env.CDK_ENV_WEB_HOST ||

--- a/packages/constructs/src/JaypieWebDeploymentBucket.ts
+++ b/packages/constructs/src/JaypieWebDeploymentBucket.ts
@@ -19,7 +19,9 @@ import {
 import * as route53 from "aws-cdk-lib/aws-route53";
 import * as route53Targets from "aws-cdk-lib/aws-route53-targets";
 import * as s3 from "aws-cdk-lib/aws-s3";
+import { LambdaDestination } from "aws-cdk-lib/aws-s3-notifications";
 import * as kms from "aws-cdk-lib/aws-kms";
+import * as wafv2 from "aws-cdk-lib/aws-wafv2";
 import { Construct } from "constructs";
 import { ConfigurationError } from "@jaypie/errors";
 
@@ -32,7 +34,31 @@ import {
   mergeDomain,
   resolveCertificate,
 } from "./helpers";
+import { resolveDatadogForwarderFunction } from "./helpers/resolveDatadogForwarderFunction";
+import {
+  JaypieWafConfig,
+  SecurityHeadersOverrides,
+} from "./JaypieDistribution";
 import { JaypieHostedZone } from "./JaypieHostedZone";
+
+const DEFAULT_RATE_LIMIT = 2000;
+
+const DEFAULT_MANAGED_RULES = [
+  "AWSManagedRulesCommonRuleSet",
+  "AWSManagedRulesKnownBadInputsRuleSet",
+];
+
+/**
+ * WAF configuration for JaypieWebDeploymentBucket. Same shape as
+ * JaypieDistribution's JaypieWafConfig, but `name` is optional — when omitted,
+ * the construct id is used to namespace the WebACL and WAF log bucket.
+ */
+export type JaypieWebDeploymentBucketWafConfig = Omit<
+  JaypieWafConfig,
+  "name"
+> & {
+  name?: string;
+};
 
 export interface JaypieWebDeploymentBucketProps extends s3.BucketProps {
   /**
@@ -41,19 +67,59 @@ export interface JaypieWebDeploymentBucketProps extends s3.BucketProps {
    */
   certificate?: boolean | acm.ICertificate;
   /**
+   * Log destination configuration for CloudFront access logs.
+   * - LambdaDestination: Use a specific Lambda destination for S3 notifications
+   * - true: Use Datadog forwarder for S3 notifications (default)
+   * - false: Disable S3 notifications (logging still occurs if logBucket is set)
+   * @default true
+   */
+  destination?: LambdaDestination | boolean;
+  /**
    * The domain name for the website
    * @default mergeDomain(CDK_ENV_WEB_SUBDOMAIN, CDK_ENV_WEB_HOSTED_ZONE || CDK_ENV_HOSTED_ZONE)
    */
   host?: string;
   /**
+   * External log bucket for CloudFront access logs.
+   * - IBucket: Use existing bucket directly
+   * - string: Bucket name to import
+   * - { exportName: string }: CloudFormation export name to import
+   * - true: Use account logging bucket (CDK.IMPORT.LOG_BUCKET)
+   * @default undefined (creates new bucket if destination !== false)
+   */
+  logBucket?: s3.IBucket | string | { exportName: string } | true;
+  /**
    * Optional bucket name
    */
   name?: string;
+  /**
+   * Full override for the response headers policy.
+   * When provided, bypasses all default security header logic.
+   */
+  responseHeadersPolicy?: cloudfront.IResponseHeadersPolicy;
   /**
    * Role tag for tagging resources
    * @default CDK.ROLE.HOSTING
    */
   roleTag?: string;
+  /**
+   * Security headers configuration.
+   * - true/undefined: apply sensible defaults (HSTS, X-Frame-Options, CSP, etc.)
+   * - false: disable security headers entirely
+   * - SecurityHeadersOverrides object: merge overrides with defaults
+   * @default true
+   */
+  securityHeaders?: boolean | SecurityHeadersOverrides;
+  /**
+   * WAF WebACL configuration for the CloudFront distribution.
+   * - true/undefined: create and attach a WebACL with sensible defaults; the
+   *   construct id is used to namespace the WebACL and WAF log bucket
+   * - false: disable WAF
+   * - JaypieWebDeploymentBucketWafConfig: customize WAF behavior; if `name`
+   *   is omitted the construct id is used
+   * @default true
+   */
+  waf?: boolean | JaypieWebDeploymentBucketWafConfig;
   /**
    * The hosted zone for DNS records
    * @default CDK_ENV_WEB_HOSTED_ZONE || CDK_ENV_HOSTED_ZONE
@@ -78,6 +144,10 @@ export class JaypieWebDeploymentBucket extends Construct implements s3.IBucket {
   public readonly distributionDomainName?: string;
   public readonly certificate?: acm.ICertificate;
   public readonly distribution?: cloudfront.Distribution;
+  public readonly logBucket?: s3.IBucket;
+  public readonly responseHeadersPolicy?: cloudfront.IResponseHeadersPolicy;
+  public readonly wafLogBucket?: s3.IBucket;
+  public readonly webAcl?: wafv2.CfnWebACL;
 
   constructor(
     scope: Construct,
@@ -86,7 +156,21 @@ export class JaypieWebDeploymentBucket extends Construct implements s3.IBucket {
   ) {
     super(scope, id);
 
-    const roleTag = props.roleTag || CDK.ROLE.HOSTING;
+    const {
+      certificate: certificateProp,
+      destination: destinationProp = true,
+      host: propsHost,
+      logBucket: logBucketProp,
+      name: nameProp,
+      responseHeadersPolicy: responseHeadersPolicyProp,
+      roleTag: roleTagProp,
+      securityHeaders: securityHeadersProp,
+      waf: wafProp = true,
+      zone: propsZone,
+      ...bucketProps
+    } = props;
+
+    const roleTag = roleTagProp || CDK.ROLE.HOSTING;
 
     // Environment variable validation
     if (
@@ -117,7 +201,7 @@ export class JaypieWebDeploymentBucket extends Construct implements s3.IBucket {
     }
 
     // Determine host from props or environment
-    let host = props.host;
+    let host: string | undefined = propsHost;
     if (!host) {
       try {
         host =
@@ -139,7 +223,7 @@ export class JaypieWebDeploymentBucket extends Construct implements s3.IBucket {
 
     // Determine zone from props or environment
     const zone =
-      props.zone ||
+      propsZone ||
       process.env.CDK_ENV_WEB_HOSTED_ZONE ||
       process.env.CDK_ENV_HOSTED_ZONE;
 
@@ -148,13 +232,13 @@ export class JaypieWebDeploymentBucket extends Construct implements s3.IBucket {
       accessControl: s3.BucketAccessControl.BUCKET_OWNER_FULL_CONTROL,
       autoDeleteObjects: true,
       blockPublicAccess: s3.BlockPublicAccess.BLOCK_ACLS_ONLY,
-      bucketName: props.name || constructEnvName("web"),
+      bucketName: nameProp || constructEnvName("web"),
       publicReadAccess: true,
       removalPolicy: RemovalPolicy.DESTROY,
       versioned: false,
       websiteErrorDocument: "index.html",
       websiteIndexDocument: "index.html",
-      ...props,
+      ...bucketProps,
     });
 
     // Delegate IBucket properties to the bucket
@@ -255,7 +339,7 @@ export class JaypieWebDeploymentBucket extends Construct implements s3.IBucket {
 
       // Use resolveCertificate to create certificate at stack level (enables reuse when swapping constructs)
       this.certificate = resolveCertificate(this, {
-        certificate: props.certificate,
+        certificate: certificateProp,
         domainName: host,
         roleTag,
         zone: hostedZone,
@@ -267,16 +351,155 @@ export class JaypieWebDeploymentBucket extends Construct implements s3.IBucket {
         });
       }
 
+      // Resolve response headers policy for security headers
+      let resolvedResponseHeadersPolicy:
+        | cloudfront.IResponseHeadersPolicy
+        | undefined;
+      if (responseHeadersPolicyProp) {
+        resolvedResponseHeadersPolicy = responseHeadersPolicyProp;
+      } else if (securityHeadersProp !== false) {
+        const overrides =
+          typeof securityHeadersProp === "object" ? securityHeadersProp : {};
+        resolvedResponseHeadersPolicy = new cloudfront.ResponseHeadersPolicy(
+          this,
+          "SecurityHeaders",
+          {
+            customHeadersBehavior: {
+              customHeaders: [
+                {
+                  header: "Cache-Control",
+                  override: true,
+                  value:
+                    "no-store, no-cache, must-revalidate, proxy-revalidate",
+                },
+                {
+                  header: "Cross-Origin-Embedder-Policy",
+                  override: true,
+                  value: "unsafe-none",
+                },
+                {
+                  header: "Cross-Origin-Opener-Policy",
+                  override: true,
+                  value: "same-origin",
+                },
+                {
+                  header: "Cross-Origin-Resource-Policy",
+                  override: true,
+                  value: "same-origin",
+                },
+                {
+                  header: "Permissions-Policy",
+                  override: true,
+                  value:
+                    overrides.permissionsPolicy ??
+                    CDK.SECURITY_HEADERS.PERMISSIONS_POLICY,
+                },
+              ],
+            },
+            removeHeaders: ["Server"],
+            securityHeadersBehavior: {
+              contentSecurityPolicy: {
+                contentSecurityPolicy:
+                  overrides.contentSecurityPolicy ??
+                  CDK.SECURITY_HEADERS.CONTENT_SECURITY_POLICY,
+                override: true,
+              },
+              contentTypeOptions: { override: true },
+              frameOptions: {
+                frameOption:
+                  overrides.frameOption ?? cloudfront.HeadersFrameOption.DENY,
+                override: true,
+              },
+              referrerPolicy: {
+                referrerPolicy:
+                  overrides.referrerPolicy ??
+                  cloudfront.HeadersReferrerPolicy
+                    .STRICT_ORIGIN_WHEN_CROSS_ORIGIN,
+                override: true,
+              },
+              strictTransportSecurity: {
+                accessControlMaxAge: Duration.seconds(
+                  overrides.hstsMaxAge ?? CDK.SECURITY_HEADERS.HSTS_MAX_AGE,
+                ),
+                includeSubdomains: overrides.hstsIncludeSubdomains ?? true,
+                override: true,
+                preload: true,
+              },
+            },
+          },
+        );
+      }
+      this.responseHeadersPolicy = resolvedResponseHeadersPolicy;
+
+      // Resolve or create access log bucket
+      let accessLogBucket: s3.IBucket | undefined;
+      const isExternalLogBucket = logBucketProp !== undefined;
+
+      if (logBucketProp !== undefined) {
+        accessLogBucket = this.resolveLogBucket(logBucketProp);
+      } else if (destinationProp !== false) {
+        const createdBucket = new s3.Bucket(
+          this,
+          constructEnvName("LogBucket"),
+          {
+            autoDeleteObjects: true,
+            lifecycleRules: [
+              {
+                expiration: Duration.days(90),
+                transitions: [
+                  {
+                    storageClass: s3.StorageClass.INFREQUENT_ACCESS,
+                    transitionAfter: Duration.days(30),
+                  },
+                ],
+              },
+            ],
+            objectOwnership: s3.ObjectOwnership.OBJECT_WRITER,
+            removalPolicy: RemovalPolicy.DESTROY,
+          },
+        );
+        Tags.of(createdBucket).add(CDK.TAG.ROLE, CDK.ROLE.STORAGE);
+        accessLogBucket = createdBucket;
+      }
+
+      if (
+        accessLogBucket &&
+        destinationProp !== false &&
+        !isExternalLogBucket
+      ) {
+        const lambdaDestination =
+          destinationProp === true
+            ? new LambdaDestination(resolveDatadogForwarderFunction(this))
+            : destinationProp;
+
+        (accessLogBucket as s3.Bucket).addEventNotification(
+          s3.EventType.OBJECT_CREATED,
+          lambdaDestination,
+        );
+      }
+
+      this.logBucket = accessLogBucket;
+
       // Create CloudFront distribution
       this.distribution = new cloudfront.Distribution(this, "Distribution", {
         defaultBehavior: {
           cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
           origin: new origins.S3StaticWebsiteOrigin(this.bucket),
+          ...(resolvedResponseHeadersPolicy
+            ? { responseHeadersPolicy: resolvedResponseHeadersPolicy }
+            : {}),
           viewerProtocolPolicy:
             cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
         },
         certificate: this.certificate,
         domainNames: [host],
+        ...(accessLogBucket
+          ? {
+              enableLogging: true,
+              logBucket: accessLogBucket,
+              logFilePrefix: "cloudfront-logs/",
+            }
+          : {}),
       });
       Tags.of(this.distribution).add(CDK.TAG.ROLE, roleTag);
 
@@ -289,6 +512,9 @@ export class JaypieWebDeploymentBucket extends Construct implements s3.IBucket {
             viewerProtocolPolicy:
               cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
             cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
+            ...(resolvedResponseHeadersPolicy
+              ? { responseHeadersPolicy: resolvedResponseHeadersPolicy }
+              : {}),
           },
         );
       }
@@ -322,7 +548,179 @@ export class JaypieWebDeploymentBucket extends Construct implements s3.IBucket {
           }),
         );
       }
+
+      // Create and attach WAF WebACL
+      let resolvedWebAclArn: string | undefined;
+      const wafConfig = this.resolveWafConfig(wafProp, id);
+      if (wafConfig) {
+        if (wafConfig.webAclArn) {
+          resolvedWebAclArn = wafConfig.webAclArn;
+          this.distribution.attachWebAclId(wafConfig.webAclArn);
+        } else {
+          const {
+            managedRuleOverrides,
+            managedRuleScopeDowns,
+            managedRules = DEFAULT_MANAGED_RULES,
+            rateLimitPerIp = DEFAULT_RATE_LIMIT,
+          } = wafConfig;
+
+          let priority = 0;
+          const rules: wafv2.CfnWebACL.RuleProperty[] = [];
+
+          for (const ruleName of managedRules) {
+            const ruleActionOverrides = managedRuleOverrides?.[ruleName];
+            const scopeDownStatement = managedRuleScopeDowns?.[ruleName];
+            rules.push({
+              name: ruleName,
+              priority: priority++,
+              overrideAction: { none: {} },
+              statement: {
+                managedRuleGroupStatement: {
+                  name: ruleName,
+                  vendorName: "AWS",
+                  ...(ruleActionOverrides && { ruleActionOverrides }),
+                  ...(scopeDownStatement && { scopeDownStatement }),
+                },
+              },
+              visibilityConfig: {
+                cloudWatchMetricsEnabled: true,
+                metricName: ruleName,
+                sampledRequestsEnabled: true,
+              },
+            });
+          }
+
+          rules.push({
+            name: "RateLimitPerIp",
+            priority,
+            action: { block: {} },
+            statement: {
+              rateBasedStatement: {
+                aggregateKeyType: "IP",
+                limit: rateLimitPerIp,
+              },
+            },
+            visibilityConfig: {
+              cloudWatchMetricsEnabled: true,
+              metricName: "RateLimitPerIp",
+              sampledRequestsEnabled: true,
+            },
+          });
+
+          const webAclName = constructEnvName(`${wafConfig.name}-WebAcl`);
+          const webAcl = new wafv2.CfnWebACL(this, "WebAcl", {
+            defaultAction: { allow: {} },
+            name: webAclName,
+            rules,
+            scope: "CLOUDFRONT",
+            visibilityConfig: {
+              cloudWatchMetricsEnabled: true,
+              metricName: webAclName,
+              sampledRequestsEnabled: true,
+            },
+          });
+
+          (this as { webAcl?: wafv2.CfnWebACL }).webAcl = webAcl;
+          resolvedWebAclArn = webAcl.attrArn;
+          this.distribution.attachWebAclId(webAcl.attrArn);
+          Tags.of(webAcl).add(CDK.TAG.ROLE, roleTag);
+        }
+      }
+
+      // Create WAF logging
+      if (resolvedWebAclArn && wafConfig) {
+        const { logBucket: wafLogBucketProp = true } = wafConfig;
+
+        let wafLogBucket: s3.IBucket | undefined;
+        if (wafLogBucketProp === true) {
+          const wafLogBucketId = constructEnvName(
+            `${wafConfig.name}-WafLogBucket`,
+          );
+          const wafLogBucketName = `aws-waf-logs-${constructEnvName(
+            `${wafConfig.name}-waf`,
+          ).toLowerCase()}`;
+          const createdBucket = new s3.Bucket(this, wafLogBucketId, {
+            bucketName: wafLogBucketName,
+            lifecycleRules: [
+              {
+                expiration: Duration.days(90),
+                transitions: [
+                  {
+                    storageClass: s3.StorageClass.INFREQUENT_ACCESS,
+                    transitionAfter: Duration.days(30),
+                  },
+                ],
+              },
+            ],
+            objectOwnership: s3.ObjectOwnership.OBJECT_WRITER,
+            removalPolicy: RemovalPolicy.RETAIN,
+          });
+          Tags.of(createdBucket).add(CDK.TAG.ROLE, CDK.ROLE.MONITORING);
+
+          if (destinationProp !== false) {
+            const lambdaDestination =
+              destinationProp === true
+                ? new LambdaDestination(resolveDatadogForwarderFunction(this))
+                : destinationProp;
+            createdBucket.addEventNotification(
+              s3.EventType.OBJECT_CREATED,
+              lambdaDestination,
+            );
+          }
+
+          wafLogBucket = createdBucket;
+        } else if (typeof wafLogBucketProp === "object") {
+          wafLogBucket = wafLogBucketProp;
+        }
+
+        if (wafLogBucket) {
+          (this as { wafLogBucket?: s3.IBucket }).wafLogBucket = wafLogBucket;
+          new wafv2.CfnLoggingConfiguration(this, "WafLoggingConfig", {
+            logDestinationConfigs: [wafLogBucket.bucketArn],
+            resourceArn: resolvedWebAclArn,
+          });
+        }
+      }
     }
+  }
+
+  private resolveWafConfig(
+    wafProp: boolean | JaypieWebDeploymentBucketWafConfig,
+    defaultName: string,
+  ): JaypieWafConfig | undefined {
+    if (wafProp === false) return undefined;
+    if (wafProp === true) return { name: defaultName };
+    if (wafProp.enabled === false) return undefined;
+    return { ...wafProp, name: wafProp.name || defaultName };
+  }
+
+  private isExportNameObject(value: unknown): value is { exportName: string } {
+    return (
+      typeof value === "object" &&
+      value !== null &&
+      "exportName" in value &&
+      typeof (value as { exportName: string }).exportName === "string"
+    );
+  }
+
+  private resolveLogBucket(
+    logBucketProp: s3.IBucket | string | { exportName: string } | true,
+  ): s3.IBucket {
+    if (logBucketProp === true) {
+      const bucketName = Fn.importValue(CDK.IMPORT.LOG_BUCKET);
+      return s3.Bucket.fromBucketName(this, "ImportedLogBucket", bucketName);
+    }
+
+    if (this.isExportNameObject(logBucketProp)) {
+      const bucketName = Fn.importValue(logBucketProp.exportName);
+      return s3.Bucket.fromBucketName(this, "ImportedLogBucket", bucketName);
+    }
+
+    if (typeof logBucketProp === "string") {
+      return s3.Bucket.fromBucketName(this, "ImportedLogBucket", logBucketProp);
+    }
+
+    return logBucketProp;
   }
 
   // Implement remaining IBucket methods by delegating to the bucket

--- a/packages/constructs/src/__tests__/JaypieWebDeploymentBucket.spec.ts
+++ b/packages/constructs/src/__tests__/JaypieWebDeploymentBucket.spec.ts
@@ -257,6 +257,41 @@ describe("JaypieWebDeploymentBucket", () => {
     });
   });
 
+  describe("HostConfig", () => {
+    it("resolves host from a HostConfig object via envHostname", () => {
+      process.env.PROJECT_ENV = "production";
+      const { stack, zone } = makeStack();
+
+      const construct = new JaypieWebDeploymentBucket(stack, "Web", {
+        host: { subdomain: "app", domain: "example.com" },
+        zone,
+      });
+      const template = Template.fromStack(stack);
+      const distribution = findDistribution(template);
+
+      expect(construct.distribution).toBeDefined();
+      expect(distribution.Properties.DistributionConfig.Aliases).toEqual([
+        "app.example.com",
+      ]);
+    });
+
+    it("includes env in non-production HostConfig hosts", () => {
+      process.env.PROJECT_ENV = "sandbox";
+      const { stack, zone } = makeStack();
+
+      new JaypieWebDeploymentBucket(stack, "Web", {
+        host: { subdomain: "app", domain: "example.com" },
+        zone,
+      });
+      const template = Template.fromStack(stack);
+      const distribution = findDistribution(template);
+
+      expect(distribution.Properties.DistributionConfig.Aliases).toEqual([
+        "app.sandbox.example.com",
+      ]);
+    });
+  });
+
   describe("Access Logging", () => {
     it("creates an access log bucket by default", () => {
       const { stack, zone } = makeStack();

--- a/packages/constructs/src/__tests__/JaypieWebDeploymentBucket.spec.ts
+++ b/packages/constructs/src/__tests__/JaypieWebDeploymentBucket.spec.ts
@@ -1,0 +1,301 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Stack } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import * as cloudfront from "aws-cdk-lib/aws-cloudfront";
+import * as route53 from "aws-cdk-lib/aws-route53";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import { JaypieWebDeploymentBucket } from "../JaypieWebDeploymentBucket";
+
+function findDistribution(template: Template) {
+  const resources = template.findResources("AWS::CloudFront::Distribution");
+  return Object.values(resources)[0];
+}
+
+function makeStack() {
+  const stack = new Stack(undefined, "Stack", {
+    env: { account: "111111111111", region: "us-east-1" },
+  });
+  const zone = new route53.HostedZone(stack, "Zone", {
+    zoneName: "example.com",
+  });
+  return { stack, zone };
+}
+
+describe("JaypieWebDeploymentBucket", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.CDK_ENV_HOSTED_ZONE;
+    delete process.env.CDK_ENV_WEB_HOST;
+    delete process.env.CDK_ENV_WEB_HOSTED_ZONE;
+    delete process.env.CDK_ENV_WEB_SUBDOMAIN;
+    delete process.env.CDK_ENV_REPO;
+    delete process.env.PROJECT_ENV;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  describe("Base Cases", () => {
+    it("is a function", () => {
+      expect(JaypieWebDeploymentBucket).toBeFunction();
+    });
+
+    it("creates only an S3 bucket without host/zone", () => {
+      const stack = new Stack();
+
+      const construct = new JaypieWebDeploymentBucket(stack, "Web");
+      const template = Template.fromStack(stack);
+
+      expect(construct.bucket).toBeDefined();
+      expect(construct.distribution).toBeUndefined();
+      expect(construct.responseHeadersPolicy).toBeUndefined();
+      expect(construct.webAcl).toBeUndefined();
+      expect(construct.logBucket).toBeUndefined();
+      template.hasResource("AWS::S3::Bucket", {});
+      template.resourceCountIs("AWS::CloudFront::Distribution", 0);
+      template.resourceCountIs("AWS::WAFv2::WebACL", 0);
+    });
+
+    it("creates distribution, headers, log bucket, and WAF with host+zone", () => {
+      const { stack, zone } = makeStack();
+
+      const construct = new JaypieWebDeploymentBucket(stack, "Web", {
+        host: "app.example.com",
+        zone,
+      });
+      const template = Template.fromStack(stack);
+
+      expect(construct.distribution).toBeDefined();
+      expect(construct.responseHeadersPolicy).toBeDefined();
+      expect(construct.logBucket).toBeDefined();
+      expect(construct.webAcl).toBeDefined();
+      expect(construct.wafLogBucket).toBeDefined();
+
+      template.hasResource("AWS::CloudFront::Distribution", {});
+      template.hasResource("AWS::CloudFront::ResponseHeadersPolicy", {});
+      template.hasResource("AWS::WAFv2::WebACL", {});
+      template.hasResource("AWS::WAFv2::LoggingConfiguration", {});
+    });
+  });
+
+  describe("Security Headers", () => {
+    it("attaches default ResponseHeadersPolicy to default behavior", () => {
+      const { stack, zone } = makeStack();
+
+      new JaypieWebDeploymentBucket(stack, "Web", {
+        host: "app.example.com",
+        zone,
+      });
+      const template = Template.fromStack(stack);
+      const distribution = findDistribution(template);
+
+      expect(
+        distribution.Properties.DistributionConfig.DefaultCacheBehavior
+          .ResponseHeadersPolicyId,
+      ).toBeDefined();
+    });
+
+    it("disables security headers when securityHeaders is false", () => {
+      const { stack, zone } = makeStack();
+
+      const construct = new JaypieWebDeploymentBucket(stack, "Web", {
+        host: "app.example.com",
+        zone,
+        securityHeaders: false,
+      });
+      const template = Template.fromStack(stack);
+
+      expect(construct.responseHeadersPolicy).toBeUndefined();
+      template.resourceCountIs("AWS::CloudFront::ResponseHeadersPolicy", 0);
+    });
+
+    it("merges securityHeaders overrides with defaults", () => {
+      const { stack, zone } = makeStack();
+
+      new JaypieWebDeploymentBucket(stack, "Web", {
+        host: "app.example.com",
+        zone,
+        securityHeaders: {
+          contentSecurityPolicy: "default-src 'self';",
+          frameOption: cloudfront.HeadersFrameOption.SAMEORIGIN,
+        },
+      });
+      const template = Template.fromStack(stack);
+
+      expect(() =>
+        template.hasResourceProperties(
+          "AWS::CloudFront::ResponseHeadersPolicy",
+          {
+            ResponseHeadersPolicyConfig: {
+              SecurityHeadersConfig: {
+                ContentSecurityPolicy: {
+                  ContentSecurityPolicy: "default-src 'self';",
+                },
+                FrameOptions: {
+                  FrameOption: "SAMEORIGIN",
+                },
+              },
+            },
+          },
+        ),
+      ).not.toThrow();
+    });
+
+    it("uses responseHeadersPolicy override and skips default policy", () => {
+      const { stack, zone } = makeStack();
+
+      const customPolicy = new cloudfront.ResponseHeadersPolicy(
+        stack,
+        "CustomPolicy",
+        {
+          securityHeadersBehavior: {
+            contentTypeOptions: { override: true },
+          },
+        },
+      );
+
+      const construct = new JaypieWebDeploymentBucket(stack, "Web", {
+        host: "app.example.com",
+        zone,
+        responseHeadersPolicy: customPolicy,
+      });
+
+      expect(construct.responseHeadersPolicy).toBe(customPolicy);
+    });
+  });
+
+  describe("WAF", () => {
+    it("creates a WebACL named after the construct id by default", () => {
+      const { stack, zone } = makeStack();
+
+      new JaypieWebDeploymentBucket(stack, "MyWeb", {
+        host: "app.example.com",
+        zone,
+      });
+      const template = Template.fromStack(stack);
+
+      expect(() =>
+        template.hasResourceProperties("AWS::WAFv2::WebACL", {
+          Name: Match.stringLikeRegexp("MyWeb-WebAcl"),
+        }),
+      ).not.toThrow();
+    });
+
+    it("disables WAF when waf is false", () => {
+      const { stack, zone } = makeStack();
+
+      const construct = new JaypieWebDeploymentBucket(stack, "Web", {
+        host: "app.example.com",
+        zone,
+        waf: false,
+      });
+      const template = Template.fromStack(stack);
+
+      expect(construct.webAcl).toBeUndefined();
+      template.resourceCountIs("AWS::WAFv2::WebACL", 0);
+    });
+
+    it("respects custom waf.name and rateLimitPerIp", () => {
+      const { stack, zone } = makeStack();
+
+      new JaypieWebDeploymentBucket(stack, "Web", {
+        host: "app.example.com",
+        zone,
+        waf: { name: "custom", rateLimitPerIp: 500 },
+      });
+      const template = Template.fromStack(stack);
+
+      expect(() =>
+        template.hasResourceProperties("AWS::WAFv2::WebACL", {
+          Name: Match.stringLikeRegexp("custom-WebAcl"),
+          Rules: Match.arrayWith([
+            Match.objectLike({
+              Name: "RateLimitPerIp",
+              Statement: {
+                RateBasedStatement: Match.objectLike({ Limit: 500 }),
+              },
+            }),
+          ]),
+        }),
+      ).not.toThrow();
+    });
+
+    it("disables WAF logging when waf.logBucket is false", () => {
+      const { stack, zone } = makeStack();
+
+      const construct = new JaypieWebDeploymentBucket(stack, "Web", {
+        host: "app.example.com",
+        zone,
+        waf: { logBucket: false },
+      });
+      const template = Template.fromStack(stack);
+
+      expect(construct.wafLogBucket).toBeUndefined();
+      template.resourceCountIs("AWS::WAFv2::LoggingConfiguration", 0);
+    });
+
+    it("attaches an existing WebACL ARN", () => {
+      const { stack, zone } = makeStack();
+      const externalArn =
+        "arn:aws:wafv2:us-east-1:111111111111:global/webacl/external/abc";
+
+      const construct = new JaypieWebDeploymentBucket(stack, "Web", {
+        host: "app.example.com",
+        zone,
+        waf: { webAclArn: externalArn },
+      });
+      const template = Template.fromStack(stack);
+
+      expect(construct.webAcl).toBeUndefined();
+      template.resourceCountIs("AWS::WAFv2::WebACL", 0);
+      const distribution = findDistribution(template);
+      expect(distribution.Properties.DistributionConfig.WebACLId).toBe(
+        externalArn,
+      );
+    });
+  });
+
+  describe("Access Logging", () => {
+    it("creates an access log bucket by default", () => {
+      const { stack, zone } = makeStack();
+
+      const construct = new JaypieWebDeploymentBucket(stack, "Web", {
+        host: "app.example.com",
+        zone,
+      });
+      const template = Template.fromStack(stack);
+
+      expect(construct.logBucket).toBeDefined();
+      // DestinationBucket + access LogBucket + WafLogBucket
+      template.resourceCountIs("AWS::S3::Bucket", 3);
+    });
+
+    it("skips creating an access log bucket when destination is false", () => {
+      const { stack, zone } = makeStack();
+
+      const construct = new JaypieWebDeploymentBucket(stack, "Web", {
+        host: "app.example.com",
+        zone,
+        destination: false,
+        waf: false,
+      });
+
+      expect(construct.logBucket).toBeUndefined();
+    });
+
+    it("uses an external IBucket when provided as logBucket", () => {
+      const { stack, zone } = makeStack();
+      const externalBucket = new s3.Bucket(stack, "External");
+
+      const construct = new JaypieWebDeploymentBucket(stack, "Web", {
+        host: "app.example.com",
+        zone,
+        logBucket: externalBucket,
+      });
+
+      expect(construct.logBucket).toBe(externalBucket);
+    });
+  });
+});

--- a/packages/eslint/__tests__/index.spec.js
+++ b/packages/eslint/__tests__/index.spec.js
@@ -37,4 +37,29 @@ describe("Index", () => {
       expect(hasRecommendedConfig).toBe(true);
     });
   });
+
+  describe("Issue 333: TypeScript resolver", () => {
+    it("uses resolver-next so interfaceVersion 3 resolvers load", () => {
+      const tsConfig = index.find(
+        (config) => config.name === "jaypie:typescriptRecommended",
+      );
+      expect(tsConfig).toBeDefined();
+      expect(tsConfig.settings).toBeDefined();
+      expect(tsConfig.settings["import-x/resolver-next"]).toBeDefined();
+      expect(Array.isArray(tsConfig.settings["import-x/resolver-next"])).toBe(
+        true,
+      );
+      expect(
+        tsConfig.settings["import-x/resolver-next"].length,
+      ).toBeGreaterThan(0);
+    });
+
+    it("clears the legacy import-x/resolver typescript entry", () => {
+      const tsConfig = index.find(
+        (config) => config.name === "jaypie:typescriptRecommended",
+      );
+      expect(tsConfig).toBeDefined();
+      expect(tsConfig.settings["import-x/resolver"]).toBeUndefined();
+    });
+  });
 });

--- a/packages/eslint/index.js
+++ b/packages/eslint/index.js
@@ -3,6 +3,7 @@ import vitest from "@vitest/eslint-plugin";
 import globals from "globals";
 import tsPlugin from "@typescript-eslint/eslint-plugin";
 import * as tsParser from "@typescript-eslint/parser";
+import { createTypeScriptImportResolver } from "eslint-import-resolver-typescript";
 import { flatConfigs as importxFlatConfigs } from "eslint-plugin-import-x";
 import prettierPlugin from "eslint-plugin-prettier";
 import pluginPrettierVue from "eslint-plugin-prettier-vue";
@@ -23,6 +24,11 @@ export default [
   {
     ...importxFlatConfigs.typescript,
     name: "jaypie:typescriptRecommended",
+    settings: {
+      ...importxFlatConfigs.typescript.settings,
+      "import-x/resolver-next": [createTypeScriptImportResolver()],
+      "import-x/resolver": undefined,
+    },
   },
 
   //

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/eslint",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.53",
+  "version": "0.8.54",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/constructs/1.2.52.md
+++ b/packages/mcp/release-notes/constructs/1.2.52.md
@@ -1,0 +1,24 @@
+---
+version: 1.2.52
+date: 2026-05-06
+summary: JaypieWebDeploymentBucket adopts JaypieDistribution defaults — security headers, WAF, and CloudFront access logging
+---
+
+## Changes
+
+- `JaypieWebDeploymentBucket` now applies the same default security `ResponseHeadersPolicy` as `JaypieDistribution` (HSTS, X-Frame-Options, CSP, Referrer-Policy, Permissions-Policy, Cross-Origin-* headers, Server header removal). Attached to the default behavior and the production `/*` behavior.
+- Adds `securityHeaders` (`boolean | SecurityHeadersOverrides`) and `responseHeadersPolicy` (full override) props matching `JaypieDistribution`'s shape.
+- Adds CloudFront access logging by default — creates a log bucket with Datadog forwarding. New `logBucket` and `destination` props mirror `JaypieDistribution`.
+- Adds WAFv2 WebACL by default with `AWSManagedRulesCommonRuleSet`, `AWSManagedRulesKnownBadInputsRuleSet`, and IP rate limiting (2000/5min). New `waf` prop accepts `boolean | JaypieWebDeploymentBucketWafConfig`.
+- WAF defaults to namespacing the WebACL and WAF log bucket with the construct id, so multiple `JaypieWebDeploymentBucket` (or paired `JaypieDistribution`) instances coexist in one stack without name collisions.
+- Exposes `logBucket`, `responseHeadersPolicy`, `wafLogBucket`, and `webAcl` as public readonly properties.
+
+## Motivation
+
+`JaypieDistribution` ships with sensible defaults for security headers, WAF, and access logging. Static-site deployments fronted by `JaypieWebDeploymentBucket` deserve the same baseline rather than having to compose two constructs by hand.
+
+## Migration
+
+- Existing `JaypieWebDeploymentBucket` users pick up new AWS resources on next deploy: a CloudFront access-log bucket, a WAFv2 WebACL, and a WAF log bucket. There is ongoing AWS cost (WAF + S3 storage). Opt out per feature with `securityHeaders: false`, `waf: false`, `destination: false`, or `logBucket: <existing>`.
+- Custom security headers: pass `securityHeaders: { contentSecurityPolicy, frameOption, ... }` or a full `responseHeadersPolicy`.
+- Custom WAF: `waf: { name: "static", rateLimitPerIp: 500 }` or `waf: { webAclArn: "arn:..." }` to attach an existing WebACL.

--- a/packages/mcp/release-notes/constructs/1.2.52.md
+++ b/packages/mcp/release-notes/constructs/1.2.52.md
@@ -11,6 +11,7 @@ summary: JaypieWebDeploymentBucket adopts JaypieDistribution defaults — securi
 - Adds CloudFront access logging by default — creates a log bucket with Datadog forwarding. New `logBucket` and `destination` props mirror `JaypieDistribution`.
 - Adds WAFv2 WebACL by default with `AWSManagedRulesCommonRuleSet`, `AWSManagedRulesKnownBadInputsRuleSet`, and IP rate limiting (2000/5min). New `waf` prop accepts `boolean | JaypieWebDeploymentBucketWafConfig`.
 - WAF defaults to namespacing the WebACL and WAF log bucket with the construct id, so multiple `JaypieWebDeploymentBucket` (or paired `JaypieDistribution`) instances coexist in one stack without name collisions.
+- `host` widened to `string | HostConfig` on `JaypieWebDeploymentBucket` and `JaypieStaticWebBucket`, matching `JaypieDistribution` / `JaypieApiGateway` / `JaypieWebSocket`. HostConfig values are resolved via `envHostname()`.
 - Exposes `logBucket`, `responseHeadersPolicy`, `wafLogBucket`, and `webAcl` as public readonly properties.
 
 ## Motivation

--- a/packages/mcp/release-notes/eslint/1.2.4.md
+++ b/packages/mcp/release-notes/eslint/1.2.4.md
@@ -1,0 +1,22 @@
+---
+version: 1.2.4
+date: 2026-05-06
+summary: Fix TypeScript resolver — switch from legacy import-x/resolver to resolver-next so eslint-import-resolver-typescript v4 (interfaceVersion 3) loads cleanly
+---
+
+## Changes
+
+- `jaypie:typescriptRecommended` now sets `import-x/resolver-next: [createTypeScriptImportResolver()]` and clears the legacy `import-x/resolver` entry inherited from `importxFlatConfigs.typescript`.
+
+## Motivation
+
+`eslint-plugin-import-x@4.16.2` validates legacy resolvers via `interfaceVersion === 2`, but `eslint-import-resolver-typescript@4.4.4` exposes `interfaceVersion: 3`. The legacy form (`'import-x/resolver': { typescript: true }`) inherited from the plugin's bundled flat config therefore failed validation, and every `.ts`/`.tsx` file produced `Resolve error: typescript with invalid interface loaded as resolver` plus cascading `import-x/no-unresolved` errors.
+
+The v3-compatible path is `import-x/resolver-next`, which accepts modern resolvers via the resolver factory.
+
+## Migration
+
+- No consumer changes required. Re-export `@jaypie/eslint` as before.
+- Downstream workarounds that overrode `import-x/resolver-next` can be removed.
+
+Fixes #333.

--- a/packages/mcp/release-notes/mcp/0.8.54.md
+++ b/packages/mcp/release-notes/mcp/0.8.54.md
@@ -1,0 +1,10 @@
+---
+version: 0.8.54
+date: 2026-05-06
+summary: Update web skill to document JaypieWebDeploymentBucket security headers, WAF, and access logging defaults
+---
+
+## Changes
+
+- Updated `skill("web")` props table and added Security Headers / WAF / Access Logging sections covering `JaypieWebDeploymentBucket`'s new defaults and override mechanisms (`securityHeaders`, `responseHeadersPolicy`, `waf`, `logBucket`, `destination`).
+- Mirrors the `JaypieDistribution` patterns documented in `skill("cdk")` so static-site and dynamic-origin guidance stay aligned.

--- a/packages/mcp/release-notes/mcp/0.8.54.md
+++ b/packages/mcp/release-notes/mcp/0.8.54.md
@@ -1,10 +1,11 @@
 ---
 version: 0.8.54
 date: 2026-05-06
-summary: Update web skill to document JaypieWebDeploymentBucket security headers, WAF, and access logging defaults
+summary: Update web skill for JaypieWebDeploymentBucket defaults; ship release notes for @jaypie/constructs 1.2.52 and @jaypie/eslint 1.2.4
 ---
 
 ## Changes
 
 - Updated `skill("web")` props table and added Security Headers / WAF / Access Logging sections covering `JaypieWebDeploymentBucket`'s new defaults and override mechanisms (`securityHeaders`, `responseHeadersPolicy`, `waf`, `logBucket`, `destination`).
 - Mirrors the `JaypieDistribution` patterns documented in `skill("cdk")` so static-site and dynamic-origin guidance stay aligned.
+- Added release notes for `@jaypie/constructs` 1.2.52 and `@jaypie/eslint` 1.2.4 (#333).

--- a/packages/mcp/skills/web.md
+++ b/packages/mcp/skills/web.md
@@ -35,7 +35,7 @@ new JaypieWebDeploymentBucket(this, "Web", {
 
 | Prop | Type | Default |
 |------|------|---------|
-| `host` | `string` | `mergeDomain(CDK_ENV_WEB_SUBDOMAIN, CDK_ENV_WEB_HOSTED_ZONE \|\| CDK_ENV_HOSTED_ZONE)` |
+| `host` | `string \| HostConfig` | `mergeDomain(CDK_ENV_WEB_SUBDOMAIN, CDK_ENV_WEB_HOSTED_ZONE \|\| CDK_ENV_HOSTED_ZONE)` — `HostConfig` is resolved via `envHostname()` |
 | `zone` | `string \| IHostedZone \| JaypieHostedZone` | `CDK_ENV_WEB_HOSTED_ZONE \|\| CDK_ENV_HOSTED_ZONE` |
 | `certificate` | `boolean \| ICertificate` | `true` (creates via `resolveCertificate`) |
 | `destination` | `LambdaDestination \| boolean` | `true` (Datadog forwarder for access-log bucket notifications) |

--- a/packages/mcp/skills/web.md
+++ b/packages/mcp/skills/web.md
@@ -38,8 +38,13 @@ new JaypieWebDeploymentBucket(this, "Web", {
 | `host` | `string` | `mergeDomain(CDK_ENV_WEB_SUBDOMAIN, CDK_ENV_WEB_HOSTED_ZONE \|\| CDK_ENV_HOSTED_ZONE)` |
 | `zone` | `string \| IHostedZone \| JaypieHostedZone` | `CDK_ENV_WEB_HOSTED_ZONE \|\| CDK_ENV_HOSTED_ZONE` |
 | `certificate` | `boolean \| ICertificate` | `true` (creates via `resolveCertificate`) |
+| `destination` | `LambdaDestination \| boolean` | `true` (Datadog forwarder for access-log bucket notifications) |
+| `logBucket` | `IBucket \| string \| { exportName } \| true` | undefined — creates a new bucket if `destination !== false` |
 | `name` | `string` | `constructEnvName("web")` |
+| `responseHeadersPolicy` | `IResponseHeadersPolicy` | undefined — full override; bypasses default security headers |
 | `roleTag` | `string` | `CDK.ROLE.HOSTING` |
+| `securityHeaders` | `boolean \| SecurityHeadersOverrides` | `true` |
+| `waf` | `boolean \| JaypieWebDeploymentBucketWafConfig` | `true` (WAF name defaults to construct id) |
 
 Also accepts all `s3.BucketProps` — the bucket defaults to `autoDeleteObjects: true`, `publicReadAccess: true`, `websiteIndexDocument: "index.html"`, `websiteErrorDocument: "index.html"` (SPA-friendly).
 
@@ -47,6 +52,52 @@ Also accepts all `s3.BucketProps` — the bucket defaults to `autoDeleteObjects:
 
 - Default behavior: S3 static website origin, `REDIRECT_TO_HTTPS`, `CACHING_DISABLED`.
 - In production (`isProductionEnv()`), a second behavior on `/*` enables `CACHING_OPTIMIZED` — `index.html` stays uncached so SPA deploys are visible immediately; hashed assets get edge cache.
+- Access logs land in a CloudFront log bucket with Datadog forwarding by default. Set `destination: false` to skip notifications, or pass `logBucket: <existing>` to reuse a bucket.
+
+### Security Headers
+
+Same defaults as `JaypieDistribution`: HSTS, X-Frame-Options, CSP, Referrer-Policy, Permissions-Policy, Cross-Origin-* headers, and Server header removal (applied via a `ResponseHeadersPolicy` on the default behavior and the production `/*` behavior). Override the same way:
+
+```typescript
+// Disable
+new JaypieWebDeploymentBucket(this, "Web", { host, zone, securityHeaders: false });
+
+// Override specific headers
+new JaypieWebDeploymentBucket(this, "Web", {
+  host, zone,
+  securityHeaders: {
+    contentSecurityPolicy: "default-src 'self';",
+    frameOption: HeadersFrameOption.SAMEORIGIN,
+  },
+});
+
+// Full custom policy
+new JaypieWebDeploymentBucket(this, "Web", { host, zone, responseHeadersPolicy: myPolicy });
+```
+
+### WAF
+
+Same defaults as `JaypieDistribution` (AWSManagedRulesCommonRuleSet, AWSManagedRulesKnownBadInputsRuleSet, IP rate limit 2000/5min, WAF logging to S3 with Datadog forwarding). The WebACL and WAF log bucket are namespaced with the construct id by default so multiple instances coexist without collision:
+
+```typescript
+// Default — WAF named after construct id ("MyWeb-WebAcl")
+new JaypieWebDeploymentBucket(this, "MyWeb", { host, zone });
+
+// Disable
+new JaypieWebDeploymentBucket(this, "Web", { host, zone, waf: false });
+
+// Custom name + rate limit
+new JaypieWebDeploymentBucket(this, "Web", {
+  host, zone,
+  waf: { name: "static", rateLimitPerIp: 500 },
+});
+
+// Existing WebACL
+new JaypieWebDeploymentBucket(this, "Web", {
+  host, zone,
+  waf: { webAclArn: "arn:aws:wafv2:..." },
+});
+```
 
 ### DNS
 

--- a/workspaces/documentation/docs/guides/cdk-infrastructure.md
+++ b/workspaces/documentation/docs/guides/cdk-infrastructure.md
@@ -182,12 +182,17 @@ new JaypieApiGateway(this, "Gateway", {
 
 ### JaypieWebDeploymentBucket
 
-Static site hosting with CloudFront.
+Static site hosting on S3 with CloudFront, ACM, Route53, and (when `CDK_ENV_REPO` is set) a GitHub OIDC deploy role. Ships with security headers, WAFv2, and CloudFront access logging by default — same override mechanisms as `JaypieDistribution`.
 
 ```typescript
 new JaypieWebDeploymentBucket(this, "Web", {
-  source: "../web/dist",
   host: "app.example.com",
+  zone: "example.com",
+});
+
+// HostConfig — resolved via envHostname()
+new JaypieWebDeploymentBucket(this, "Web", {
+  host: { subdomain: "app", domain: "example.com" },
   zone: "example.com",
 });
 ```

--- a/workspaces/documentation/docs/packages/constructs.md
+++ b/workspaces/documentation/docs/packages/constructs.md
@@ -152,14 +152,19 @@ new JaypieApiGateway(this, "Gateway", {
 
 ## JaypieWebDeploymentBucket
 
-Static site hosting with CloudFront.
+Static site on S3 fronted by CloudFront, ACM, and Route53. Ships with default security headers, WAFv2, and CloudFront access logging — same override mechanisms as `JaypieDistribution` (`securityHeaders`, `responseHeadersPolicy`, `waf`, `logBucket`, `destination`). When `CDK_ENV_REPO` is set, also provisions a scoped GitHub OIDC deploy role with `cloudfront:CreateInvalidation` on the distribution.
 
 ```typescript
 import { JaypieWebDeploymentBucket } from "@jaypie/constructs";
 
 new JaypieWebDeploymentBucket(this, "Web", {
-  source: "../web/dist",
   host: "app.example.com",
+  zone: "example.com",
+});
+
+// host accepts a HostConfig object resolved via envHostname()
+new JaypieWebDeploymentBucket(this, "Web", {
+  host: { subdomain: "app", domain: "example.com" },
   zone: "example.com",
 });
 ```


### PR DESCRIPTION
## Summary

- **JaypieWebDeploymentBucket** now ships with the same defaults as `JaypieDistribution`: security-headers `ResponseHeadersPolicy`, WAFv2 WebACL, CloudFront access logging — with the same override mechanisms (`securityHeaders`, `responseHeadersPolicy`, `waf`, `logBucket`, `destination`). WAF resources are namespaced with the construct id by default to avoid collisions.
- **`host` widened** to `string | HostConfig` on `JaypieWebDeploymentBucket` and `JaypieStaticWebBucket`, matching `JaypieDistribution`, `JaypieApiGateway`, and `JaypieWebSocket`.
- **Fixes #333** — `@jaypie/eslint` switches from the legacy `import-x/resolver` to `import-x/resolver-next` so `eslint-import-resolver-typescript@4.4` (interfaceVersion 3) loads cleanly. No more "Resolve error: typescript with invalid interface" on `.ts`/`.tsx` files.

## Versions

- `@jaypie/constructs` 1.2.51 → 1.2.52
- `@jaypie/eslint` 1.2.3 → 1.2.4
- `@jaypie/mcp` 0.8.53 → 0.8.54

## Heads-up

Existing `JaypieWebDeploymentBucket` deployments will provision new AWS resources on next deploy: a CloudFront access-log bucket, a WAFv2 WebACL, and a WAF log bucket (with ongoing AWS cost). Opt out per feature: `securityHeaders: false`, `waf: false`, `destination: false`, `logBucket: <existing>`. Release notes flag this with migration guidance.

## Test plan

- [x] 509/509 `@jaypie/constructs` tests pass; new `JaypieWebDeploymentBucket.spec.ts` covers defaults + each override (security headers, WAF, access logging) and the HostConfig path
- [x] `@jaypie/eslint` test added that fails before the fix and passes after; verified end-to-end by running `npx eslint` over a real `.ts` file with no resolver errors
- [x] Typecheck + lint clean for `@jaypie/constructs` and `@jaypie/eslint`
- [x] Rollup build succeeds for `@jaypie/constructs`
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)