### PR TITLE
Bundle #341 #336 #342: migration timeout, llm sibling rejections, WAF path-scoped allow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28389,7 +28389,7 @@
     },
     "packages/constructs": {
       "name": "@jaypie/constructs",
-      "version": "1.2.54",
+      "version": "1.2.55",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*",
@@ -29214,7 +29214,7 @@
       "license": "MIT"
     },
     "packages/jaypie": {
-      "version": "1.2.46",
+      "version": "1.2.47",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "^1.2.8",
@@ -29239,7 +29239,7 @@
         "typescript-eslint": "^8.46.1"
       },
       "peerDependencies": {
-        "@jaypie/llm": "^1.2.33",
+        "@jaypie/llm": "^1.2.34",
         "@jaypie/mongoose": "^1.2.2"
       },
       "peerDependenciesMeta": {
@@ -29348,7 +29348,7 @@
     },
     "packages/llm": {
       "name": "@jaypie/llm",
-      "version": "1.2.33",
+      "version": "1.2.34",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "*",
@@ -29471,7 +29471,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.57",
+      "version": "0.8.58",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.4",

--- a/packages/constructs/CLAUDE.md
+++ b/packages/constructs/CLAUDE.md
@@ -259,7 +259,28 @@ new JaypieDistribution(this, "Dist", {
     },
   },
 });
+
+// Path-scoped relaxations: flip specific sub-rules to count only on listed paths
+new JaypieDistribution(this, "Dist", {
+  handler,
+  waf: {
+    name: "api",
+    allow: [
+      {
+        path: "/hooks/*", // trailing * → STARTS_WITH; otherwise EXACTLY
+        AWSManagedRulesCommonRuleSet: ["ExploitablePaths_URIPATH"],
+        AWSManagedRulesKnownBadInputsRuleSet: ["CrossSiteScripting_BODY"],
+      },
+    ],
+  },
+});
 ```
+
+`waf.allow` composes with `managedRuleOverrides`: the baseline overrides apply
+to both the relaxed and strict emissions of a group; entries in `allow`
+further relax specific (path × sub-rule) intersections. Groups not named in
+`allow` keep their existing single-rule emission. `path` and each rule-group
+value accept either a single string or an array.
 
 ### Streaming Lambda
 

--- a/packages/constructs/package.json
+++ b/packages/constructs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/constructs",
-  "version": "1.2.54",
+  "version": "1.2.55",
   "description": "CDK constructs for Jaypie applications",
   "repository": {
     "type": "git",

--- a/packages/constructs/src/JaypieDistribution.ts
+++ b/packages/constructs/src/JaypieDistribution.ts
@@ -31,6 +31,18 @@ const DEFAULT_MANAGED_RULES = [
   "AWSManagedRulesKnownBadInputsRuleSet",
 ];
 
+/**
+ * One entry in a `waf.allow` list. Names one or more URL paths and, for each
+ * managed rule group key, the sub-rule names to flip from `block` to `count`
+ * on that path set. See JaypieWafConfig.allow.
+ */
+export interface JaypieWafAllowEntry {
+  /** URL path or paths. Trailing `*` → STARTS_WITH; otherwise EXACTLY. */
+  path: string | string[];
+  /** Managed-rule-group keys (e.g. AWSManagedRulesCommonRuleSet) → sub-rule names. */
+  [ruleGroupKey: string]: string | string[] | undefined;
+}
+
 export interface JaypieWafConfig {
   /**
    * Unique name for this distribution's WAF resources. Required when passing a
@@ -108,6 +120,27 @@ export interface JaypieWafConfig {
    * @default 2000
    */
   rateLimitPerIp?: number;
+
+  /**
+   * Path-scoped relaxations layered on top of the default managed-rule groups.
+   * Each entry names one or more URL paths and, for each managed rule group
+   * key, the sub-rule names to flip from `block` to `count` on that path set.
+   * Strict default action is preserved on every other path.
+   *
+   * Composes with `managedRuleOverrides`: the baseline override list applies
+   * to both the relaxed and strict emissions of a group; entries in `allow`
+   * additionally relax specific (path × sub-rule) intersections.
+   *
+   * @example
+   * allow: [
+   *   {
+   *     path: "/hooks/*",
+   *     AWSManagedRulesCommonRuleSet: ["ExploitablePaths_URIPATH"],
+   *     AWSManagedRulesKnownBadInputsRuleSet: ["CrossSiteScripting_BODY"],
+   *   },
+   * ]
+   */
+  allow?: JaypieWafAllowEntry | JaypieWafAllowEntry[];
 
   /**
    * Use an existing WebACL ARN instead of creating one
@@ -572,19 +605,135 @@ export class JaypieDistribution
       } else {
         // Create new WebACL
         const {
+          allow,
           managedRuleOverrides,
           managedRuleScopeDowns,
           managedRules = DEFAULT_MANAGED_RULES,
           rateLimitPerIp = DEFAULT_RATE_LIMIT,
         } = wafConfig;
 
+        const allowEntries: JaypieWafAllowEntry[] = allow
+          ? Array.isArray(allow)
+            ? allow
+            : [allow]
+          : [];
+
+        // Group allow entries by managed rule group name
+        type GroupAllowance = { paths: string[]; ruleNames: string[] };
+        const groupAllowances: Record<string, GroupAllowance[]> = {};
+        for (const entry of allowEntries) {
+          const paths = Array.isArray(entry.path) ? entry.path : [entry.path];
+          for (const key of Object.keys(entry)) {
+            if (key === "path") continue;
+            const raw = entry[key];
+            if (raw == null) continue;
+            const ruleNames = Array.isArray(raw) ? raw : [raw];
+            if (!groupAllowances[key]) groupAllowances[key] = [];
+            groupAllowances[key].push({ paths, ruleNames });
+          }
+        }
+
+        const pathToStatement = (
+          path: string,
+        ): wafv2.CfnWebACL.StatementProperty => {
+          const isPrefix = path.endsWith("*");
+          return {
+            byteMatchStatement: {
+              fieldToMatch: { uriPath: {} },
+              positionalConstraint: isPrefix ? "STARTS_WITH" : "EXACTLY",
+              searchString: isPrefix ? path.slice(0, -1) : path,
+              textTransformations: [{ priority: 0, type: "NONE" }],
+            },
+          };
+        };
+
+        const pathsToStatement = (
+          paths: string[],
+        ): wafv2.CfnWebACL.StatementProperty => {
+          if (paths.length === 1) return pathToStatement(paths[0]);
+          return {
+            orStatement: { statements: paths.map(pathToStatement) },
+          };
+        };
+
+        const andScopeDown = (
+          base: wafv2.CfnWebACL.StatementProperty | undefined,
+          extra: wafv2.CfnWebACL.StatementProperty,
+        ): wafv2.CfnWebACL.StatementProperty =>
+          base ? { andStatement: { statements: [base, extra] } } : extra;
+
         let priority = 0;
         const rules: wafv2.CfnWebACL.RuleProperty[] = [];
 
         // Add managed rule groups
         for (const ruleName of managedRules) {
-          const ruleActionOverrides = managedRuleOverrides?.[ruleName];
-          const scopeDownStatement = managedRuleScopeDowns?.[ruleName];
+          const baseOverrides = managedRuleOverrides?.[ruleName];
+          const baseScopeDown = managedRuleScopeDowns?.[ruleName];
+          const allowances = groupAllowances[ruleName];
+
+          if (!allowances || allowances.length === 0) {
+            rules.push({
+              name: ruleName,
+              priority: priority++,
+              overrideAction: { none: {} },
+              statement: {
+                managedRuleGroupStatement: {
+                  name: ruleName,
+                  vendorName: "AWS",
+                  ...(baseOverrides && { ruleActionOverrides: baseOverrides }),
+                  ...(baseScopeDown && { scopeDownStatement: baseScopeDown }),
+                },
+              },
+              visibilityConfig: {
+                cloudWatchMetricsEnabled: true,
+                metricName: ruleName,
+                sampledRequestsEnabled: true,
+              },
+            });
+            continue;
+          }
+
+          // Emit one relaxed rule per allow entry that names this group
+          allowances.forEach(({ paths, ruleNames }, index) => {
+            const entryOverrides: wafv2.CfnWebACL.RuleActionOverrideProperty[] =
+              ruleNames.map((n) => ({
+                name: n,
+                actionToUse: { count: {} },
+              }));
+            const combinedOverrides = [
+              ...(baseOverrides ?? []),
+              ...entryOverrides,
+            ];
+            const relaxedScopeDown = andScopeDown(
+              baseScopeDown,
+              pathsToStatement(paths),
+            );
+            const relaxedName = `${ruleName}-allow-${index}`;
+            rules.push({
+              name: relaxedName,
+              priority: priority++,
+              overrideAction: { none: {} },
+              statement: {
+                managedRuleGroupStatement: {
+                  name: ruleName,
+                  vendorName: "AWS",
+                  ruleActionOverrides: combinedOverrides,
+                  scopeDownStatement: relaxedScopeDown,
+                },
+              },
+              visibilityConfig: {
+                cloudWatchMetricsEnabled: true,
+                metricName: relaxedName,
+                sampledRequestsEnabled: true,
+              },
+            });
+          });
+
+          // Emit one strict rule whose scope-down excludes every relaxed path
+          const allPaths = allowances.flatMap((a) => a.paths);
+          const strictScopeDown = andScopeDown(baseScopeDown, {
+            notStatement: { statement: pathsToStatement(allPaths) },
+          });
           rules.push({
             name: ruleName,
             priority: priority++,
@@ -593,8 +742,8 @@ export class JaypieDistribution
               managedRuleGroupStatement: {
                 name: ruleName,
                 vendorName: "AWS",
-                ...(ruleActionOverrides && { ruleActionOverrides }),
-                ...(scopeDownStatement && { scopeDownStatement }),
+                ...(baseOverrides && { ruleActionOverrides: baseOverrides }),
+                scopeDownStatement: strictScopeDown,
               },
             },
             visibilityConfig: {

--- a/packages/constructs/src/JaypieMigration.ts
+++ b/packages/constructs/src/JaypieMigration.ts
@@ -30,6 +30,8 @@ export interface JaypieMigrationProps {
   secrets?: SecretsArrayItem[];
   /** DynamoDB tables to grant read/write access */
   tables?: dynamodb.ITable[];
+  /** Lambda timeout. Defaults to 15 minutes (Lambda max). */
+  timeout?: cdk.Duration;
 }
 
 export class JaypieMigration extends Construct {
@@ -45,9 +47,9 @@ export class JaypieMigration extends Construct {
       handler = "index.handler",
       secrets = [],
       tables = [],
+      timeout = cdk.Duration.minutes(15),
     } = props;
 
-    // Migration Lambda — 5 minute timeout for long-running migrations
     this.lambda = new JaypieLambda(this, "MigrationLambda", {
       code,
       description: "DynamoDB migration custom resource",
@@ -56,7 +58,7 @@ export class JaypieMigration extends Construct {
       roleTag: CDK.ROLE.PROCESSING,
       secrets,
       tables,
-      timeout: cdk.Duration.minutes(5),
+      timeout,
     });
 
     // Grant control-plane perms on the passed tables so migrations that

--- a/packages/constructs/src/__tests__/JaypieDistribution.spec.ts
+++ b/packages/constructs/src/__tests__/JaypieDistribution.spec.ts
@@ -1726,6 +1726,344 @@ describe("JaypieDistribution", () => {
       });
     });
 
+    describe("waf.allow path-scoped relaxation (#342)", () => {
+      const findRulesOfName = (template: Template, ruleName: string): any[] => {
+        const resources = template.findResources("AWS::WAFv2::WebACL");
+        const webAcl = Object.values(resources)[0];
+        const rules = (webAcl as any)?.Properties?.Rules || [];
+        return rules.filter((r: any) => {
+          if (r.Name === ruleName) return true;
+          if (
+            typeof r.Name === "string" &&
+            r.Name.startsWith(`${ruleName}-allow-`)
+          )
+            return true;
+          const statementName = r.Statement?.ManagedRuleGroupStatement?.Name;
+          return statementName === ruleName;
+        });
+      };
+
+      it("emits one relaxed rule and one strict rule for a group named in allow", () => {
+        const stack = new Stack();
+        const bucket = new s3.Bucket(stack, "TestBucket");
+        const origin = origins.S3BucketOrigin.withOriginAccessControl(bucket);
+
+        new JaypieDistribution(stack, "TestDistribution", {
+          handler: origin,
+          waf: {
+            name: "test",
+            allow: [
+              {
+                path: "/hooks/*",
+                AWSManagedRulesCommonRuleSet: ["ExploitablePaths_URIPATH"],
+              },
+            ],
+          },
+        });
+        const template = Template.fromStack(stack);
+        const matched = findRulesOfName(
+          template,
+          "AWSManagedRulesCommonRuleSet",
+        );
+        expect(matched.length).toBe(2);
+      });
+
+      it("relaxed rule uses STARTS_WITH for trailing-star paths and overrides to count", () => {
+        const stack = new Stack();
+        const bucket = new s3.Bucket(stack, "TestBucket");
+        const origin = origins.S3BucketOrigin.withOriginAccessControl(bucket);
+
+        new JaypieDistribution(stack, "TestDistribution", {
+          handler: origin,
+          waf: {
+            name: "test",
+            allow: [
+              {
+                path: "/hooks/*",
+                AWSManagedRulesCommonRuleSet: ["ExploitablePaths_URIPATH"],
+              },
+            ],
+          },
+        });
+        const template = Template.fromStack(stack);
+
+        template.hasResourceProperties("AWS::WAFv2::WebACL", {
+          Rules: Match.arrayWith([
+            Match.objectLike({
+              Statement: {
+                ManagedRuleGroupStatement: Match.objectLike({
+                  Name: "AWSManagedRulesCommonRuleSet",
+                  RuleActionOverrides: Match.arrayWith([
+                    {
+                      Name: "ExploitablePaths_URIPATH",
+                      ActionToUse: { Count: {} },
+                    },
+                  ]),
+                  ScopeDownStatement: {
+                    ByteMatchStatement: Match.objectLike({
+                      PositionalConstraint: "STARTS_WITH",
+                      SearchString: "/hooks/",
+                    }),
+                  },
+                }),
+              },
+            }),
+          ]),
+        });
+      });
+
+      it("strict rule scope-down is NOT of the relaxed paths", () => {
+        const stack = new Stack();
+        const bucket = new s3.Bucket(stack, "TestBucket");
+        const origin = origins.S3BucketOrigin.withOriginAccessControl(bucket);
+
+        new JaypieDistribution(stack, "TestDistribution", {
+          handler: origin,
+          waf: {
+            name: "test",
+            allow: [
+              {
+                path: "/hooks/*",
+                AWSManagedRulesCommonRuleSet: ["ExploitablePaths_URIPATH"],
+              },
+            ],
+          },
+        });
+        const template = Template.fromStack(stack);
+        const matched = findRulesOfName(
+          template,
+          "AWSManagedRulesCommonRuleSet",
+        );
+        const strict = matched.find(
+          (r: any) =>
+            !r.Statement?.ManagedRuleGroupStatement?.RuleActionOverrides,
+        );
+        expect(strict).toBeDefined();
+        expect(
+          strict?.Statement?.ManagedRuleGroupStatement?.ScopeDownStatement
+            ?.NotStatement?.Statement?.ByteMatchStatement?.SearchString,
+        ).toBe("/hooks/");
+      });
+
+      it("treats paths without trailing star as EXACTLY", () => {
+        const stack = new Stack();
+        const bucket = new s3.Bucket(stack, "TestBucket");
+        const origin = origins.S3BucketOrigin.withOriginAccessControl(bucket);
+
+        new JaypieDistribution(stack, "TestDistribution", {
+          handler: origin,
+          waf: {
+            name: "test",
+            allow: [
+              {
+                path: "/exact/path",
+                AWSManagedRulesCommonRuleSet: ["ExploitablePaths_URIPATH"],
+              },
+            ],
+          },
+        });
+        const template = Template.fromStack(stack);
+
+        template.hasResourceProperties("AWS::WAFv2::WebACL", {
+          Rules: Match.arrayWith([
+            Match.objectLike({
+              Statement: {
+                ManagedRuleGroupStatement: Match.objectLike({
+                  Name: "AWSManagedRulesCommonRuleSet",
+                  ScopeDownStatement: {
+                    ByteMatchStatement: Match.objectLike({
+                      PositionalConstraint: "EXACTLY",
+                      SearchString: "/exact/path",
+                    }),
+                  },
+                }),
+              },
+            }),
+          ]),
+        });
+      });
+
+      it("ORs multiple paths in one entry", () => {
+        const stack = new Stack();
+        const bucket = new s3.Bucket(stack, "TestBucket");
+        const origin = origins.S3BucketOrigin.withOriginAccessControl(bucket);
+
+        new JaypieDistribution(stack, "TestDistribution", {
+          handler: origin,
+          waf: {
+            name: "test",
+            allow: [
+              {
+                path: ["/hooks/*", "/webhooks/*"],
+                AWSManagedRulesCommonRuleSet: "ExploitablePaths_URIPATH",
+              },
+            ],
+          },
+        });
+        const template = Template.fromStack(stack);
+        const matched = findRulesOfName(
+          template,
+          "AWSManagedRulesCommonRuleSet",
+        );
+        const relaxed = matched.find(
+          (r: any) =>
+            r.Statement?.ManagedRuleGroupStatement?.RuleActionOverrides,
+        );
+        const orStatements =
+          relaxed?.Statement?.ManagedRuleGroupStatement?.ScopeDownStatement
+            ?.OrStatement?.Statements;
+        expect(Array.isArray(orStatements)).toBe(true);
+        expect(orStatements.length).toBe(2);
+      });
+
+      it("accepts a bare object (not wrapped in an array)", () => {
+        const stack = new Stack();
+        const bucket = new s3.Bucket(stack, "TestBucket");
+        const origin = origins.S3BucketOrigin.withOriginAccessControl(bucket);
+
+        new JaypieDistribution(stack, "TestDistribution", {
+          handler: origin,
+          waf: {
+            name: "test",
+            allow: {
+              path: "/hooks/*",
+              AWSManagedRulesCommonRuleSet: "ExploitablePaths_URIPATH",
+            },
+          },
+        });
+        const template = Template.fromStack(stack);
+        const matched = findRulesOfName(
+          template,
+          "AWSManagedRulesCommonRuleSet",
+        );
+        expect(matched.length).toBe(2);
+      });
+
+      it("leaves groups not named in allow with their single-entry shape", () => {
+        const stack = new Stack();
+        const bucket = new s3.Bucket(stack, "TestBucket");
+        const origin = origins.S3BucketOrigin.withOriginAccessControl(bucket);
+
+        new JaypieDistribution(stack, "TestDistribution", {
+          handler: origin,
+          waf: {
+            name: "test",
+            allow: [
+              {
+                path: "/hooks/*",
+                AWSManagedRulesCommonRuleSet: ["ExploitablePaths_URIPATH"],
+              },
+            ],
+          },
+        });
+        const template = Template.fromStack(stack);
+        const matched = findRulesOfName(
+          template,
+          "AWSManagedRulesKnownBadInputsRuleSet",
+        );
+        expect(matched.length).toBe(1);
+        expect(
+          matched[0]?.Statement?.ManagedRuleGroupStatement?.ScopeDownStatement,
+        ).toBeUndefined();
+      });
+
+      it("composes with managedRuleOverrides — baseline applies to both relaxed and strict", () => {
+        const stack = new Stack();
+        const bucket = new s3.Bucket(stack, "TestBucket");
+        const origin = origins.S3BucketOrigin.withOriginAccessControl(bucket);
+
+        new JaypieDistribution(stack, "TestDistribution", {
+          handler: origin,
+          waf: {
+            name: "test",
+            managedRuleOverrides: {
+              AWSManagedRulesCommonRuleSet: [
+                { name: "SizeRestrictions_BODY", actionToUse: { count: {} } },
+              ],
+            },
+            allow: [
+              {
+                path: "/hooks/*",
+                AWSManagedRulesCommonRuleSet: ["ExploitablePaths_URIPATH"],
+              },
+            ],
+          },
+        });
+        const template = Template.fromStack(stack);
+        const matched = findRulesOfName(
+          template,
+          "AWSManagedRulesCommonRuleSet",
+        );
+
+        const relaxed = matched.find(
+          (r: any) =>
+            r.Statement?.ManagedRuleGroupStatement?.ScopeDownStatement
+              ?.ByteMatchStatement,
+        );
+        const strict = matched.find(
+          (r: any) =>
+            r.Statement?.ManagedRuleGroupStatement?.ScopeDownStatement
+              ?.NotStatement,
+        );
+
+        const relaxedOverrideNames = (
+          relaxed?.Statement?.ManagedRuleGroupStatement?.RuleActionOverrides ??
+          []
+        ).map((o: any) => o.Name);
+        expect(relaxedOverrideNames).toContain("SizeRestrictions_BODY");
+        expect(relaxedOverrideNames).toContain("ExploitablePaths_URIPATH");
+
+        const strictOverrideNames = (
+          strict?.Statement?.ManagedRuleGroupStatement?.RuleActionOverrides ??
+          []
+        ).map((o: any) => o.Name);
+        expect(strictOverrideNames).toContain("SizeRestrictions_BODY");
+        expect(strictOverrideNames).not.toContain("ExploitablePaths_URIPATH");
+      });
+
+      it("strict NotStatement excludes the union of paths across all entries for a group", () => {
+        const stack = new Stack();
+        const bucket = new s3.Bucket(stack, "TestBucket");
+        const origin = origins.S3BucketOrigin.withOriginAccessControl(bucket);
+
+        new JaypieDistribution(stack, "TestDistribution", {
+          handler: origin,
+          waf: {
+            name: "test",
+            allow: [
+              {
+                path: "/hooks/*",
+                AWSManagedRulesCommonRuleSet: ["ExploitablePaths_URIPATH"],
+              },
+              {
+                path: "/webhooks/*",
+                AWSManagedRulesCommonRuleSet: ["SizeRestrictions_BODY"],
+              },
+            ],
+          },
+        });
+        const template = Template.fromStack(stack);
+        const matched = findRulesOfName(
+          template,
+          "AWSManagedRulesCommonRuleSet",
+        );
+        const strict = matched.find(
+          (r: any) =>
+            r.Statement?.ManagedRuleGroupStatement?.ScopeDownStatement
+              ?.NotStatement,
+        );
+        const orStatements =
+          strict?.Statement?.ManagedRuleGroupStatement?.ScopeDownStatement
+            ?.NotStatement?.Statement?.OrStatement?.Statements;
+        expect(Array.isArray(orStatements)).toBe(true);
+        const searchStrings = orStatements.map(
+          (s: any) => s.ByteMatchStatement?.SearchString,
+        );
+        expect(searchStrings).toContain("/hooks/");
+        expect(searchStrings).toContain("/webhooks/");
+      });
+    });
+
     it("supports existing WebACL ARN", () => {
       const stack = new Stack();
       const bucket = new s3.Bucket(stack, "TestBucket");

--- a/packages/constructs/src/__tests__/JaypieMigration.spec.ts
+++ b/packages/constructs/src/__tests__/JaypieMigration.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { Stack } from "aws-cdk-lib";
+import { Duration, Stack } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
 import * as lambda from "aws-cdk-lib/aws-lambda";
@@ -136,6 +136,41 @@ describe("JaypieMigration", () => {
       expect(allActions.has("dynamodb:UpdateTable")).toBe(true);
       expect(allActions.has("dynamodb:UpdateTimeToLive")).toBe(true);
       expect(allActions.has("dynamodb:UpdateContinuousBackups")).toBe(true);
+    });
+
+    it("defaults Lambda timeout to 15 minutes (issue #341)", () => {
+      const stack = new Stack();
+      new JaypieMigration(stack, "TestMigration", {
+        code: lambda.Code.fromInline("exports.handler = () => {}"),
+        handler: "index.handler",
+      });
+
+      const template = Template.fromStack(stack);
+      const resources = template.findResources("AWS::Lambda::Function");
+      const lambdaFunctions = Object.values(resources);
+      const migrationLambda = lambdaFunctions.find(
+        (r: any) => r.Properties?.Handler === "index.handler",
+      );
+
+      expect(migrationLambda?.Properties?.Timeout).toBe(900);
+    });
+
+    it("accepts a custom timeout (issue #341)", () => {
+      const stack = new Stack();
+      new JaypieMigration(stack, "TestMigration", {
+        code: lambda.Code.fromInline("exports.handler = () => {}"),
+        handler: "index.handler",
+        timeout: Duration.minutes(7),
+      });
+
+      const template = Template.fromStack(stack);
+      const resources = template.findResources("AWS::Lambda::Function");
+      const lambdaFunctions = Object.values(resources);
+      const migrationLambda = lambdaFunctions.find(
+        (r: any) => r.Properties?.Handler === "index.handler",
+      );
+
+      expect(migrationLambda?.Properties?.Timeout).toBe(420);
     });
 
     it("does not grant DynamoDB perms with star resource (issue #339)", () => {

--- a/packages/jaypie/package.json
+++ b/packages/jaypie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jaypie",
-  "version": "1.2.46",
+  "version": "1.2.47",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"
@@ -54,7 +54,7 @@
     "typescript-eslint": "^8.46.1"
   },
   "peerDependencies": {
-    "@jaypie/llm": "^1.2.33",
+    "@jaypie/llm": "^1.2.34",
     "@jaypie/mongoose": "^1.2.2"
   },
   "peerDependenciesMeta": {

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/llm",
-  "version": "1.2.33",
+  "version": "1.2.34",
   "description": "Large language model utilities",
   "repository": {
     "type": "git",

--- a/packages/llm/src/operate/StreamLoop.ts
+++ b/packages/llm/src/operate/StreamLoop.ts
@@ -3,7 +3,7 @@ import { sleep } from "@jaypie/kit";
 import { JsonObject } from "@jaypie/types";
 
 import { MAX_CONSECUTIVE_TOOL_ERRORS } from "./OperateLoop.js";
-import { isTransientNetworkError } from "./retry/isTransientNetworkError.js";
+import { createStaleRejectionGuard } from "./retry/createStaleRejectionGuard.js";
 import { Toolkit } from "../tools/Toolkit.class.js";
 import {
   LlmHistory,
@@ -278,26 +278,10 @@ export class StreamLoop {
     let attempt = 0;
     let chunksYielded = false;
 
-    // Persistent guard against stale socket errors (TypeError: terminated).
-    // Installed after the first abort and kept alive through subsequent attempts.
-    let staleGuard: ((reason: unknown) => void) | undefined;
-
-    const installGuard = () => {
-      if (staleGuard) return;
-      staleGuard = (reason: unknown) => {
-        if (isTransientNetworkError(reason)) {
-          log.trace("Suppressed stale socket error during retry");
-        }
-      };
-      process.on("unhandledRejection", staleGuard);
-    };
-
-    const removeGuard = () => {
-      if (staleGuard) {
-        process.removeListener("unhandledRejection", staleGuard);
-        staleGuard = undefined;
-      }
-    };
+    // Guard against stale rejections firing after the stream loop has already
+    // caught the originating error: undici socket teardown and twin
+    // upstream-SDK rejections (issue #336).
+    const guard = createStaleRejectionGuard();
 
     try {
       while (true) {
@@ -348,11 +332,10 @@ export class StreamLoop {
           }
           break;
         } catch (error: unknown) {
-          // Abort the previous request to kill lingering socket callbacks
           controller.abort("retry");
 
-          // Install the guard immediately after abort
-          installGuard();
+          guard.recordCaught(error);
+          guard.install();
 
           // If chunks were already yielded, we can't transparently retry
           if (chunksYielded) {
@@ -394,7 +377,7 @@ export class StreamLoop {
         }
       }
     } finally {
-      removeGuard();
+      guard.remove();
     }
 
     // Execute afterEachModelResponse hook

--- a/packages/llm/src/operate/retry/RetryExecutor.ts
+++ b/packages/llm/src/operate/retry/RetryExecutor.ts
@@ -2,7 +2,7 @@ import { sleep } from "@jaypie/kit";
 import { BadGatewayError } from "@jaypie/errors";
 
 import { getLogger } from "../../util/index.js";
-import { isTransientNetworkError } from "./isTransientNetworkError.js";
+import { createStaleRejectionGuard } from "./createStaleRejectionGuard.js";
 import {
   HookRunner,
   hookRunner as defaultHookRunner,
@@ -75,28 +75,11 @@ export class RetryExecutor {
     const log = getLogger();
     let attempt = 0;
 
-    // Persistent guard against stale socket errors (TypeError: terminated).
-    // Installed after the first abort and kept alive through subsequent attempts
-    // so that asynchronous undici socket teardown errors that fire between
-    // sleep completion and the next operation's await are caught.
-    let staleGuard: ((reason: unknown) => void) | undefined;
-
-    const installGuard = () => {
-      if (staleGuard) return;
-      staleGuard = (reason: unknown) => {
-        if (isTransientNetworkError(reason)) {
-          log.trace("Suppressed stale socket error during retry");
-        }
-      };
-      process.on("unhandledRejection", staleGuard);
-    };
-
-    const removeGuard = () => {
-      if (staleGuard) {
-        process.removeListener("unhandledRejection", staleGuard);
-        staleGuard = undefined;
-      }
-    };
+    // Guard against stale rejections firing on a subsequent microtask after
+    // the retry layer has already caught the originating error: undici socket
+    // teardown (TypeError: terminated) and twin upstream-SDK rejections
+    // (e.g. issue #336 — OpenRouter SyntaxError siblings).
+    const guard = createStaleRejectionGuard();
 
     try {
       while (true) {
@@ -111,13 +94,10 @@ export class RetryExecutor {
 
           return result;
         } catch (error: unknown) {
-          // Abort the previous request to kill lingering socket callbacks
           controller.abort("retry");
 
-          // Install the guard immediately after abort — stale socket errors
-          // can fire on any subsequent microtask boundary (during hook calls,
-          // sleep, or the next operation attempt)
-          installGuard();
+          guard.recordCaught(error);
+          guard.install();
 
           // Check if we've exhausted retries
           if (!this.policy.shouldRetry(attempt)) {
@@ -176,7 +156,7 @@ export class RetryExecutor {
         }
       }
     } finally {
-      removeGuard();
+      guard.remove();
     }
   }
 }

--- a/packages/llm/src/operate/retry/__tests__/RetryExecutor.spec.ts
+++ b/packages/llm/src/operate/retry/__tests__/RetryExecutor.spec.ts
@@ -398,6 +398,36 @@ describe("RetryExecutor", () => {
       expect(result).toBe("success");
     });
 
+    it("suppresses sibling rejection of the just-caught error (issue #336)", async () => {
+      // Mirror the OpenRouter scenario: caught error is a SyntaxError, and
+      // the SDK fires a twin rejection of the same shape on a later microtask.
+      const looseExecutor = new RetryExecutor({
+        errorClassifier: {
+          isRetryable: () => true,
+          isKnownError: () => true,
+        },
+        policy: new RetryPolicy({ maxRetries: 3 }),
+      });
+
+      const caught = new SyntaxError("Unexpected end of JSON input");
+      const sibling = new SyntaxError("Unexpected end of JSON input");
+      const siblingPromise = Promise.reject(sibling);
+      siblingPromise.catch(() => {});
+
+      const operation = vi
+        .fn()
+        .mockImplementationOnce(() => Promise.reject(caught))
+        .mockImplementationOnce(() => {
+          process.emit("unhandledRejection", sibling, siblingPromise);
+          return Promise.resolve("success");
+        });
+
+      const result = await looseExecutor.execute(operation, {
+        context: mockContext,
+      });
+      expect(result).toBe("success");
+    });
+
     it("cleans up guard after execute completes successfully", async () => {
       const removeSpy = vi.spyOn(process, "removeListener");
 

--- a/packages/llm/src/operate/retry/__tests__/createStaleRejectionGuard.spec.ts
+++ b/packages/llm/src/operate/retry/__tests__/createStaleRejectionGuard.spec.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createStaleRejectionGuard } from "../createStaleRejectionGuard.js";
+
+const traceMock = vi.fn();
+
+vi.mock("../../../util/index.js", () => ({
+  getLogger: () => ({
+    debug: vi.fn(),
+    error: vi.fn(),
+    trace: traceMock,
+    var: vi.fn(),
+    warn: vi.fn(),
+  }),
+}));
+
+describe("createStaleRejectionGuard", () => {
+  beforeEach(() => {
+    traceMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("Base Cases", () => {
+    it("is a function", () => {
+      expect(typeof createStaleRejectionGuard).toBe("function");
+    });
+
+    it("returns install/remove/recordCaught controls", () => {
+      const guard = createStaleRejectionGuard();
+      expect(typeof guard.install).toBe("function");
+      expect(typeof guard.remove).toBe("function");
+      expect(typeof guard.recordCaught).toBe("function");
+    });
+  });
+
+  describe("install / remove", () => {
+    it("registers a single listener even if install called twice", () => {
+      const onSpy = vi.spyOn(process, "on");
+      const guard = createStaleRejectionGuard();
+      guard.install();
+      guard.install();
+
+      const calls = onSpy.mock.calls.filter(
+        (c) => c[0] === "unhandledRejection",
+      );
+      expect(calls.length).toBe(1);
+
+      guard.remove();
+      onSpy.mockRestore();
+    });
+
+    it("removes the listener it installed", () => {
+      const removeSpy = vi.spyOn(process, "removeListener");
+      const guard = createStaleRejectionGuard();
+      guard.install();
+      guard.remove();
+
+      const calls = removeSpy.mock.calls.filter(
+        (c) => c[0] === "unhandledRejection",
+      );
+      expect(calls.length).toBe(1);
+      removeSpy.mockRestore();
+    });
+  });
+
+  describe("Suppression", () => {
+    it("suppresses transient socket errors (e.g. TypeError: terminated)", () => {
+      const guard = createStaleRejectionGuard();
+      guard.install();
+
+      const terminated = new TypeError("terminated");
+      const rejected = Promise.reject(terminated);
+      rejected.catch(() => {});
+
+      process.emit("unhandledRejection", terminated, rejected);
+
+      expect(traceMock).toHaveBeenCalledWith(
+        "Suppressed stale socket error during retry",
+      );
+      guard.remove();
+    });
+
+    it("suppresses sibling rejection that is the same error instance (issue #336)", () => {
+      const guard = createStaleRejectionGuard();
+      guard.install();
+
+      const upstream = new SyntaxError("Unexpected end of JSON input");
+      guard.recordCaught(upstream);
+
+      const rejected = Promise.reject(upstream);
+      rejected.catch(() => {});
+      process.emit("unhandledRejection", upstream, rejected);
+
+      expect(traceMock).toHaveBeenCalledWith(
+        "Suppressed sibling rejection of already-handled error",
+      );
+      guard.remove();
+    });
+
+    it("suppresses sibling rejection that is a fresh Error with matching name+message (issue #336)", () => {
+      const guard = createStaleRejectionGuard();
+      guard.install();
+
+      const upstream = new SyntaxError("Unexpected end of JSON input");
+      guard.recordCaught(upstream);
+
+      const sibling = new SyntaxError("Unexpected end of JSON input");
+      const rejected = Promise.reject(sibling);
+      rejected.catch(() => {});
+      process.emit("unhandledRejection", sibling, rejected);
+
+      expect(traceMock).toHaveBeenCalledWith(
+        "Suppressed sibling rejection of already-handled error",
+      );
+      guard.remove();
+    });
+
+    it("does not suppress unrelated rejections", () => {
+      const guard = createStaleRejectionGuard();
+      guard.install();
+
+      const upstream = new SyntaxError("Unexpected end of JSON input");
+      guard.recordCaught(upstream);
+
+      const unrelated = new Error("totally unrelated");
+      const rejected = Promise.reject(unrelated);
+      rejected.catch(() => {});
+      process.emit("unhandledRejection", unrelated, rejected);
+
+      expect(traceMock).not.toHaveBeenCalled();
+      guard.remove();
+    });
+
+    it("forgets recorded errors after remove()", () => {
+      const guard = createStaleRejectionGuard();
+      guard.install();
+
+      const upstream = new SyntaxError("Unexpected end of JSON input");
+      guard.recordCaught(upstream);
+      guard.remove();
+
+      guard.install();
+      const rejected = Promise.reject(upstream);
+      rejected.catch(() => {});
+      process.emit("unhandledRejection", upstream, rejected);
+
+      expect(traceMock).not.toHaveBeenCalled();
+      guard.remove();
+    });
+  });
+});

--- a/packages/llm/src/operate/retry/createStaleRejectionGuard.ts
+++ b/packages/llm/src/operate/retry/createStaleRejectionGuard.ts
@@ -1,0 +1,96 @@
+import { getLogger } from "../../util/index.js";
+import { isTransientNetworkError } from "./isTransientNetworkError.js";
+
+//
+//
+// Types
+//
+
+export interface StaleRejectionGuard {
+  /** Install the unhandledRejection listener (idempotent) */
+  install(): void;
+  /** Remove the listener and forget recorded errors */
+  remove(): void;
+  /** Record an error the retry loop has caught and is handling */
+  recordCaught(error: unknown): void;
+}
+
+//
+//
+// Helpers
+//
+
+/**
+ * Compare an unhandled rejection reason against errors the retry loop has
+ * already caught. Reference equality first, then fall back to message + name
+ * — providers sometimes surface twin rejections as fresh Error instances
+ * rebuilt from the same upstream failure.
+ */
+function matchesCaughtError(
+  reason: unknown,
+  caught: ReadonlySet<unknown>,
+): boolean {
+  if (caught.has(reason)) return true;
+  if (!(reason instanceof Error)) return false;
+  for (const handled of caught) {
+    if (
+      handled instanceof Error &&
+      handled.name === reason.name &&
+      handled.message === reason.message
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+//
+//
+// Main
+//
+
+/**
+ * Create a guard that suppresses unhandled rejections firing as siblings of
+ * an error the retry loop has already caught. Provider SDKs occasionally
+ * surface a single upstream failure as twin rejections — the retry layer
+ * accepts responsibility for the first; this guard prevents the second from
+ * crashing the host while the retry is in flight.
+ *
+ * The guard also continues to suppress transient socket teardown errors
+ * (e.g. undici `TypeError: terminated`) emitted between attempts.
+ */
+export function createStaleRejectionGuard(): StaleRejectionGuard {
+  const log = getLogger();
+  const caughtErrors = new Set<unknown>();
+  let listener:
+    | ((reason: unknown, promise: Promise<unknown>) => void)
+    | undefined;
+
+  return {
+    install() {
+      if (listener) return;
+      listener = (reason, promise) => {
+        if (isTransientNetworkError(reason)) {
+          promise?.catch?.(() => {});
+          log.trace("Suppressed stale socket error during retry");
+          return;
+        }
+        if (matchesCaughtError(reason, caughtErrors)) {
+          promise?.catch?.(() => {});
+          log.trace("Suppressed sibling rejection of already-handled error");
+        }
+      };
+      process.on("unhandledRejection", listener);
+    },
+    remove() {
+      if (listener) {
+        process.removeListener("unhandledRejection", listener);
+        listener = undefined;
+      }
+      caughtErrors.clear();
+    },
+    recordCaught(error) {
+      caughtErrors.add(error);
+    },
+  };
+}

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.57",
+  "version": "0.8.58",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/constructs/1.2.55.md
+++ b/packages/mcp/release-notes/constructs/1.2.55.md
@@ -1,0 +1,20 @@
+---
+version: 1.2.55
+date: 2026-05-10
+summary: JaypieMigration accepts a timeout prop and defaults to 15 minutes (issue #341)
+---
+
+## Changes
+
+- `JaypieMigrationProps` accepts an optional `timeout?: cdk.Duration` that is forwarded to the inner `JaypieLambda`.
+- The default migration Lambda timeout is now **15 minutes** (Lambda's maximum), up from 5 minutes.
+
+## Motivation
+
+Real-world DynamoDB migrations the construct exists to support routinely exceed five minutes: first-time GSI creation on small tables commonly takes 3–10 minutes to reach `ACTIVE`, and a backfill that scans and rewrites entities after the GSI is ready adds more. With the previous 5-minute hard cap, migrations had no way to poll long enough to see a healthy GSI finish — they timed out and CloudFormation rolled back even when the underlying operation would have completed.
+
+Fifteen minutes is the realistic ceiling for a synchronous custom resource backed by a Lambda. Anything that legitimately needs more should run as an `isCompleteHandler` (a separate enhancement).
+
+## Migration
+
+No action required. Callers that previously relied on the 5-minute default will continue to complete well under 15 minutes; raising the ceiling does not change happy-path behavior. Callers that want to keep the old 5-minute cap can pass `timeout: Duration.minutes(5)` explicitly.

--- a/packages/mcp/release-notes/constructs/1.2.55.md
+++ b/packages/mcp/release-notes/constructs/1.2.55.md
@@ -1,20 +1,45 @@
 ---
 version: 1.2.55
 date: 2026-05-10
-summary: JaypieMigration accepts a timeout prop and defaults to 15 minutes (issue #341)
+summary: JaypieMigration `timeout` prop default 15m (#341); JaypieDistribution `waf.allow` path-scoped relaxations (#342)
 ---
 
 ## Changes
 
+### `JaypieMigration` — `timeout` prop, default 15 minutes (#341)
+
 - `JaypieMigrationProps` accepts an optional `timeout?: cdk.Duration` that is forwarded to the inner `JaypieLambda`.
 - The default migration Lambda timeout is now **15 minutes** (Lambda's maximum), up from 5 minutes.
 
+### `JaypieDistribution` — `waf.allow` (#342)
+
+- New `waf.allow` field accepts an entry (or array of entries) shaped `{ path, AWSManagedRulesCommonRuleSet: [...], AWSManagedRulesKnownBadInputsRuleSet: [...], ... }`. Each entry flips the named sub-rules from `block` to `count` **only** on requests matching its path set; strict default action is preserved everywhere else.
+- `path` accepts a string or string[]. Trailing `*` becomes WAFv2 `STARTS_WITH`; no trailing `*` becomes `EXACTLY`. Multiple paths in one entry are OR'd.
+- Each managed-rule-group key accepts a string or string[] of sub-rule names.
+- `waf.allow` composes with `waf.managedRuleOverrides`: the baseline override list applies to both the relaxed and strict emissions of a group; `allow` further relaxes specific (path × sub-rule) intersections. Groups not named in `allow` keep their existing single-rule emission.
+
+```ts
+waf: {
+  allow: [
+    {
+      path: "/hooks/*",
+      AWSManagedRulesCommonRuleSet: ["ExploitablePaths_URIPATH"],
+      AWSManagedRulesKnownBadInputsRuleSet: ["CrossSiteScripting_BODY"],
+    },
+  ],
+}
+```
+
 ## Motivation
 
-Real-world DynamoDB migrations the construct exists to support routinely exceed five minutes: first-time GSI creation on small tables commonly takes 3–10 minutes to reach `ACTIVE`, and a backfill that scans and rewrites entities after the GSI is ready adds more. With the previous 5-minute hard cap, migrations had no way to poll long enough to see a healthy GSI finish — they timed out and CloudFormation rolled back even when the underlying operation would have completed.
+### `JaypieMigration` timeout
 
-Fifteen minutes is the realistic ceiling for a synchronous custom resource backed by a Lambda. Anything that legitimately needs more should run as an `isCompleteHandler` (a separate enhancement).
+Real-world DynamoDB migrations the construct exists to support routinely exceed five minutes: first-time GSI creation commonly takes 3–10 minutes to reach `ACTIVE`, and a backfill that scans and rewrites entities after the GSI is ready adds more. The previous 5-minute hard cap left no headroom; CloudFormation rolled back even when the underlying operation would have completed.
+
+### `waf.allow`
+
+Webhook ingress paths (Datadog, GitHub, Slack, Jira) legitimately trip body- and URI-inspection rules in `AWSManagedRulesCommonRuleSet` / `AWSManagedRulesKnownBadInputsRuleSet`, while the rest of the API should keep full blocking. The previous escape hatch — distribution-wide `managedRuleOverrides` — weakened protection on every path on the host. `waf.allow` confines the relaxation to the listed paths.
 
 ## Migration
 
-No action required. Callers that previously relied on the 5-minute default will continue to complete well under 15 minutes; raising the ceiling does not change happy-path behavior. Callers that want to keep the old 5-minute cap can pass `timeout: Duration.minutes(5)` explicitly.
+No action required. `JaypieMigration` callers that previously relied on the 5-minute default still complete in well under 15 minutes; callers that want to keep 5 minutes can pass `timeout: Duration.minutes(5)` explicitly. `waf.allow` is opt-in — distributions that don't pass it keep their previous WebACL exactly.

--- a/packages/mcp/release-notes/jaypie/1.2.47.md
+++ b/packages/mcp/release-notes/jaypie/1.2.47.md
@@ -1,0 +1,9 @@
+---
+version: 1.2.47
+date: 2026-05-10
+summary: Bump @jaypie/llm to 1.2.34 for retry-executor sibling-rejection fix (issue #336)
+---
+
+## Changes
+
+- Bumps the `@jaypie/llm` peer dependency to `^1.2.34` so the retry executor no longer crashes the host when an upstream SDK surfaces twin rejections of an already-handled error.

--- a/packages/mcp/release-notes/llm/1.2.34.md
+++ b/packages/mcp/release-notes/llm/1.2.34.md
@@ -1,0 +1,18 @@
+---
+version: 1.2.34
+date: 2026-05-10
+summary: Retry executor swallows sibling rejections of already-handled upstream errors (issue #336)
+---
+
+## Changes
+
+- New shared `createStaleRejectionGuard` helper records errors that the retry layer has caught and recognizes sibling unhandled rejections by reference *or* by `name + message`. When a sibling fires, the guard attaches a `.catch()` to the dangling promise so it is no longer treated as unhandled.
+- `RetryExecutor` and `StreamLoop` both consume the shared guard. Transient socket teardown errors (`TypeError: terminated`, `ECONNRESET`, etc.) continue to be suppressed exactly as before.
+
+## Motivation
+
+Provider SDKs occasionally surface a single upstream failure as twin promise rejections. The retry layer catches and handles the first; the second arrives on a later microtask and escaped the previous guard because that guard only matched a fixed set of transient-network patterns. A real example: OpenRouter's `matchers.js` does `JSON.parse("")` and throws `SyntaxError: Unexpected end of JSON input`. The retry executor caught it and was sleeping before the next attempt when the sibling rejection killed the host process — many hours into a long evaluation run.
+
+## Migration
+
+No action required. The new guard is strictly more permissive than the old one — it swallows the same transient-network rejections plus any rejection whose error matches one the retry loop has already caught. Unrelated rejections are unaffected.

--- a/packages/mcp/release-notes/mcp/0.8.58.md
+++ b/packages/mcp/release-notes/mcp/0.8.58.md
@@ -6,4 +6,4 @@ summary: Release notes for @jaypie/constructs 1.2.55 and @jaypie/llm 1.2.34
 
 ## Changes
 
-- Adds release notes for `@jaypie/constructs` 1.2.55 (`JaypieMigration` `timeout` prop, default 15 minutes — issue #341) and `@jaypie/llm` 1.2.34 (retry executor swallows sibling rejections — issue #336), plus the corresponding `jaypie` 1.2.47 dependency bump.
+- Adds release notes for `@jaypie/constructs` 1.2.55 (`JaypieMigration` `timeout` prop default 15 minutes — issue #341; `JaypieDistribution` `waf.allow` path-scoped relaxations — issue #342) and `@jaypie/llm` 1.2.34 (retry executor swallows sibling rejections — issue #336), plus the corresponding `jaypie` 1.2.47 dependency bump.

--- a/packages/mcp/release-notes/mcp/0.8.58.md
+++ b/packages/mcp/release-notes/mcp/0.8.58.md
@@ -1,0 +1,9 @@
+---
+version: 0.8.58
+date: 2026-05-10
+summary: Release notes for @jaypie/constructs 1.2.55 and @jaypie/llm 1.2.34
+---
+
+## Changes
+
+- Adds release notes for `@jaypie/constructs` 1.2.55 (`JaypieMigration` `timeout` prop, default 15 minutes — issue #341) and `@jaypie/llm` 1.2.34 (retry executor swallows sibling rejections — issue #336), plus the corresponding `jaypie` 1.2.47 dependency bump.


### PR DESCRIPTION
## Summary

Three issues bundled into one release.

### `@jaypie/constructs` 1.2.55

- **#341** — `JaypieMigration` accepts a `timeout` prop and defaults to **15 minutes** (Lambda max). The previous 5-minute hard cap left no headroom for first-time GSI creation + backfill, even when the underlying operation would have completed.
- **#342** — `JaypieDistribution` gains `waf.allow`, a top-level field that flips named sub-rules of managed rule groups from `block` to `count` only on listed paths. For each referenced group, the construct emits one relaxed rule per `allow` entry plus one strict rule whose scope-down is `NOT` of the union of every relaxed path. Composes with `managedRuleOverrides`. Use case: webhook ingress at `/hooks/*` that legitimately trips body/URI inspection while the rest of the API keeps full blocking.

### `@jaypie/llm` 1.2.34

- **#336** — Retry executor swallows sibling rejections of an already-handled error. New shared `createStaleRejectionGuard` records each caught error and recognizes sibling rejections by reference or `name + message`, attaching a `.catch()` to the dangling promise so it is no longer unhandled. Wired into both `RetryExecutor` and `StreamLoop`. Continues to suppress transient socket teardown.

### Coordinated version bumps

- `@jaypie/constructs` 1.2.54 → 1.2.55
- `@jaypie/llm` 1.2.33 → 1.2.34
- `jaypie` 1.2.46 → 1.2.47 (peer `@jaypie/llm` range)
- `@jaypie/mcp` 0.8.57 → 0.8.58 (release notes added)

## Test plan

- [x] `npm test -w packages/constructs` — 536/536
- [x] `npm test -w packages/llm` — 816/816
- [x] `npm test -w packages/mcp` — 41/41
- [x] `npm test -w packages/jaypie` — 6/6
- [x] `npm run typecheck` / `npm run build` clean on every touched package
- [x] NPM Check workflow green on the branch
- [ ] NPM Deploy publishes 1.2.55 / 1.2.34 / 1.2.47 / 0.8.58 cleanly on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)