### PR TITLE
fix(constructs): WAF log bucket name truncation and JaypieWebDeploymentBucket.exportOutputs (#337)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28389,7 +28389,7 @@
     },
     "packages/constructs": {
       "name": "@jaypie/constructs",
-      "version": "1.2.52",
+      "version": "1.2.53",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*",
@@ -29471,7 +29471,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.55",
+      "version": "0.8.56",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.4",

--- a/packages/constructs/package.json
+++ b/packages/constructs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/constructs",
-  "version": "1.2.52",
+  "version": "1.2.53",
   "description": "CDK constructs for Jaypie applications",
   "repository": {
     "type": "git",

--- a/packages/constructs/src/JaypieDistribution.ts
+++ b/packages/constructs/src/JaypieDistribution.ts
@@ -13,6 +13,7 @@ import { Construct } from "constructs";
 import { CDK } from "./constants";
 import {
   constructEnvName,
+  constructWafLogBucketName,
   envHostname,
   HostConfig,
   isValidHostname,
@@ -654,9 +655,7 @@ export class JaypieDistribution
         const wafLogBucketId = wafConfig.name
           ? constructEnvName(`${wafConfig.name}-WafLogBucket`)
           : constructEnvName("WafLogBucket");
-        const wafLogBucketName = wafConfig.name
-          ? `aws-waf-logs-${constructEnvName(`${wafConfig.name}-waf`).toLowerCase()}`
-          : `aws-waf-logs-${constructEnvName("waf").toLowerCase()}`;
+        const wafLogBucketName = constructWafLogBucketName(wafConfig.name);
         const createdBucket = new s3.Bucket(this, wafLogBucketId, {
           bucketName: wafLogBucketName,
           lifecycleRules: [

--- a/packages/constructs/src/JaypieWebDeploymentBucket.ts
+++ b/packages/constructs/src/JaypieWebDeploymentBucket.ts
@@ -28,6 +28,7 @@ import { ConfigurationError } from "@jaypie/errors";
 import { CDK } from "./constants";
 import {
   constructEnvName,
+  constructWafLogBucketName,
   envHostname,
   HostConfig,
   isProductionEnv,
@@ -660,9 +661,7 @@ export class JaypieWebDeploymentBucket extends Construct implements s3.IBucket {
           const wafLogBucketId = constructEnvName(
             `${wafConfig.name}-WafLogBucket`,
           );
-          const wafLogBucketName = `aws-waf-logs-${constructEnvName(
-            `${wafConfig.name}-waf`,
-          ).toLowerCase()}`;
+          const wafLogBucketName = constructWafLogBucketName(wafConfig.name);
           const createdBucket = new s3.Bucket(this, wafLogBucketId, {
             bucketName: wafLogBucketName,
             lifecycleRules: [
@@ -706,6 +705,50 @@ export class JaypieWebDeploymentBucket extends Construct implements s3.IBucket {
         }
       }
     }
+  }
+
+  /**
+   * Emit stack-level CfnOutputs with stable, hash-free logical IDs so they can
+   * be read directly from `cdk-outputs.json` without prefix-matching. Skips
+   * outputs whose underlying resource is absent.
+   *
+   * Logical IDs (with optional `prefix`):
+   * - `${prefix}DestinationBucketName`
+   * - `${prefix}DestinationBucketDeployRoleArn` (when a deploy role exists)
+   * - `${prefix}DistributionId` (when a distribution exists)
+   * - `${prefix}CertificateArn` (when a certificate exists)
+   *
+   * @returns map of created outputs keyed by their logical ID
+   */
+  public exportOutputs(
+    options: { prefix?: string; scope?: Construct } = {},
+  ): Record<string, CfnOutput> {
+    const { prefix = "", scope = Stack.of(this) } = options;
+    const outputs: Record<string, CfnOutput> = {};
+
+    const create = (id: string, value: string): CfnOutput => {
+      const logicalId = `${prefix}${id}`;
+      const output = new CfnOutput(scope, `${logicalId}Export`, { value });
+      output.overrideLogicalId(logicalId);
+      outputs[logicalId] = output;
+      return output;
+    };
+
+    create("DestinationBucketName", this.bucket.bucketName);
+
+    if (this.deployRoleArn) {
+      create("DestinationBucketDeployRoleArn", this.deployRoleArn);
+    }
+
+    if (this.distribution) {
+      create("DistributionId", this.distribution.distributionId);
+    }
+
+    if (this.certificate) {
+      create("CertificateArn", this.certificate.certificateArn);
+    }
+
+    return outputs;
   }
 
   private resolveWafConfig(

--- a/packages/constructs/src/__tests__/JaypieWebDeploymentBucket.spec.ts
+++ b/packages/constructs/src/__tests__/JaypieWebDeploymentBucket.spec.ts
@@ -255,6 +255,33 @@ describe("JaypieWebDeploymentBucket", () => {
         externalArn,
       );
     });
+
+    it("truncates long WAF log bucket names to 63 chars while preserving nonce", () => {
+      process.env.PROJECT_ENV = "development";
+      process.env.PROJECT_KEY = "jaypie";
+      process.env.PROJECT_NONCE = "598eea56";
+      const { stack, zone } = makeStack();
+
+      new JaypieWebDeploymentBucket(stack, "DocumentationBucket", {
+        host: "app.example.com",
+        zone,
+      });
+      const template = Template.fromStack(stack);
+
+      const buckets = template.findResources("AWS::S3::Bucket");
+      const wafLogBucket = Object.values(buckets).find((bucket) => {
+        const name = bucket.Properties?.BucketName;
+        return typeof name === "string" && name.startsWith("aws-waf-logs-");
+      });
+
+      expect(wafLogBucket).toBeDefined();
+      const name = wafLogBucket!.Properties.BucketName as string;
+      expect(name.length).toBeLessThanOrEqual(63);
+      expect(name.startsWith("aws-waf-logs-")).toBe(true);
+      expect(name.endsWith("-598eea56")).toBe(true);
+      expect(name).not.toMatch(/-+$/);
+      expect(name).not.toMatch(/--/);
+    });
   });
 
   describe("HostConfig", () => {
@@ -331,6 +358,76 @@ describe("JaypieWebDeploymentBucket", () => {
       });
 
       expect(construct.logBucket).toBe(externalBucket);
+    });
+  });
+
+  describe("exportOutputs", () => {
+    it("emits stack-level outputs with stable logical IDs", () => {
+      process.env.CDK_ENV_REPO = "owner/repo";
+      const { stack, zone } = makeStack();
+
+      const construct = new JaypieWebDeploymentBucket(stack, "Web", {
+        host: "app.example.com",
+        zone,
+      });
+      construct.exportOutputs();
+
+      const template = Template.fromStack(stack);
+      const outputs = template.findOutputs("*");
+      const ids = Object.keys(outputs);
+
+      expect(ids).toContain("DestinationBucketName");
+      expect(ids).toContain("DestinationBucketDeployRoleArn");
+      expect(ids).toContain("DistributionId");
+      expect(ids).toContain("CertificateArn");
+    });
+
+    it("skips outputs whose underlying resources do not exist", () => {
+      const stack = new Stack();
+      const construct = new JaypieWebDeploymentBucket(stack, "Web");
+      construct.exportOutputs();
+
+      const template = Template.fromStack(stack);
+      const ids = Object.keys(template.findOutputs("*"));
+
+      expect(ids).toContain("DestinationBucketName");
+      expect(ids).not.toContain("DestinationBucketDeployRoleArn");
+      expect(ids).not.toContain("DistributionId");
+      expect(ids).not.toContain("CertificateArn");
+    });
+
+    it("prefixes logical IDs to avoid collisions for multi-instance stacks", () => {
+      process.env.CDK_ENV_REPO = "owner/repo";
+      const { stack, zone } = makeStack();
+
+      const a = new JaypieWebDeploymentBucket(stack, "A", {
+        host: "a.example.com",
+        zone,
+      });
+      const b = new JaypieWebDeploymentBucket(stack, "B", {
+        host: "b.example.com",
+        zone,
+      });
+      a.exportOutputs({ prefix: "A" });
+      b.exportOutputs({ prefix: "B" });
+
+      const template = Template.fromStack(stack);
+      const ids = Object.keys(template.findOutputs("*"));
+
+      expect(ids).toContain("ADestinationBucketName");
+      expect(ids).toContain("BDestinationBucketName");
+      expect(ids).toContain("ADistributionId");
+      expect(ids).toContain("BDistributionId");
+    });
+
+    it("returns the constructed outputs keyed by logical ID", () => {
+      const stack = new Stack();
+      const construct = new JaypieWebDeploymentBucket(stack, "Web");
+
+      const result = construct.exportOutputs();
+
+      expect(result.DestinationBucketName).toBeDefined();
+      expect(result.DestinationBucketDeployRoleArn).toBeUndefined();
     });
   });
 });

--- a/packages/constructs/src/helpers/__tests__/constructWafLogBucketName.spec.ts
+++ b/packages/constructs/src/helpers/__tests__/constructWafLogBucketName.spec.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { constructWafLogBucketName } from "../constructWafLogBucketName";
+
+describe("constructWafLogBucketName", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.PROJECT_ENV;
+    delete process.env.PROJECT_KEY;
+    delete process.env.PROJECT_NONCE;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe("Base Cases", () => {
+    it("is a function", () => {
+      expect(typeof constructWafLogBucketName).toBe("function");
+    });
+
+    it("builds aws-waf-logs prefixed name with env-key-name-waf-nonce shape", () => {
+      process.env.PROJECT_ENV = "sandbox";
+      process.env.PROJECT_KEY = "jaypie";
+      process.env.PROJECT_NONCE = "abcd1234";
+
+      expect(constructWafLogBucketName("api")).toBe(
+        "aws-waf-logs-sandbox-jaypie-api-waf-abcd1234",
+      );
+    });
+
+    it("omits the name segment when called without a name", () => {
+      process.env.PROJECT_ENV = "sandbox";
+      process.env.PROJECT_KEY = "jaypie";
+      process.env.PROJECT_NONCE = "abcd1234";
+
+      expect(constructWafLogBucketName()).toBe(
+        "aws-waf-logs-sandbox-jaypie-waf-abcd1234",
+      );
+    });
+
+    it("lowercases mixed-case construct names", () => {
+      process.env.PROJECT_ENV = "sandbox";
+      process.env.PROJECT_KEY = "jaypie";
+      process.env.PROJECT_NONCE = "abcd1234";
+
+      expect(constructWafLogBucketName("MyWeb")).toBe(
+        "aws-waf-logs-sandbox-jaypie-myweb-waf-abcd1234",
+      );
+    });
+  });
+
+  describe("Truncation", () => {
+    it("truncates the middle to keep the result within 63 chars", () => {
+      process.env.PROJECT_ENV = "development";
+      process.env.PROJECT_KEY = "jaypie";
+      process.env.PROJECT_NONCE = "598eea56";
+
+      const name = constructWafLogBucketName("DocumentationBucket");
+
+      expect(name.length).toBeLessThanOrEqual(63);
+      expect(name.startsWith("aws-waf-logs-")).toBe(true);
+      expect(name.endsWith("-598eea56")).toBe(true);
+    });
+
+    it("preserves the nonce suffix verbatim when truncating", () => {
+      process.env.PROJECT_ENV = "development";
+      process.env.PROJECT_KEY = "jaypie";
+      process.env.PROJECT_NONCE = "598eea56";
+
+      const name = constructWafLogBucketName("DocumentationBucket");
+
+      expect(name.endsWith("-598eea56")).toBe(true);
+    });
+
+    it("does not leave a trailing dash after truncation", () => {
+      process.env.PROJECT_ENV = "development";
+      process.env.PROJECT_KEY = "jaypie";
+      process.env.PROJECT_NONCE = "598eea56";
+
+      const name = constructWafLogBucketName("DocumentationBucket");
+
+      expect(name).not.toMatch(/-+-[^-]+$/);
+      const middle = name.slice(
+        "aws-waf-logs-".length,
+        name.length - "-598eea56".length,
+      );
+      expect(middle).not.toMatch(/-$/);
+    });
+
+    it("does not truncate when the constructed name fits", () => {
+      process.env.PROJECT_ENV = "sandbox";
+      process.env.PROJECT_KEY = "jaypie";
+      process.env.PROJECT_NONCE = "abcd";
+
+      const name = constructWafLogBucketName("api");
+
+      expect(name).toBe("aws-waf-logs-sandbox-jaypie-api-waf-abcd");
+    });
+  });
+
+  describe("Defaults", () => {
+    it("falls back to nonce 'cfe2' when PROJECT_NONCE is unset", () => {
+      process.env.PROJECT_ENV = "sandbox";
+      process.env.PROJECT_KEY = "jaypie";
+
+      expect(constructWafLogBucketName("api")).toBe(
+        "aws-waf-logs-sandbox-jaypie-api-waf-cfe2",
+      );
+    });
+  });
+});

--- a/packages/constructs/src/helpers/constructWafLogBucketName.ts
+++ b/packages/constructs/src/helpers/constructWafLogBucketName.ts
@@ -1,0 +1,27 @@
+import { constructEnvName } from "./constructEnvName";
+
+const AWS_WAF_LOGS_PREFIX = "aws-waf-logs-";
+const S3_BUCKET_NAME_MAX_LENGTH = 63;
+
+/**
+ * Build a WAF log bucket name shaped like
+ * `aws-waf-logs-${env}-${key}-${name}-waf-${nonce}` (or `-waf-` only when
+ * `name` is empty). The `aws-waf-logs-` prefix is required by AWS WAF, and
+ * `-${PROJECT_NONCE}` is preserved verbatim for uniqueness; the middle is
+ * truncated when needed to fit S3's 63-char limit.
+ */
+export function constructWafLogBucketName(name?: string): string {
+  const nonce = (process.env.PROJECT_NONCE ?? "cfe2").toLowerCase();
+  const nonceSuffix = `-${nonce}`;
+  const innerName = name ? `${name}-waf` : "waf";
+  const middle = constructEnvName(innerName)
+    .toLowerCase()
+    .slice(0, -nonceSuffix.length);
+  const maxMiddleLength =
+    S3_BUCKET_NAME_MAX_LENGTH - AWS_WAF_LOGS_PREFIX.length - nonceSuffix.length;
+  const truncated =
+    middle.length > maxMiddleLength
+      ? middle.slice(0, maxMiddleLength).replace(/-+$/, "")
+      : middle;
+  return `${AWS_WAF_LOGS_PREFIX}${truncated}${nonceSuffix}`;
+}

--- a/packages/constructs/src/helpers/index.ts
+++ b/packages/constructs/src/helpers/index.ts
@@ -2,6 +2,7 @@ export { addDatadogLayers } from "./addDatadogLayers";
 export { constructEnvName } from "./constructEnvName";
 export { constructStackName } from "./constructStackName";
 export { constructTagger } from "./constructTagger";
+export { constructWafLogBucketName } from "./constructWafLogBucketName";
 export { envHostname, HostConfig } from "./envHostname";
 export {
   extendDatadogRole,

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.55",
+  "version": "0.8.56",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/constructs/1.2.53.md
+++ b/packages/mcp/release-notes/constructs/1.2.53.md
@@ -1,0 +1,21 @@
+---
+version: 1.2.53
+date: 2026-05-07
+summary: Truncate WAF log bucket names to fit S3's 63-char limit; add JaypieWebDeploymentBucket.exportOutputs()
+---
+
+## Changes
+
+- WAF log bucket names created by `JaypieWebDeploymentBucket` and `JaypieDistribution` are now truncated to fit S3's 63-character limit. The `aws-waf-logs-` prefix and `-${PROJECT_NONCE}` suffix are preserved verbatim; the middle is shortened only when the full name would exceed the limit.
+- Adds `constructWafLogBucketName(name?)` helper used by both constructs.
+- Adds `JaypieWebDeploymentBucket.exportOutputs({ prefix?, scope? })` — emits stack-level `CfnOutput`s with stable, hash-free logical IDs (`DestinationBucketName`, `DestinationBucketDeployRoleArn`, `DistributionId`, `CertificateArn`) so consumers can read `cdk-outputs.json` without prefix-matching. Outputs whose underlying resource is absent are skipped. Pass `prefix` to namespace outputs when a stack has multiple instances.
+
+## Motivation
+
+WAF log bucket names: in long-named environments (e.g., `PROJECT_ENV=development`, construct id `DocumentationBucket`), the generated bucket name reached 64 characters, blocking CDK synth with `InvalidBucketNameValue`. Shorter environments like `sandbox` were unaffected, masking the regression introduced when WAF logging became default in 1.2.52.
+
+`exportOutputs()`: the existing in-construct `CfnOutput`s get CDK-generated logical IDs like `WebDestinationBucketNameB89ADFD6`, forcing every `cdk-outputs.json` consumer to grep by prefix or duplicate outputs by hand. `exportOutputs()` is opt-in so single-bucket stacks get clean names without breaking multi-bucket use.
+
+## Migration
+
+No action required for the WAF bucket name fix. To opt into stable output names, call `bucket.exportOutputs()` on each `JaypieWebDeploymentBucket` (or pass `{ prefix }` for multi-instance stacks).

--- a/packages/mcp/release-notes/mcp/0.8.56.md
+++ b/packages/mcp/release-notes/mcp/0.8.56.md
@@ -1,0 +1,14 @@
+---
+version: 0.8.56
+date: 2026-05-07
+summary: Issues skill references gh CLI; web skill documents JaypieWebDeploymentBucket.exportOutputs()
+---
+
+## Changes
+
+- `skill("issues")` now instructs agents to use `gh issue create` after user approval. Previous wording referenced `mcp__github__issue_write`, which is not a generally available tool.
+- `skill("web")` documents the new `JaypieWebDeploymentBucket.exportOutputs()` method (constructs 1.2.53) for emitting stable, hash-free output logical IDs.
+
+## Motivation
+
+The GitHub CLI (`gh`) is the standard way Claude Code agents create issues in this repo, so the skill should match what's actually available. Surfacing `exportOutputs()` in the web skill helps agents recommend it instead of hand-rolled `overrideLogicalId` workarounds.

--- a/packages/mcp/skills/issues.md
+++ b/packages/mcp/skills/issues.md
@@ -17,7 +17,7 @@ Before creating an issue:
 1. Draft the issue title and body
 2. Present the draft to the user
 3. Wait for explicit approval ("yes", "submit it", etc.)
-4. Only then use `mcp__github__issue_write` to create the issue
+4. Only then use `gh issue create` to create the issue
 
 ## Issue Format
 

--- a/packages/mcp/skills/web.md
+++ b/packages/mcp/skills/web.md
@@ -121,6 +121,21 @@ Exposed as `CfnOutput`s for workflow consumption:
 | `DistributionId` | CloudFront distribution for `aws cloudfront create-invalidation` |
 | `CertificateArn` | ACM certificate ARN (when a certificate is created) |
 
+By default these outputs live inside the construct, so CDK adds the parent path and a hash suffix (e.g., `WebDestinationBucketNameB89ADFD6`). To get stable, hash-free logical IDs in `cdk-outputs.json`, call `exportOutputs()`:
+
+```typescript
+const web = new JaypieWebDeploymentBucket(this, "Web", { host, zone });
+web.exportOutputs();
+// → DestinationBucketName, DestinationBucketDeployRoleArn, DistributionId, CertificateArn
+```
+
+For stacks with multiple `JaypieWebDeploymentBucket` instances, pass a `prefix` to avoid collisions:
+
+```typescript
+appWeb.exportOutputs({ prefix: "App" });   // AppDestinationBucketName, ...
+docsWeb.exportOutputs({ prefix: "Docs" }); // DocsDestinationBucketName, ...
+```
+
 See `skill("cicd-deploy")` for the workflow pattern that reads these outputs and deploys content.
 
 ## JaypieStaticWebBucket

--- a/workspaces/documentation/docs/packages/constructs.md
+++ b/workspaces/documentation/docs/packages/constructs.md
@@ -169,6 +169,21 @@ new JaypieWebDeploymentBucket(this, "Web", {
 });
 ```
 
+### Stable Outputs for cdk-outputs.json
+
+Call `exportOutputs()` to emit stack-level `CfnOutput`s with hash-free logical IDs (`DestinationBucketName`, `DestinationBucketDeployRoleArn`, `DistributionId`, `CertificateArn`):
+
+```typescript
+const web = new JaypieWebDeploymentBucket(this, "Web", { host, zone });
+web.exportOutputs();
+
+// Multi-instance stacks: use prefix to avoid collisions
+appWeb.exportOutputs({ prefix: "App" });   // AppDestinationBucketName, ...
+docsWeb.exportOutputs({ prefix: "Docs" }); // DocsDestinationBucketName, ...
+```
+
+Outputs whose underlying resource doesn't exist (e.g., no deploy role, no distribution) are skipped.
+
 ## JaypieDynamoDb
 
 DynamoDB table with Jaypie single-table design patterns.


### PR DESCRIPTION
## Summary

- **Fix WAF log bucket name overflow.** `JaypieWebDeploymentBucket` and `JaypieDistribution` now truncate the WAF log bucket name to fit S3's 63-char limit. The `aws-waf-logs-` prefix and `-${PROJECT_NONCE}` suffix are preserved verbatim. Synth was failing in long-named environments (e.g., `PROJECT_ENV=development` + construct id `DocumentationBucket`) since the WAF defaults landed in 1.2.52.
- **Add `JaypieWebDeploymentBucket.exportOutputs({ prefix?, scope? })`** (closes #337). Emits stack-level `CfnOutput`s with stable, hash-free logical IDs (`DestinationBucketName`, `DestinationBucketDeployRoleArn`, `DistributionId`, `CertificateArn`) so consumers can read `cdk-outputs.json` without prefix-matching CDK's auto-generated IDs.
- **MCP skill updates.** `skill("issues")` references `gh issue create`; `skill("web")` documents the new `exportOutputs()` method.

## Versions

- `@jaypie/constructs` 1.2.52 → 1.2.53
- `@jaypie/mcp` 0.8.55 → 0.8.56

Release notes added at `packages/mcp/release-notes/constructs/1.2.53.md` and `packages/mcp/release-notes/mcp/0.8.56.md`.

## Test plan

- [x] Added unit tests for `constructWafLogBucketName` (9 tests) covering truncation, nonce preservation, default fallback, and trailing-dash handling.
- [x] Added test in `JaypieWebDeploymentBucket.spec.ts` reproducing the failing build (development env + DocumentationBucket id) and asserting the resulting bucket name is ≤63 chars with the nonce suffix intact.
- [x] Added 4 tests for `exportOutputs()` covering: full set when all resources present, gated emission when resources absent, prefix-based collision avoidance for multi-instance stacks, and return value.
- [x] All 523 constructs tests pass; 41 mcp tests pass.
- [x] Typecheck clean.
- [x] Zero lint warnings on touched files.
- [x] MCP rebuilt so dist ships updated skills/release-notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)