### PR TITLE
fix(llm): downgrade tool-throw log level from error to warn (#344)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28389,7 +28389,7 @@
     },
     "packages/constructs": {
       "name": "@jaypie/constructs",
-      "version": "1.2.55",
+      "version": "1.2.56",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*",
@@ -29315,7 +29315,7 @@
     },
     "packages/lambda": {
       "name": "@jaypie/lambda",
-      "version": "1.2.6",
+      "version": "1.2.7",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-typescript": "^12.1.2",
@@ -29471,7 +29471,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.58",
+      "version": "0.8.59",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29239,7 +29239,7 @@
         "typescript-eslint": "^8.46.1"
       },
       "peerDependencies": {
-        "@jaypie/llm": "^1.2.34",
+        "@jaypie/llm": "^1.2.35",
         "@jaypie/mongoose": "^1.2.2"
       },
       "peerDependenciesMeta": {
@@ -29348,7 +29348,7 @@
     },
     "packages/llm": {
       "name": "@jaypie/llm",
-      "version": "1.2.34",
+      "version": "1.2.35",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "*",

--- a/packages/constructs/package.json
+++ b/packages/constructs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/constructs",
-  "version": "1.2.55",
+  "version": "1.2.56",
   "description": "CDK constructs for Jaypie applications",
   "repository": {
     "type": "git",

--- a/packages/constructs/src/JaypieEnvSecret.ts
+++ b/packages/constructs/src/JaypieEnvSecret.ts
@@ -44,14 +44,18 @@ function cleanName(name: string): string {
   return name.replace(/[^a-zA-Z0-9:-]/g, "");
 }
 
-function exportEnvName(name: string, env = process.env): string {
+function exportEnvName(
+  name: string,
+  env = process.env,
+  consumer = false,
+): string {
   let rawName;
   if (checkEnvIsProvider(env)) {
     rawName = `env-${env.PROJECT_ENV}-${env.PROJECT_KEY}-${name}`;
     // Clean the entire name to only allow alphanumeric, colons, and hyphens
     return cleanName(rawName);
   } else {
-    if (checkEnvIsConsumer(env)) {
+    if (consumer || checkEnvIsConsumer(env)) {
       rawName = `env-${CDK.ENV.SANDBOX}-${env.PROJECT_KEY}-${name}`;
     } else {
       rawName = `env-${env.PROJECT_ENV}-${env.PROJECT_KEY}-${name}`;
@@ -116,7 +120,7 @@ export class JaypieEnvSecret extends Construct implements ISecret {
     let exportName;
 
     if (!exportParam) {
-      exportName = exportEnvName(id);
+      exportName = exportEnvName(envKey || id, process.env, consumer);
     } else {
       exportName = cleanName(exportParam);
     }

--- a/packages/constructs/src/JaypieMigration.ts
+++ b/packages/constructs/src/JaypieMigration.ts
@@ -26,12 +26,16 @@ export interface JaypieMigrationProps {
   environment?: Record<string, string> | (Record<string, string> | string)[];
   /** Lambda handler entry point */
   handler?: string;
+  /** Polling interval between isCompleteHandler invocations. Default: 60 seconds. */
+  queryInterval?: cdk.Duration;
   /** Secrets to make available to the migration Lambda */
   secrets?: SecretsArrayItem[];
   /** DynamoDB tables to grant read/write access */
   tables?: dynamodb.ITable[];
-  /** Lambda timeout. Defaults to 15 minutes (Lambda max). */
+  /** Lambda timeout per invocation. Defaults to 15 minutes (Lambda max). */
   timeout?: cdk.Duration;
+  /** Maximum total wall time across all isCompleteHandler invocations. Default: 2 hours. */
+  totalTimeout?: cdk.Duration;
 }
 
 export class JaypieMigration extends Construct {
@@ -45,9 +49,11 @@ export class JaypieMigration extends Construct {
       dependencies = [],
       environment,
       handler = "index.handler",
+      queryInterval = cdk.Duration.seconds(60),
       secrets = [],
       tables = [],
       timeout = cdk.Duration.minutes(15),
+      totalTimeout = cdk.Duration.hours(2),
     } = props;
 
     this.lambda = new JaypieLambda(this, "MigrationLambda", {
@@ -76,9 +82,14 @@ export class JaypieMigration extends Construct {
       );
     }
 
-    // Custom Resource provider wrapping the Lambda
+    // cr.Provider with isCompleteHandler enables the waiter pattern: onEventHandler
+    // returns PhysicalResourceId immediately; isCompleteHandler is polled via Step
+    // Functions until migrationHandler returns pending: false (or omits pending).
     const provider = new cr.Provider(this, "MigrationProvider", {
+      isCompleteHandler: this.lambda,
       onEventHandler: this.lambda,
+      queryInterval,
+      totalTimeout,
     });
 
     // Custom Resource that triggers on every deploy.

--- a/packages/constructs/src/__tests__/JaypieEnvSecret.spec.ts
+++ b/packages/constructs/src/__tests__/JaypieEnvSecret.spec.ts
@@ -1,5 +1,5 @@
 import { ConfigurationError } from "@jaypie/errors";
-import { expect, it, describe } from "vitest";
+import { expect, it, describe, afterEach } from "vitest";
 import { RemovalPolicy, Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
 import { JaypieEnvSecret } from "../JaypieEnvSecret.js";
@@ -161,6 +161,71 @@ describe("JaypieSecret", () => {
         DeletionPolicy: "Retain",
         UpdateReplacePolicy: "Retain",
       });
+    });
+  });
+
+  describe("Issue #347: Cross-stack export name regression", () => {
+    const originalEnv = { ...process.env };
+
+    afterEach(() => {
+      process.env = { ...originalEnv };
+    });
+
+    it("provider shorthand export name uses key, not prefixed construct id", () => {
+      process.env.MY_SECRET = "my-value";
+      process.env.PROJECT_ENV = CDK.ENV.SANDBOX;
+      process.env.PROJECT_KEY = "testproject";
+
+      const stack = new Stack();
+      new JaypieEnvSecret(stack, "MY_SECRET");
+      const template = Template.fromStack(stack);
+
+      const outputs = template.findOutputs("*");
+      const exportNames = Object.values(outputs)
+        .filter((o: any) => o.Export?.Name)
+        .map((o: any) => o.Export.Name);
+
+      expect(exportNames.length).toBe(1);
+      expect(exportNames[0]).toBe("env-sandbox-testproject-MYSECRET");
+    });
+
+    it("consumer:true export name uses sandbox format without relying on PROJECT_ENV=personal", () => {
+      process.env.MY_SECRET = "my-value";
+      process.env.PROJECT_KEY = "testproject";
+      delete process.env.PROJECT_ENV;
+
+      const stack = new Stack();
+      new JaypieEnvSecret(stack, "MY_SECRET", { consumer: true });
+      const template = Template.fromStack(stack);
+
+      const templateStr = JSON.stringify(template.toJSON());
+      expect(templateStr).toContain("env-sandbox-testproject-MYSECRET");
+      expect(templateStr).not.toContain("undefined");
+    });
+
+    it("provider and consumer produce matching export names", () => {
+      process.env.MY_SECRET = "my-value";
+      process.env.PROJECT_KEY = "testproject";
+
+      const providerStack = new Stack();
+      process.env.PROJECT_ENV = CDK.ENV.SANDBOX;
+      new JaypieEnvSecret(providerStack, "MY_SECRET");
+      const providerTemplate = Template.fromStack(providerStack);
+
+      const outputs = providerTemplate.findOutputs("*");
+      const exportNames = Object.values(outputs)
+        .filter((o: any) => o.Export?.Name)
+        .map((o: any) => o.Export.Name as string);
+      expect(exportNames.length).toBe(1);
+      const providerExportName = exportNames[0];
+
+      const consumerStack = new Stack();
+      delete process.env.PROJECT_ENV;
+      new JaypieEnvSecret(consumerStack, "MY_SECRET", { consumer: true });
+      const consumerTemplate = Template.fromStack(consumerStack);
+
+      const consumerStr = JSON.stringify(consumerTemplate.toJSON());
+      expect(consumerStr).toContain(providerExportName);
     });
   });
 

--- a/packages/constructs/src/__tests__/JaypieMigration.spec.ts
+++ b/packages/constructs/src/__tests__/JaypieMigration.spec.ts
@@ -155,6 +155,38 @@ describe("JaypieMigration", () => {
       expect(migrationLambda?.Properties?.Timeout).toBe(900);
     });
 
+    it("provisions Step Functions state machine for waiter pattern (issue #346)", () => {
+      const stack = new Stack();
+      new JaypieMigration(stack, "TestMigration", {
+        code: lambda.Code.fromInline("exports.handler = () => {}"),
+        handler: "index.handler",
+      });
+      const template = Template.fromStack(stack);
+      template.hasResource("AWS::StepFunctions::StateMachine", {});
+    });
+
+    it("accepts queryInterval prop (issue #346)", () => {
+      const stack = new Stack();
+      expect(() => {
+        new JaypieMigration(stack, "TestMigration", {
+          code: lambda.Code.fromInline("exports.handler = () => {}"),
+          handler: "index.handler",
+          queryInterval: Duration.seconds(30),
+        });
+      }).not.toThrow();
+    });
+
+    it("accepts totalTimeout prop (issue #346)", () => {
+      const stack = new Stack();
+      expect(() => {
+        new JaypieMigration(stack, "TestMigration", {
+          code: lambda.Code.fromInline("exports.handler = () => {}"),
+          handler: "index.handler",
+          totalTimeout: Duration.hours(4),
+        });
+      }).not.toThrow();
+    });
+
     it("accepts a custom timeout (issue #341)", () => {
       const stack = new Stack();
       new JaypieMigration(stack, "TestMigration", {

--- a/packages/jaypie/package.json
+++ b/packages/jaypie/package.json
@@ -54,7 +54,7 @@
     "typescript-eslint": "^8.46.1"
   },
   "peerDependencies": {
-    "@jaypie/llm": "^1.2.34",
+    "@jaypie/llm": "^1.2.35",
     "@jaypie/mongoose": "^1.2.2"
   },
   "peerDependenciesMeta": {

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/lambda",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"

--- a/packages/lambda/src/__tests__/migrationHandler.spec.ts
+++ b/packages/lambda/src/__tests__/migrationHandler.spec.ts
@@ -29,35 +29,74 @@ describe("migrationHandler", () => {
   });
 
   describe("Behavior", () => {
-    it("Returns the handler result on success", async () => {
-      const handler = migrationHandler(async () => ({ status: "complete" }));
-      const result = await handler({}, {});
-      expect(result).toEqual({ status: "complete" });
-    });
-
-    it("Re-throws unhandled errors so CFN sees a failed custom resource", async () => {
-      const handler = migrationHandler(async () => {
-        throw new Error("AccessDeniedException: dynamodb:DescribeTable");
+    describe("onEventHandler mode (event without Data)", () => {
+      it("Returns PhysicalResourceId immediately without calling the user handler", async () => {
+        const userHandler = vi.fn().mockResolvedValue({ status: "complete" });
+        const handler = migrationHandler(userHandler);
+        const result = await handler({}, {});
+        expect(userHandler).not.toHaveBeenCalled();
+        expect(result).toMatchObject({ PhysicalResourceId: expect.any(String) });
       });
-      await expect(handler({}, {})).rejects.toThrow();
+
+      it("Preserves PhysicalResourceId from event for Update and Delete requests", async () => {
+        const handler = migrationHandler(async () => ({ status: "complete" }));
+        const result = await handler(
+          { RequestType: "Update", PhysicalResourceId: "my-migration-123" },
+          {},
+        );
+        expect(result).toMatchObject({ PhysicalResourceId: "my-migration-123" });
+      });
     });
 
-    it("Allows opting out of throwing by passing throw: false", async () => {
-      const handler = migrationHandler(
-        async () => {
-          throw new Error("boom");
-        },
-        { throw: false },
-      );
-      const result = await handler({}, {});
-      expect(result).toBeDefined();
-    });
+    describe("isCompleteHandler mode (event with Data)", () => {
+      it("Runs the user handler and returns IsComplete: true when no pending flag", async () => {
+        const handler = migrationHandler(async () => ({ status: "complete" }));
+        const result = await handler({ Data: {} }, {});
+        expect(result).toMatchObject({ IsComplete: true });
+      });
 
-    it("Accepts options-first parameter order", async () => {
-      const handler = migrationHandler({ name: "test" }, async () => ({
-        ok: true,
-      }));
-      await expect(handler({}, {})).resolves.toEqual({ ok: true });
+      it("Returns IsComplete: false when handler returns pending: true", async () => {
+        const handler = migrationHandler(
+          async () => ({ status: "in-progress", pending: true }),
+        );
+        const result = await handler({ Data: {} }, {});
+        expect(result).toMatchObject({ IsComplete: false });
+      });
+
+      it("Returns IsComplete: true when handler returns pending: false", async () => {
+        const handler = migrationHandler(
+          async () => ({ status: "complete", pending: false }),
+        );
+        const result = await handler({ Data: {} }, {});
+        expect(result).toMatchObject({ IsComplete: true });
+      });
+
+      it("Re-throws unhandled errors so CFN sees a failed custom resource", async () => {
+        const handler = migrationHandler(async () => {
+          throw new Error("AccessDeniedException: dynamodb:DescribeTable");
+        });
+        await expect(handler({ Data: {} }, {})).rejects.toThrow();
+      });
+
+      it("Allows opting out of throwing by passing throw: false", async () => {
+        const handler = migrationHandler(
+          async () => {
+            throw new Error("boom");
+          },
+          { throw: false },
+        );
+        const result = await handler({ Data: {} }, {});
+        expect(result).toBeDefined();
+      });
+
+      it("Accepts options-first parameter order", async () => {
+        const handler = migrationHandler({ name: "test" }, async () => ({
+          ok: true,
+        }));
+        await expect(handler({ Data: {} }, {})).resolves.toMatchObject({
+          IsComplete: true,
+        });
+      });
     });
   });
 });

--- a/packages/lambda/src/migrationHandler.ts
+++ b/packages/lambda/src/migrationHandler.ts
@@ -1,14 +1,28 @@
 import lambdaHandler, {
+  LambdaContext,
   LambdaHandlerFunction,
   LambdaHandlerOptions,
 } from "./lambdaHandler.js";
 
+type MigrationResult<T = unknown> = T & { pending?: boolean };
+
 // Defaults to throw: true so a failed migration fails the CFN custom resource
 // (and therefore the deploy) instead of being swallowed and reported COMPLETE.
+//
+// When cr.Provider uses the same Lambda for both onEventHandler and isCompleteHandler,
+// the event shape differs: isCompleteHandler receives a top-level Data field (from
+// onEventHandler's response); onEventHandler does not. We use this to branch:
+//
+// - onEventHandler mode: return PhysicalResourceId immediately (migration runs later).
+// - isCompleteHandler mode: run migration; map pending → IsComplete for CFN waiter.
 const migrationHandler = function <TEvent = unknown, TResult = unknown>(
-  handler: LambdaHandlerFunction<TEvent, TResult> | LambdaHandlerOptions,
-  options: LambdaHandlerOptions | LambdaHandlerFunction<TEvent, TResult> = {},
-): LambdaHandlerFunction<TEvent, TResult> {
+  handler:
+    | LambdaHandlerFunction<TEvent, MigrationResult<TResult>>
+    | LambdaHandlerOptions,
+  options:
+    | LambdaHandlerOptions
+    | LambdaHandlerFunction<TEvent, MigrationResult<TResult>> = {},
+): LambdaHandlerFunction<TEvent, unknown> {
   if (typeof handler === "object" && typeof options === "function") {
     const temp = handler;
     handler = options;
@@ -16,10 +30,35 @@ const migrationHandler = function <TEvent = unknown, TResult = unknown>(
   }
 
   const opts = options as LambdaHandlerOptions;
-  return lambdaHandler<TEvent, TResult>(
-    handler as LambdaHandlerFunction<TEvent, TResult>,
+  const innerHandler = lambdaHandler<TEvent, MigrationResult<TResult>>(
+    handler as LambdaHandlerFunction<TEvent, MigrationResult<TResult>>,
     { throw: true, ...opts },
   );
+
+  return async (
+    event: TEvent = {} as TEvent,
+    context: LambdaContext = {},
+  ): Promise<unknown> => {
+    const cfnEvent = event as Record<string, unknown>;
+
+    // isCompleteHandler: CDK cr.Provider passes the Data from onEventHandler in event.
+    // Run the migration and map the pending flag to CFN's IsComplete protocol.
+    if (cfnEvent !== null && typeof cfnEvent === "object" && "Data" in cfnEvent) {
+      const result = await innerHandler(event, context);
+      const pending =
+        result !== null &&
+        typeof result === "object" &&
+        Boolean((result as MigrationResult<unknown>).pending);
+      return { Data: result, IsComplete: !pending };
+    }
+
+    // onEventHandler: return PhysicalResourceId immediately; the migration runs
+    // in subsequent isCompleteHandler invocations via the Step Functions waiter.
+    return {
+      PhysicalResourceId:
+        (cfnEvent?.PhysicalResourceId as string | undefined) ?? "migration",
+    };
+  };
 };
 
 export default migrationHandler;

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/llm",
-  "version": "1.2.34",
+  "version": "1.2.35",
   "description": "Large language model utilities",
   "repository": {
     "type": "git",

--- a/packages/llm/src/operate/OperateLoop.ts
+++ b/packages/llm/src/operate/OperateLoop.ts
@@ -447,7 +447,7 @@ export class OperateLoop {
               toolResultFormatted as LlmInputMessage,
             );
 
-            log.error(`Error executing function call ${toolCall.name}`);
+            log.warn(`Error executing function call ${toolCall.name}`);
             log.var({ error });
 
             // Track consecutive errors and stop if threshold reached

--- a/packages/llm/src/operate/StreamLoop.ts
+++ b/packages/llm/src/operate/StreamLoop.ts
@@ -509,7 +509,7 @@ export class StreamLoop {
           name: toolCall.name,
         } as LlmToolResult & { name: string });
 
-        log.error(`Error executing function call ${toolCall.name}`);
+        log.warn(`Error executing function call ${toolCall.name}`);
         log.var({ error });
 
         // Track consecutive errors and stop if threshold reached

--- a/packages/llm/src/operate/__tests__/OperateLoop.spec.ts
+++ b/packages/llm/src/operate/__tests__/OperateLoop.spec.ts
@@ -486,6 +486,86 @@ describe("OperateLoop", () => {
 
         expect(beforeToolHook).toHaveBeenCalled();
       });
+
+      it("logs at warn level when tool throws, not error", async () => {
+        const { log: mockLog } = await import("@jaypie/logger");
+        const mockLogger = {
+          debug: vi.fn(),
+          error: vi.fn(),
+          trace: vi.fn(),
+          var: vi.fn(),
+          warn: vi.fn(),
+        };
+        (mockLog.lib as Mock).mockReturnValue(mockLogger);
+
+        let callCount = 0;
+        mockAdapter.parseResponse = vi.fn((response): ParsedResponse => {
+          callCount++;
+          if (callCount === 1) {
+            return {
+              content: undefined,
+              hasToolCalls: true,
+              stopReason: "tool_use",
+              usage: {
+                input: 10,
+                output: 20,
+                reasoning: 0,
+                total: 30,
+                provider: "mock",
+                model: "mock-model",
+              },
+              raw: response,
+            };
+          }
+          return {
+            content: "Done!",
+            hasToolCalls: false,
+            stopReason: "end_turn",
+            usage: {
+              input: 10,
+              output: 20,
+              reasoning: 0,
+              total: 30,
+              provider: "mock",
+              model: "mock-model",
+            },
+            raw: response,
+          };
+        }) as Mock;
+
+        mockAdapter.extractToolCalls = vi.fn((): StandardToolCall[] => [
+          {
+            callId: "call-123",
+            name: "test_tool",
+            arguments: "{}",
+            raw: {},
+          },
+        ]);
+
+        const toolkit = new Toolkit([
+          {
+            name: "test_tool",
+            description: "A test tool",
+            parameters: { type: "object" },
+            type: "function",
+            call: vi.fn(() => {
+              throw new Error("refused: not in allowlist");
+            }),
+          },
+        ]);
+
+        const loop = new OperateLoop({
+          adapter: mockAdapter,
+          client: mockClient,
+        });
+
+        await loop.execute("Call the tool", { tools: toolkit, turns: 3 });
+
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+          expect.stringContaining("test_tool"),
+        );
+        expect(mockLogger.error).not.toHaveBeenCalled();
+      });
     });
 
     describe("Structured Output", () => {

--- a/packages/llm/src/operate/__tests__/StreamLoop.spec.ts
+++ b/packages/llm/src/operate/__tests__/StreamLoop.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach, Mock } from "vitest";
 
 import {
   StreamLoop,
@@ -1281,6 +1281,89 @@ describe("StreamLoop", () => {
             title: "Bad Function Call",
           },
         });
+      });
+
+      it("logs at warn level when tool throws, not error", async () => {
+        const { log: mockLog } = await import("@jaypie/logger");
+        const mockLogger = {
+          debug: vi.fn(),
+          error: vi.fn(),
+          trace: vi.fn(),
+          var: vi.fn(),
+          warn: vi.fn(),
+        };
+        (mockLog.lib as Mock).mockReturnValue(mockLogger);
+
+        const toolkit = new Toolkit([
+          {
+            name: "broken_tool",
+            description: "Throws an error",
+            parameters: { type: "object" },
+            type: "function",
+            call: vi.fn(() => {
+              throw new Error("refused: not in allowlist");
+            }),
+          },
+        ]);
+
+        let callCount = 0;
+        mockAdapter.executeStreamRequest = vi.fn(
+          async function* (): AsyncIterable<LlmStreamChunk> {
+            callCount++;
+            if (callCount === 1) {
+              yield {
+                type: LlmStreamChunkType.ToolCall,
+                toolCall: {
+                  id: "call-1",
+                  name: "broken_tool",
+                  arguments: "{}",
+                },
+              };
+              yield {
+                type: LlmStreamChunkType.Done,
+                usage: [
+                  {
+                    input: 10,
+                    output: 10,
+                    reasoning: 0,
+                    total: 20,
+                    provider: "mock",
+                    model: "mock-model",
+                  },
+                ],
+              };
+            } else {
+              yield { type: LlmStreamChunkType.Text, content: "Recovered" };
+              yield {
+                type: LlmStreamChunkType.Done,
+                usage: [
+                  {
+                    input: 10,
+                    output: 10,
+                    reasoning: 0,
+                    total: 20,
+                    provider: "mock",
+                    model: "mock-model",
+                  },
+                ],
+              };
+            }
+          },
+        );
+
+        const loop = new StreamLoop({
+          adapter: mockAdapter,
+          client: mockClient,
+        });
+
+        await collectChunks(
+          loop.execute("Use broken tool", { tools: toolkit, turns: 3 }),
+        );
+
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+          expect.stringContaining("broken_tool"),
+        );
+        expect(mockLogger.error).not.toHaveBeenCalled();
       });
 
       it("passes through error chunks from adapter", async () => {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.58",
+  "version": "0.8.59",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/constructs/1.2.56.md
+++ b/packages/mcp/release-notes/constructs/1.2.56.md
@@ -1,0 +1,46 @@
+---
+version: 1.2.56
+date: 2026-05-10
+summary: JaypieMigration waiter pattern via cr.Provider isCompleteHandler (#346)
+---
+
+## Changes
+
+### `JaypieMigration` — waiter pattern with `queryInterval` and `totalTimeout` (#346)
+
+- `JaypieMigrationProps` accepts two new optional props:
+  - `queryInterval?: cdk.Duration` — polling interval between `isCompleteHandler` invocations. Default: **60 seconds**.
+  - `totalTimeout?: cdk.Duration` — maximum wall time across all invocations. Default: **2 hours**.
+- `cr.Provider` is now wired with `isCompleteHandler: this.lambda` in addition to `onEventHandler`, activating Step Functions-backed polling. Each invocation of `isCompleteHandler` lives under the per-Lambda timeout cap, but the orchestration can run for `totalTimeout` (up to 2 h by default).
+- `onEventHandler` now returns `PhysicalResourceId` immediately; the migration Lambda runs exclusively in `isCompleteHandler` invocations.
+
+```ts
+new JaypieMigration(this, "Migration", {
+  code: "dist/migration",
+  handler: "index.handler",
+  tables: [table],
+  queryInterval: Duration.seconds(60),   // optional, this is the default
+  totalTimeout: Duration.hours(2),       // optional, this is the default
+});
+```
+
+## Motivation
+
+`JaypieMigration` previously ran all migrations synchronously inside a single Lambda invocation, bounded by Lambda's 15-minute hard cap. Multi-step migrations whose cumulative wall time exceeds 15 minutes — three back-to-back GSI creations being the canonical example — would be killed mid-flight, causing CloudFormation rollback and repeated partial teardown cycles.
+
+AWS's canonical answer for this shape is `cr.Provider`'s waiter pattern: an `isCompleteHandler` Lambda is invoked repeatedly on a `queryInterval` until it returns `IsComplete: true`. Step Functions orchestrates the polling loop; each invocation is independently time-bounded by the Lambda timeout, while the total can span hours.
+
+## Migration
+
+No action required for existing single-shot migrations. `migrationHandler` maps a handler that returns no `pending` flag to `IsComplete: true`, so `cr.Provider` calls `isCompleteHandler` exactly once and the deploy completes as before. The only observable difference is an extra `onEventHandler` invocation (which returns immediately) before the migration runs.
+
+To enable multi-step migrations, return `{ pending: true }` from `migrationHandler` until all steps are complete:
+
+```typescript
+import { migrationHandler } from "jaypie";
+
+export const handler = migrationHandler(async (event) => {
+  const remaining = await runNextPendingMigration();
+  return { pending: remaining > 0 };
+});
+```

--- a/packages/mcp/release-notes/constructs/1.2.56.md
+++ b/packages/mcp/release-notes/constructs/1.2.56.md
@@ -1,10 +1,22 @@
 ---
 version: 1.2.56
 date: 2026-05-10
-summary: JaypieMigration waiter pattern via cr.Provider isCompleteHandler (#346)
+summary: JaypieMigration waiter pattern (#346); fix JaypieEnvSecret cross-stack export name regression (#347)
 ---
 
 ## Changes
+
+### `JaypieEnvSecret` — fix cross-stack export name regression (#347)
+
+Two bugs introduced by the shorthand detection feature (1.2.44+) that broke cross-stack `JaypieEnvSecret` wiring:
+
+1. **Export name drift** — when using shorthand (`new JaypieEnvSecret(scope, "SECRET_KEY")`), the CDK construct id was prefixed to `EnvSecret_SECRET_KEY`, causing the auto-generated `Export.Name` to change from `env-<env>-<project>-SECRETKEY` to `env-<env>-<project>-EnvSecretSECRETKEY`. CloudFormation refused to delete the old export while any consumer still imported it.
+
+2. **Consumer `undefined` env vars** — `exportEnvName` ignored the explicit `consumer: true` prop and fell through to an else branch when `PROJECT_ENV` was not `"personal"`, producing `env-undefined-undefined-...` in `Fn::ImportValue`.
+
+**Fixes:**
+- `exportEnvName` now accepts `consumer` and uses it alongside `checkEnvIsConsumer(env)`, so explicit `{ consumer: true }` always resolves to the sandbox-scoped import name regardless of `PROJECT_ENV`.
+- The `exportEnvName` call site now passes `envKey || id` instead of `id`, restoring the original key as the name component and eliminating the `EnvSecret` prefix from the export name.
 
 ### `JaypieMigration` — waiter pattern with `queryInterval` and `totalTimeout` (#346)
 

--- a/packages/mcp/release-notes/lambda/1.2.7.md
+++ b/packages/mcp/release-notes/lambda/1.2.7.md
@@ -1,0 +1,29 @@
+---
+version: 1.2.7
+date: 2026-05-10
+summary: migrationHandler waiter protocol — onEventHandler/isCompleteHandler mode detection and pending flag (#346)
+---
+
+## Changes
+
+- `migrationHandler` now detects whether the Lambda is being invoked as `onEventHandler` or `isCompleteHandler` (by `cr.Provider`'s Step Functions waiter) and branches accordingly:
+  - **`onEventHandler` mode** (event has no `Data` field): returns `{ PhysicalResourceId }` immediately without running the user's handler. This is the fast-return that lets CFN start the polling loop.
+  - **`isCompleteHandler` mode** (event has a top-level `Data` field): runs the user's handler and wraps the result in CFN's `IsComplete` protocol: `{ IsComplete: !pending, Data: result }`.
+- The user handler may return `{ pending: true }` to signal more work remains; the waiter will re-invoke after `queryInterval`. Omitting `pending` (or `pending: false`) maps to `IsComplete: true`.
+
+```typescript
+import { migrationHandler } from "jaypie";
+
+export const handler = migrationHandler(async (event) => {
+  const remaining = await runNextPendingMigration();
+  return { pending: remaining > 0 };
+});
+```
+
+## Motivation
+
+`cr.Provider` uses a Step Functions state machine to poll `isCompleteHandler` independently from `onEventHandler`. When both handlers point to the same Lambda ARN, the Lambda must distinguish its role from the event shape. `isCompleteHandler` events always carry a top-level `Data` field (whatever `onEventHandler` returned); `onEventHandler` events do not. This is the discriminator.
+
+## Migration
+
+Existing `migrationHandler` users are upgraded automatically when they deploy with `@jaypie/constructs@1.2.56` (which now always wires `isCompleteHandler`). The migration runs in `isCompleteHandler` instead of `onEventHandler`; CloudFormation behavior is identical for single-shot migrations that complete in one call.

--- a/packages/mcp/release-notes/llm/1.2.35.md
+++ b/packages/mcp/release-notes/llm/1.2.35.md
@@ -1,0 +1,9 @@
+---
+version: 1.2.35
+date: 2026-05-10
+summary: Downgrade tool-throw log level from error to warn
+---
+
+## Bug Fixes
+
+- **Tool throw log level** — When a tool registered with the operate loop throws, the error is now logged at `log.warn` instead of `log.error` in both the streaming and non-streaming paths. Tool throws are a normal operating mode; the loop already feeds the error back to the model as a `tool_result`. Elevating every tool throw to `error` caused monitoring noise for routine outcomes like authorization refusals and allowlist misses. The existing `log.warn("Stopped after N consecutive tool errors")` continues to fire at warn for the terminal threshold case.

--- a/packages/mcp/release-notes/mcp/0.8.59.md
+++ b/packages/mcp/release-notes/mcp/0.8.59.md
@@ -1,0 +1,13 @@
+---
+version: 0.8.59
+date: 2026-05-10
+summary: Update migrations skill for waiter pattern — pending flag, queryInterval, totalTimeout (#346)
+---
+
+## Changes
+
+- Updated `skills/migrations.md` to document the `cr.Provider` waiter pattern introduced in `@jaypie/constructs@1.2.56` and `@jaypie/lambda@1.2.7`:
+  - New `queryInterval` and `totalTimeout` props in the Props table
+  - Updated Behavior section to describe the `onEventHandler` / `isCompleteHandler` two-phase execution model
+  - New "Multi-step migrations" section explaining the `pending` flag and waiter protocol
+  - Updated Construct Internals to mention the Step Functions state machine

--- a/packages/mcp/skills/migrations.md
+++ b/packages/mcp/skills/migrations.md
@@ -35,20 +35,23 @@ new JaypieMigration(this, "SeedData", {
 | `dependencies` | `Construct[]` | `[]` | Constructs that must be created before the migration runs |
 | `environment` | `Record<string, string> \| (Record<string, string> \| string)[]` | - | Environment variables for the migration Lambda |
 | `handler` | `string` | `"index.handler"` | Lambda entry point |
+| `queryInterval` | `cdk.Duration` | `Duration.seconds(60)` | Polling interval between `isCompleteHandler` invocations |
 | `secrets` | `SecretsArrayItem[]` | `[]` | Secrets to make available to the Lambda |
 | `tables` | `dynamodb.ITable[]` | `[]` | DynamoDB tables to grant read/write access |
+| `timeout` | `cdk.Duration` | `Duration.minutes(15)` | Per-invocation Lambda timeout |
+| `totalTimeout` | `cdk.Duration` | `Duration.hours(2)` | Maximum wall time across all `isCompleteHandler` invocations |
 
 ## Behavior
 
-- **Timeout**: 5 minutes (vs 30s for API Lambdas) to accommodate long-running migrations
+- **Timeout**: 15 minutes per invocation (Lambda max); `totalTimeout` controls the end-to-end ceiling across all polling invocations (default 2 hours)
 - **Role**: Tagged as `CDK.ROLE.PROCESSING`
-- **Execution**: Runs on every deploy via CloudFormation custom resource (uses a deploy nonce to force re-invocation even when only Lambda code changes)
+- **Execution**: Uses `cr.Provider` with both `onEventHandler` and `isCompleteHandler` pointing to the same Lambda. The `onEventHandler` returns `PhysicalResourceId` immediately; the migration code runs in `isCompleteHandler` invocations, which are polled by Step Functions until `IsComplete: true`.
 - **Dependencies**: Use `dependencies` to ensure tables and other resources exist before the migration executes
 - **Permissions**: Tables passed via `tables` get data-plane (`grantReadWriteData`) plus control-plane access (`DescribeTable`, `UpdateTable`, `UpdateTimeToLive`, `UpdateContinuousBackups`) scoped to the table ARN and its indexes — migrations that add GSIs, toggle TTL, or change backups work without extra IAM
 
 ## Migration Lambda Handler
 
-The migration Lambda receives a CloudFormation custom resource event. Use `migrationHandler` so a thrown error fails the CFN custom resource (and the deploy) — `lambdaHandler`'s default `throw: false` returns a success-shaped response on error and CFN reports `CREATE_COMPLETE` even when the migration failed.
+Use `migrationHandler` from `jaypie` so errors propagate as CFN failures and the waiter protocol is handled automatically.
 
 ```typescript
 // src/migrations/seed/index.ts
@@ -68,6 +71,21 @@ export const handler = migrationHandler(async (event) => {
 ```
 
 `migrationHandler` is `lambdaHandler` with `throw: true` defaulted. Pass `{ throw: false }` to opt back into soft-fail behavior.
+
+### Multi-step migrations (waiter pattern)
+
+Return `{ pending: true }` to request another invocation after `queryInterval`. The handler runs repeatedly until `pending` is omitted or `false`.
+
+```typescript
+export const handler = migrationHandler(async (event) => {
+  const remaining = await runNextPendingMigration();
+  return { pending: remaining > 0 };
+});
+```
+
+`migrationHandler` maps the `pending` flag onto CFN's `IsComplete` protocol:
+- `pending: true` → `{ IsComplete: false }` — waiter re-invokes after `queryInterval`
+- `pending: false` or omitted → `{ IsComplete: true }` — deploy proceeds
 
 ## Building Migration Code
 
@@ -110,11 +128,11 @@ new JaypieMigration(this, "DataMigration", {
 
 ## Construct Internals
 
-`JaypieMigration` creates three resources:
+`JaypieMigration` creates:
 
 1. **`JaypieLambda`** - The migration function (exposed as `migration.lambda`)
-2. **`cr.Provider`** - CloudFormation custom resource provider wrapping the Lambda
-3. **`cdk.CustomResource`** - The custom resource that triggers on every deploy
+2. **`cr.Provider`** - Custom resource provider with `onEventHandler` and `isCompleteHandler` both pointing to the migration Lambda; backed by a Step Functions state machine for the waiter loop
+3. **`cdk.CustomResource`** - Triggers on every deploy via a `deployNonce` property
 
 Dependencies are attached to the custom resource so the migration waits for prerequisite resources.
 


### PR DESCRIPTION
## Summary

- Downgrade \`log.error\` → \`log.warn\` in both \`OperateLoop.ts\` and \`StreamLoop.ts\` for the tool-throw catch block (#344)
- Tool throws are a normal operating mode — the loop feeds the error back to the model as a \`tool_result\` so the LLM can adapt; logging at \`error\` caused Datadog noise for routine outcomes like authorization refusals and allowlist misses
- The existing \`log.warn("Stopped after N consecutive tool errors")\` threshold signal is unchanged
- \`JaypieMigration\` now wires \`isCompleteHandler: this.lambda\` on \`cr.Provider\`, enabling the Step Functions waiter pattern for multi-hour migrations (#346)
- New \`queryInterval\` (default 60s) and \`totalTimeout\` (default 2h) props on \`JaypieMigrationProps\`
- \`migrationHandler\` detects \`onEventHandler\` vs \`isCompleteHandler\` mode via event shape and maps the \`pending\` flag to CFN's \`IsComplete\` protocol

## Test plan

- [x] Two new tests added: \`logs at warn level when tool throws, not error\` in \`OperateLoop.spec.ts\` and \`StreamLoop.spec.ts\`
- [x] All 78 \`@jaypie/lambda\` tests pass, including new \`migrationHandler\` mode tests
- [x] All 539 \`@jaypie/constructs\` tests pass, including new Step Functions state machine assertion
- [x] Typecheck clean for both packages

Closes #344
Closes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)