### PR TITLE
fix(constructs,lambda): JaypieMigration loud-fail with control-plane perms (#339)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28389,7 +28389,7 @@
     },
     "packages/constructs": {
       "name": "@jaypie/constructs",
-      "version": "1.2.53",
+      "version": "1.2.54",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*",
@@ -29214,7 +29214,7 @@
       "license": "MIT"
     },
     "packages/jaypie": {
-      "version": "1.2.45",
+      "version": "1.2.46",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "^1.2.8",
@@ -29223,7 +29223,7 @@
         "@jaypie/errors": "^1.2.1",
         "@jaypie/express": "^1.2.23",
         "@jaypie/kit": "^1.2.8",
-        "@jaypie/lambda": "^1.2.5",
+        "@jaypie/lambda": "^1.2.6",
         "@jaypie/logger": "^1.2.15"
       },
       "devDependencies": {
@@ -29315,7 +29315,7 @@
     },
     "packages/lambda": {
       "name": "@jaypie/lambda",
-      "version": "1.2.5",
+      "version": "1.2.6",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-typescript": "^12.1.2",
@@ -29471,7 +29471,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.56",
+      "version": "0.8.57",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.4",
@@ -29876,7 +29876,7 @@
     },
     "packages/testkit": {
       "name": "@jaypie/testkit",
-      "version": "1.2.36",
+      "version": "1.2.37",
       "license": "MIT",
       "dependencies": {
         "jest-extended": "^4.0.2",

--- a/packages/constructs/package.json
+++ b/packages/constructs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/constructs",
-  "version": "1.2.53",
+  "version": "1.2.54",
   "description": "CDK constructs for Jaypie applications",
   "repository": {
     "type": "git",

--- a/packages/constructs/src/JaypieMigration.ts
+++ b/packages/constructs/src/JaypieMigration.ts
@@ -2,10 +2,20 @@ import { Construct } from "constructs";
 import * as cdk from "aws-cdk-lib";
 import * as cr from "aws-cdk-lib/custom-resources";
 import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
+import * as iam from "aws-cdk-lib/aws-iam";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import { CDK } from "./constants";
 import { JaypieLambda } from "./JaypieLambda";
 import type { SecretsArrayItem } from "./helpers/index.js";
+
+const DYNAMODB_CONTROL_PLANE_ACTIONS = [
+  "dynamodb:DescribeContinuousBackups",
+  "dynamodb:DescribeTable",
+  "dynamodb:DescribeTimeToLive",
+  "dynamodb:UpdateContinuousBackups",
+  "dynamodb:UpdateTable",
+  "dynamodb:UpdateTimeToLive",
+];
 
 export interface JaypieMigrationProps {
   /** Path to the bundled migration code (esbuild output directory) */
@@ -48,6 +58,21 @@ export class JaypieMigration extends Construct {
       tables,
       timeout: cdk.Duration.minutes(5),
     });
+
+    // Grant control-plane perms on the passed tables so migrations that
+    // alter table shape (GSIs, TTL, streams, backups) succeed. JaypieLambda
+    // only grants data-plane access via grantReadWriteData. Issue #339.
+    if (tables.length > 0) {
+      this.lambda.addToRolePolicy(
+        new iam.PolicyStatement({
+          actions: DYNAMODB_CONTROL_PLANE_ACTIONS,
+          resources: tables.flatMap((table) => [
+            table.tableArn,
+            `${table.tableArn}/index/*`,
+          ]),
+        }),
+      );
+    }
 
     // Custom Resource provider wrapping the Lambda
     const provider = new cr.Provider(this, "MigrationProvider", {

--- a/packages/constructs/src/__tests__/JaypieMigration.spec.ts
+++ b/packages/constructs/src/__tests__/JaypieMigration.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { Stack } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
@@ -102,6 +102,74 @@ describe("JaypieMigration", () => {
       expect(
         migrationLambda?.Properties?.Environment?.Variables,
       ).toHaveProperty("DYNAMODB_TABLE_NAME");
+    });
+
+    it("grants control-plane DynamoDB perms scoped to passed tables (issue #339)", () => {
+      const stack = new Stack();
+      const table = new dynamodb.Table(stack, "TestTable", {
+        partitionKey: { name: "model", type: dynamodb.AttributeType.STRING },
+        sortKey: { name: "id", type: dynamodb.AttributeType.STRING },
+      });
+
+      new JaypieMigration(stack, "TestMigration", {
+        code: lambda.Code.fromInline("exports.handler = () => {}"),
+        handler: "index.handler",
+        tables: [table],
+      });
+
+      const template = Template.fromStack(stack);
+      const policies = template.findResources("AWS::IAM::Policy");
+      const allActions = new Set<string>();
+      for (const policy of Object.values(policies)) {
+        const statements = (policy as any).Properties?.PolicyDocument
+          ?.Statement as Array<{ Action: unknown }>;
+        for (const statement of statements ?? []) {
+          const actions = Array.isArray(statement.Action)
+            ? statement.Action
+            : [statement.Action];
+          for (const action of actions) {
+            if (typeof action === "string") allActions.add(action);
+          }
+        }
+      }
+      expect(allActions.has("dynamodb:DescribeTable")).toBe(true);
+      expect(allActions.has("dynamodb:UpdateTable")).toBe(true);
+      expect(allActions.has("dynamodb:UpdateTimeToLive")).toBe(true);
+      expect(allActions.has("dynamodb:UpdateContinuousBackups")).toBe(true);
+    });
+
+    it("does not grant DynamoDB perms with star resource (issue #339)", () => {
+      const stack = new Stack();
+      const table = new dynamodb.Table(stack, "TestTable", {
+        partitionKey: { name: "model", type: dynamodb.AttributeType.STRING },
+      });
+
+      new JaypieMigration(stack, "TestMigration", {
+        code: lambda.Code.fromInline("exports.handler = () => {}"),
+        handler: "index.handler",
+        tables: [table],
+      });
+
+      const template = Template.fromStack(stack);
+      const policies = template.findResources("AWS::IAM::Policy");
+      for (const policy of Object.values(policies)) {
+        const statements = (policy as any).Properties?.PolicyDocument
+          ?.Statement as Array<{ Action: unknown; Resource: unknown }>;
+        for (const statement of statements ?? []) {
+          const actions = Array.isArray(statement.Action)
+            ? statement.Action
+            : [statement.Action];
+          const usesDynamoControlPlane = actions.some(
+            (action) =>
+              typeof action === "string" &&
+              (action === "dynamodb:DescribeTable" ||
+                action === "dynamodb:UpdateTable"),
+          );
+          if (usesDynamoControlPlane) {
+            expect(statement.Resource).not.toBe("*");
+          }
+        }
+      }
     });
   });
 });

--- a/packages/jaypie/package.json
+++ b/packages/jaypie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jaypie",
-  "version": "1.2.45",
+  "version": "1.2.46",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"
@@ -38,7 +38,7 @@
     "@jaypie/errors": "^1.2.1",
     "@jaypie/express": "^1.2.23",
     "@jaypie/kit": "^1.2.8",
-    "@jaypie/lambda": "^1.2.5",
+    "@jaypie/lambda": "^1.2.6",
     "@jaypie/logger": "^1.2.15"
   },
   "devDependencies": {

--- a/packages/jaypie/src/__tests__/index.spec.js
+++ b/packages/jaypie/src/__tests__/index.spec.js
@@ -18,6 +18,7 @@ import {
   cors,
   // Lambda
   lambdaHandler,
+  migrationHandler,
 } from "../index.js";
 
 //
@@ -63,6 +64,7 @@ describe("Index", () => {
   describe("Lambda exports", () => {
     it("Exports Lambda functions", () => {
       expect(lambdaHandler).toBeFunction();
+      expect(migrationHandler).toBeFunction();
     });
   });
 });

--- a/packages/jaypie/src/index.ts
+++ b/packages/jaypie/src/index.ts
@@ -31,7 +31,11 @@ export * from "@jaypie/datadog";
 export * from "@jaypie/express";
 
 // Lambda - explicitly export to avoid type conflicts with @jaypie/express
-export { lambdaHandler, lambdaStreamHandler } from "@jaypie/lambda";
+export {
+  lambdaHandler,
+  lambdaStreamHandler,
+  migrationHandler,
+} from "@jaypie/lambda";
 export type {
   AwsStreamingHandler,
   LambdaHandlerFunction,

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/lambda",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"

--- a/packages/lambda/src/__tests__/migrationHandler.spec.ts
+++ b/packages/lambda/src/__tests__/migrationHandler.spec.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { log } from "@jaypie/logger";
+import { restoreLog, spyLog } from "@jaypie/testkit";
+
+import migrationHandler from "../migrationHandler.js";
+
+const DEFAULT_ENV = process.env;
+beforeEach(() => {
+  process.env = { ...process.env };
+  spyLog(log);
+});
+afterEach(() => {
+  process.env = DEFAULT_ENV;
+  vi.clearAllMocks();
+  restoreLog(log);
+});
+
+describe("migrationHandler", () => {
+  describe("Base Cases", () => {
+    it("Works", () => {
+      expect(migrationHandler).toBeDefined();
+      expect(migrationHandler).toBeFunction();
+    });
+    it("Returns a function", () => {
+      const handler = migrationHandler(async () => "ok");
+      expect(handler).toBeFunction();
+    });
+  });
+
+  describe("Behavior", () => {
+    it("Returns the handler result on success", async () => {
+      const handler = migrationHandler(async () => ({ status: "complete" }));
+      const result = await handler({}, {});
+      expect(result).toEqual({ status: "complete" });
+    });
+
+    it("Re-throws unhandled errors so CFN sees a failed custom resource", async () => {
+      const handler = migrationHandler(async () => {
+        throw new Error("AccessDeniedException: dynamodb:DescribeTable");
+      });
+      await expect(handler({}, {})).rejects.toThrow();
+    });
+
+    it("Allows opting out of throwing by passing throw: false", async () => {
+      const handler = migrationHandler(
+        async () => {
+          throw new Error("boom");
+        },
+        { throw: false },
+      );
+      const result = await handler({}, {});
+      expect(result).toBeDefined();
+    });
+
+    it("Accepts options-first parameter order", async () => {
+      const handler = migrationHandler({ name: "test" }, async () => ({
+        ok: true,
+      }));
+      await expect(handler({}, {})).resolves.toEqual({ ok: true });
+    });
+  });
+});

--- a/packages/lambda/src/index.ts
+++ b/packages/lambda/src/index.ts
@@ -1,5 +1,6 @@
 import lambdaHandler from "./lambdaHandler.js";
 import lambdaStreamHandler from "./lambdaStreamHandler.js";
+import migrationHandler from "./migrationHandler.js";
 import websocketHandler from "./websocketHandler.js";
 
 //
@@ -7,7 +8,12 @@ import websocketHandler from "./websocketHandler.js";
 // Export
 //
 
-export { lambdaHandler, lambdaStreamHandler, websocketHandler };
+export {
+  lambdaHandler,
+  lambdaStreamHandler,
+  migrationHandler,
+  websocketHandler,
+};
 export type {
   LambdaContext,
   LambdaHandlerFunction,

--- a/packages/lambda/src/migrationHandler.ts
+++ b/packages/lambda/src/migrationHandler.ts
@@ -1,0 +1,25 @@
+import lambdaHandler, {
+  LambdaHandlerFunction,
+  LambdaHandlerOptions,
+} from "./lambdaHandler.js";
+
+// Defaults to throw: true so a failed migration fails the CFN custom resource
+// (and therefore the deploy) instead of being swallowed and reported COMPLETE.
+const migrationHandler = function <TEvent = unknown, TResult = unknown>(
+  handler: LambdaHandlerFunction<TEvent, TResult> | LambdaHandlerOptions,
+  options: LambdaHandlerOptions | LambdaHandlerFunction<TEvent, TResult> = {},
+): LambdaHandlerFunction<TEvent, TResult> {
+  if (typeof handler === "object" && typeof options === "function") {
+    const temp = handler;
+    handler = options;
+    options = temp;
+  }
+
+  const opts = options as LambdaHandlerOptions;
+  return lambdaHandler<TEvent, TResult>(
+    handler as LambdaHandlerFunction<TEvent, TResult>,
+    { throw: true, ...opts },
+  );
+};
+
+export default migrationHandler;

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.56",
+  "version": "0.8.57",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/constructs/1.2.54.md
+++ b/packages/mcp/release-notes/constructs/1.2.54.md
@@ -1,0 +1,19 @@
+---
+version: 1.2.54
+date: 2026-05-10
+summary: JaypieMigration grants control-plane DynamoDB perms scoped to passed tables (issue #339)
+---
+
+## Changes
+
+- `JaypieMigration` now grants control-plane DynamoDB actions (`DescribeContinuousBackups`, `DescribeTable`, `DescribeTimeToLive`, `UpdateContinuousBackups`, `UpdateTable`, `UpdateTimeToLive`) on the ARNs of any tables passed via `tables`, scoped to the table ARN and its indexes (`/index/*`). Data-plane access is unchanged.
+
+## Motivation
+
+The migration Lambda was previously granted only data-plane access via `grantReadWriteData`. Migrations whose entire purpose is to evolve table shape (add a GSI, change TTL, toggle streams, update backups) `AccessDenied` on the first control-plane call. Combined with `lambdaHandler`'s default soft-fail, the deploy reported `CREATE_COMPLETE` while later migrations silently never ran.
+
+Pair this with the new `migrationHandler` in `@jaypie/lambda` (1.2.6) for end-to-end loud-fail behavior.
+
+## Migration
+
+No action required. Existing migrations using only data-plane ops keep working; migrations that previously failed with `AccessDeniedException` on `dynamodb:DescribeTable` or `dynamodb:UpdateTable` should now succeed.

--- a/packages/mcp/release-notes/jaypie/1.2.46.md
+++ b/packages/mcp/release-notes/jaypie/1.2.46.md
@@ -1,0 +1,13 @@
+---
+version: 1.2.46
+date: 2026-05-10
+summary: Re-export migrationHandler from @jaypie/lambda (issue #339)
+---
+
+## Changes
+
+- Re-exports `migrationHandler` from `@jaypie/lambda` 1.2.6.
+
+## Motivation
+
+Migration Lambdas should fail loudly so a failed migration fails the deploy. Use `migrationHandler` instead of `lambdaHandler` in migration entrypoints — see the migrations skill for usage.

--- a/packages/mcp/release-notes/lambda/1.2.6.md
+++ b/packages/mcp/release-notes/lambda/1.2.6.md
@@ -1,0 +1,27 @@
+---
+version: 1.2.6
+date: 2026-05-10
+summary: Add migrationHandler that defaults throw: true so failed migrations fail the deploy (issue #339)
+---
+
+## Changes
+
+- New `migrationHandler` export. Wraps `lambdaHandler` with `throw: true` defaulted so a thrown error propagates out of the Lambda, causing the CFN custom resource (and the deploy) to fail loudly instead of swallowing the error and reporting `CREATE_COMPLETE`.
+- Re-exported by `jaypie` and mocked by `@jaypie/testkit/mock`.
+- Pass `{ throw: false }` to opt back into the soft-fail behavior.
+
+## Motivation
+
+`JaypieMigration` runs its Lambda via a CFN custom resource provider. With `lambdaHandler`'s default `throw: false`, a thrown migration error was caught, logged as `fatal`, and returned as a successful response — CFN saw a 200-shaped response and marked the resource `CREATE_COMPLETE`. The deploy turned green while later migrations silently never ran.
+
+## Migration
+
+Update migration entry points from `lambdaHandler` to `migrationHandler`:
+
+```typescript
+import { migrationHandler } from "jaypie";
+
+export const handler = migrationHandler(async (event) => {
+  // migration logic
+});
+```

--- a/packages/mcp/release-notes/mcp/0.8.57.md
+++ b/packages/mcp/release-notes/mcp/0.8.57.md
@@ -1,0 +1,9 @@
+---
+version: 0.8.57
+date: 2026-05-10
+summary: Migrations skill recommends migrationHandler and documents control-plane perms (issue #339)
+---
+
+## Changes
+
+- `skill("migrations")` now recommends `migrationHandler` for the Lambda entrypoint and documents the control-plane DynamoDB permissions added by `JaypieMigration` 1.2.54.

--- a/packages/mcp/release-notes/testkit/1.2.37.md
+++ b/packages/mcp/release-notes/testkit/1.2.37.md
@@ -1,0 +1,9 @@
+---
+version: 1.2.37
+date: 2026-05-10
+summary: Mock migrationHandler from @jaypie/lambda (issue #339)
+---
+
+## Changes
+
+- Adds `migrationHandler` mock that mirrors the real handler — defaults `throw: true` so thrown errors surface in tests.

--- a/packages/mcp/skills/migrations.md
+++ b/packages/mcp/skills/migrations.md
@@ -44,16 +44,18 @@ new JaypieMigration(this, "SeedData", {
 - **Role**: Tagged as `CDK.ROLE.PROCESSING`
 - **Execution**: Runs on every deploy via CloudFormation custom resource (uses a deploy nonce to force re-invocation even when only Lambda code changes)
 - **Dependencies**: Use `dependencies` to ensure tables and other resources exist before the migration executes
+- **Permissions**: Tables passed via `tables` get data-plane (`grantReadWriteData`) plus control-plane access (`DescribeTable`, `UpdateTable`, `UpdateTimeToLive`, `UpdateContinuousBackups`) scoped to the table ARN and its indexes — migrations that add GSIs, toggle TTL, or change backups work without extra IAM
 
 ## Migration Lambda Handler
 
-The migration Lambda receives a CloudFormation custom resource event. Return a result to signal success; throw to signal failure and roll back the stack.
+The migration Lambda receives a CloudFormation custom resource event. Use `migrationHandler` so a thrown error fails the CFN custom resource (and the deploy) — `lambdaHandler`'s default `throw: false` returns a success-shaped response on error and CFN reports `CREATE_COMPLETE` even when the migration failed.
 
 ```typescript
 // src/migrations/seed/index.ts
 import { initClient, seedEntities, APEX } from "@jaypie/dynamodb";
+import { migrationHandler } from "jaypie";
 
-export const handler = async (event: any) => {
+export const handler = migrationHandler(async (event) => {
   await initClient();
 
   await seedEntities([
@@ -62,8 +64,10 @@ export const handler = async (event: any) => {
   ]);
 
   return { status: "complete" };
-};
+});
 ```
+
+`migrationHandler` is `lambdaHandler` with `throw: true` defaulted. Pass `{ throw: false }` to opt back into soft-fail behavior.
 
 ## Building Migration Code
 

--- a/packages/testkit/package.json
+++ b/packages/testkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/testkit",
-  "version": "1.2.36",
+  "version": "1.2.37",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"

--- a/packages/testkit/src/mock/lambda.ts
+++ b/packages/testkit/src/mock/lambda.ts
@@ -30,6 +30,25 @@ export const lambdaHandler = createMockFunction<
   };
 });
 
+// Mock implementation of migrationHandler — defaults throw: true so failed
+// migrations propagate to CFN custom resource (issue #339).
+export const migrationHandler = createMockFunction<
+  (handler: HandlerFunction, props?: LambdaOptions) => HandlerFunction
+>((handler, props = {}) => {
+  if (typeof handler === "object" && typeof props === "function") {
+    const temp = handler;
+    handler = props;
+    props = temp;
+  }
+  return async (event: unknown, context: unknown, ...extra: unknown[]) => {
+    return jaypieHandler(handler, { throw: true, ...props })(
+      event,
+      context,
+      ...extra,
+    );
+  };
+});
+
 // Mock stream handler function type
 type StreamHandlerFunction = (
   event: unknown,


### PR DESCRIPTION
## Summary

- `JaypieMigration` now grants control-plane DynamoDB perms (`DescribeTable`, `UpdateTable`, `UpdateTimeToLive`, `UpdateContinuousBackups`, etc.) scoped to passed table ARNs and `/index/*`. No `*` resource.
- New `migrationHandler` in `@jaypie/lambda` wraps `lambdaHandler` with `throw: true` defaulted so failed migrations fail the CFN custom resource and the deploy.
- Mocked in `@jaypie/testkit`, re-exported by `jaypie`, recommended in the migrations skill.

Resolves #339.

## Test plan

- [x] `npm run typecheck` passes for constructs, lambda, jaypie, testkit, mcp
- [x] `npm test` passes (941 tests across affected packages)
- [x] New IAM specs verify control-plane actions present and no `*` resource on DynamoDB control-plane statements
- [x] New `migrationHandler` specs verify throw: true default and opt-out via `{ throw: false }`
- [ ] Real-world: redeploy a failing migration on `cloudagent` and confirm CFN now reports failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)