### PR TITLE
docs: document JaypieStack in cdk skill, README, and docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,16 +474,12 @@ const apiGateway = new JaypieApiGateway(this, "Api", {
 
 #### `JaypieAppStack`
 
-Base application stack with common Jaypie patterns, resource tagging, and cross-stack resource sharing capabilities.
+Application stack — extends `JaypieStack` and pre-fills `key: "app"` so the generated stack name carries the application suffix.
 
 ```typescript
 export class MyAppStack extends JaypieAppStack {
-  constructor(scope: Construct, id: string, props?: JaypieStackProps) {
-    super(scope, id, {
-      ...props,
-      service: "api",
-      project: "myproject",
-    });
+  constructor(scope: Construct, id: string, props: JaypieStackProps = {}) {
+    super(scope, id, props);
 
     // Add your application resources here
   }
@@ -609,16 +605,12 @@ const expressLambda = new JaypieExpressLambda(this, "ApiServer", {
 
 #### `JaypieInfrastructureStack`
 
-Infrastructure stack with common patterns for cross-stack resource sharing and environment-specific configurations.
+Infrastructure stack — extends `JaypieStack` and pre-fills `key: "infra"` for shared infrastructure (VPCs, databases, hosted zones, shared secrets). Also tags the stack with `stackSha` from `CDK_ENV_INFRASTRUCTURE_STACK_SHA` when set.
 
 ```typescript
 export class MyInfrastructureStack extends JaypieInfrastructureStack {
-  constructor(scope: Construct, id: string, props?: JaypieStackProps) {
-    super(scope, id, {
-      ...props,
-      service: "infrastructure",
-      project: "myproject",
-    });
+  constructor(scope: Construct, id: string, props: JaypieStackProps = {}) {
+    super(scope, id, props);
 
     // Add shared infrastructure resources like VPCs, databases, etc.
   }
@@ -627,17 +619,18 @@ export class MyInfrastructureStack extends JaypieInfrastructureStack {
 
 #### `JaypieStack`
 
-Base stack with Jaypie conventions, standardized tagging, and common resource patterns for consistent deployments.
+Base stack class for every Jaypie CDK stack. Automatically:
+
+1. Generates the stack name from `PROJECT_*` env vars: `cdk-{sponsor}-{project}-{env}-{nonce}[-{key}]`
+2. Resolves account & region from `CDK_DEFAULT_ACCOUNT` / `CDK_DEFAULT_REGION` (overridable via `env`)
+3. Applies the standard tag set (`env`, `project`, `sponsor`, `nonce`, `commit`, `buildHex`, `buildDate`, `buildTime`, `version`, `service`, `creation`, `role`, `stack`) and propagates it to taggable children
+
+`JaypieStackProps` extends CDK's `StackProps` with one optional addition: `key`, the suffix appended to the generated stack name. Most projects use `JaypieAppStack` / `JaypieInfrastructureStack` instead; extend `JaypieStack` directly for any other category.
 
 ```typescript
-export class MyStack extends JaypieStack {
-  constructor(scope: Construct, id: string, props?: JaypieStackProps) {
-    super(scope, id, {
-      ...props,
-      service: "worker",
-      project: "myproject",
-      roleTag: "processing",
-    });
+export class MyDataStack extends JaypieStack {
+  constructor(scope: Construct, id: string, props: JaypieStackProps = {}) {
+    super(scope, id, { key: "data", ...props });
 
     // Add your stack resources here
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -29471,7 +29471,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.54",
+      "version": "0.8.55",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.4",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.54",
+  "version": "0.8.55",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/mcp/0.8.55.md
+++ b/packages/mcp/release-notes/mcp/0.8.55.md
@@ -1,0 +1,11 @@
+---
+version: 0.8.55
+date: 2026-05-07
+summary: Document JaypieStack in the cdk skill
+---
+
+## Changes
+
+- Added a "Stacks" section to `skill("cdk")` introducing `JaypieStack` as the recommended base class for Jaypie CDK stacks, covering automatic stack naming, account/region resolution, and the standard tag set.
+- Mentioned `JaypieAppStack` and `JaypieInfrastructureStack` as thin subclasses that pre-fill the `app` and `infra` keys.
+- Updated the "Environment Configuration" example to reflect that `JaypieStack` resolves `CDK_DEFAULT_ACCOUNT` / `CDK_DEFAULT_REGION` automatically, so manual env wiring is only needed for cross-account/region deploys.

--- a/packages/mcp/skills/cdk.md
+++ b/packages/mcp/skills/cdk.md
@@ -96,21 +96,64 @@ workspaces/
 │   └── package.json
 ```
 
-## Environment Configuration
+## Stacks
 
-Use environment-specific configuration:
+### JaypieStack
+
+`JaypieStack` extends CDK's `Stack` and is the recommended base class for every stack in a Jaypie project. Extending it gives you three things automatically:
+
+1. **Stack naming** from environment variables, in the form
+   `cdk-{PROJECT_SPONSOR}-{PROJECT_KEY}-{PROJECT_ENV}-{PROJECT_NONCE}[-{key}]`,
+   so naming stays consistent across sandbox, personal, and production deploys.
+2. **Account & region** resolved from `CDK_DEFAULT_ACCOUNT` / `CDK_DEFAULT_REGION` (overridable via `env`).
+3. **Standard tags** applied to the stack and propagated to every taggable child resource: `env`, `project`, `sponsor`, `nonce`, `commit`, `buildHex`, `buildDate`, `buildTime`, `version`, `service`, `creation`, `role`, `stack`.
 
 ```typescript
-const env = process.env.PROJECT_ENV || "sandbox";
-const nonce = process.env.PROJECT_NONCE || "dev";
+import { Construct } from "constructs";
+import { JaypieStack, JaypieStackProps } from "@jaypie/constructs";
 
-const stack = new ApiStack(app, `api-${env}-${nonce}`, {
-  env: {
-    account: process.env.CDK_DEFAULT_ACCOUNT,
-    region: process.env.CDK_DEFAULT_REGION,
-  },
+export class DataStack extends JaypieStack {
+  constructor(scope: Construct, id: string, props: JaypieStackProps = {}) {
+    super(scope, id, { key: "data", ...props });
+    // ...your resources...
+  }
+}
+```
+
+Props extend `StackProps` with one addition:
+
+| Prop | Description |
+|------|-------------|
+| `key` | Suffix appended to the generated stack name (e.g., `"data"`, `"events"`). Optional. |
+
+If you see `undefined` or `unknown` in a generated stack name or tag, an env var is missing — fix the environment rather than overriding `stackName`.
+
+#### `JaypieAppStack` / `JaypieInfrastructureStack`
+
+Thin convenience subclasses that pre-fill `key`:
+
+- `JaypieAppStack` → `key: "app"` (application workloads — Lambdas, APIs)
+- `JaypieInfrastructureStack` → `key: "infra"` (shared infrastructure — buckets, hosted zones, shared secrets); also tags the stack with `stackSha` from `CDK_ENV_INFRASTRUCTURE_STACK_SHA` when set
+
+Use them when their key fits; extend `JaypieStack` directly for any other category.
+
+## Environment Configuration
+
+`JaypieStack` resolves the AWS account and region from `CDK_DEFAULT_ACCOUNT` / `CDK_DEFAULT_REGION` automatically, so most stacks need no env wiring at the call site:
+
+```typescript
+new ApiStack(app, "ApiStack");
+```
+
+Override per-stack only when you need to deploy outside the default context:
+
+```typescript
+new ApiStack(app, "ApiStack", {
+  env: { account: "123456789012", region: "us-west-2" },
 });
 ```
+
+See `skill("variables")` for the full set of `PROJECT_*` and `CDK_*` environment variables that drive naming and tagging.
 
 ## Resource Naming
 

--- a/packages/mcp/src/createMcpServer.ts
+++ b/packages/mcp/src/createMcpServer.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console -- MCP stdio: stderr is the only valid log channel; stdout is reserved for JSON-RPC */
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import { createMcpServerFromSuite } from "@jaypie/fabric/mcp";

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint-disable no-console -- MCP stdio: stderr is the only valid log channel; stdout is reserved for JSON-RPC */
 import { readFileSync, realpathSync } from "node:fs";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";

--- a/workspaces/documentation/docs/guides/cdk-infrastructure.md
+++ b/workspaces/documentation/docs/guides/cdk-infrastructure.md
@@ -33,8 +33,9 @@ packages/cdk/
 
 | Stack | Extends | Purpose |
 |-------|---------|---------|
-| `JaypieAppStack` | `JaypieStack` | Application resources (Lambda, API Gateway) |
-| `JaypieInfrastructureStack` | `JaypieStack` | Shared infrastructure (VPC, databases) |
+| `JaypieStack` | `Stack` (CDK) | Base class — auto-naming, account/region resolution, standard tag set |
+| `JaypieAppStack` | `JaypieStack` | Application resources (Lambda, API Gateway); pre-fills `key: "app"` |
+| `JaypieInfrastructureStack` | `JaypieStack` | Shared infrastructure (VPC, databases); pre-fills `key: "infra"` |
 
 ## Step 1: CDK Entry Point
 

--- a/workspaces/documentation/docs/packages/constructs.md
+++ b/workspaces/documentation/docs/packages/constructs.md
@@ -276,9 +276,31 @@ new JaypieLambda(this, "Api", {
 
 ## Stack Classes
 
+### JaypieStack
+
+Base stack for every Jaypie CDK stack. Extending it automatically:
+
+1. **Names the stack** from environment variables: `cdk-{PROJECT_SPONSOR}-{PROJECT_KEY}-{PROJECT_ENV}-{PROJECT_NONCE}[-{key}]`
+2. **Resolves account & region** from `CDK_DEFAULT_ACCOUNT` / `CDK_DEFAULT_REGION` (overridable via `env`)
+3. **Applies standard tags** (`env`, `project`, `sponsor`, `nonce`, `commit`, `buildHex`, `buildDate`, `buildTime`, `version`, `service`, `creation`, `role`, `stack`) and propagates them to every taggable child resource
+
+```typescript
+import { JaypieStack, JaypieStackProps } from "@jaypie/constructs";
+import type { Construct } from "constructs";
+
+export class DataStack extends JaypieStack {
+  constructor(scope: Construct, id: string, props: JaypieStackProps = {}) {
+    super(scope, id, { key: "data", ...props });
+    // ...your resources...
+  }
+}
+```
+
+`JaypieStackProps` extends CDK's `StackProps` with one optional `key` field (suffix for the generated stack name). Most projects use `JaypieAppStack` or `JaypieInfrastructureStack`; extend `JaypieStack` directly only for additional categories.
+
 ### JaypieAppStack
 
-For application resources (Lambda, API Gateway):
+For application resources (Lambda, API Gateway). Pre-fills `key: "app"`:
 
 ```typescript
 import { JaypieAppStack, JaypieLambda } from "@jaypie/constructs";
@@ -298,7 +320,7 @@ export class ApiStack extends JaypieAppStack {
 
 ### JaypieInfrastructureStack
 
-For shared infrastructure:
+For shared infrastructure. Pre-fills `key: "infra"` and tags the stack with `stackSha` from `CDK_ENV_INFRASTRUCTURE_STACK_SHA` when set:
 
 ```typescript
 import { JaypieInfrastructureStack, JaypieEnvSecret } from "@jaypie/constructs";


### PR DESCRIPTION
## Summary

- Promote `JaypieStack` as the recommended base class for Jaypie CDK stacks in `skill("cdk")`, the README, and the public documentation site. Mention `JaypieAppStack` and `JaypieInfrastructureStack` as thin subclasses that pre-fill the `app` and `infra` keys.
- Fix pre-existing fictitious props (`service`, `project`, `roleTag`) in the README's three stack examples — these don't exist on `JaypieStackProps`.
- Silence `no-console` for the two MCP stdio entrypoints with file-level eslint-disable + rationale (stderr is the only valid log channel; stdout is reserved for JSON-RPC).
- Bump `@jaypie/mcp` to `0.8.55` with a release note.

## Test plan

- [x] `npm run lint` clean repo-wide
- [x] `npm run typecheck -w packages/mcp` clean
- [x] `npm run test -w packages/mcp` — 41/41 pass
- [x] Verified the new "Stacks" section renders correctly via `mcp__jaypie__skill("cdk")` against the rebuilt dist
- [x] NPM Check workflow green on the branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)