### PR TITLE
ci: parallelize LLM capability matrix into 4 provider groups

### DIFF
--- a/.github/workflows/npm-check.yml
+++ b/.github/workflows/npm-check.yml
@@ -68,9 +68,21 @@ jobs:
       - run: npm run build
       - run: npm test
   test-llm-matrix:
-    name: LLM Capability Matrix (conditional)
+    name: LLM Capability Matrix (${{ matrix.group }})
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - group: anthropic
+            models: "claude-sonnet-4-5,claude-sonnet-4-6,claude-opus-4-1,claude-opus-4-5,claude-opus-4-7,claude-haiku-4-5"
+          - group: openai
+            models: "gpt-5,gpt-5.1,gpt-5-pro,gpt-5.4,gpt-5.4-mini,gpt-5.4-nano,gpt-5.5"
+          - group: gemini-xai
+            models: "gemini-3.1-pro-preview,gemini-3-flash-preview,gemini-3.1-flash-lite-preview,grok-4.20-0309-reasoning,grok-4.20-0309-non-reasoning,grok-4-1-fast-non-reasoning"
+          - group: openrouter
+            models: "anthropic/claude-sonnet-4.6,google/gemini-3.1-pro-preview,moonshotai/kimi-k2.6,openai/gpt-5.5,x-ai/grok-4.20"
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v4
@@ -91,12 +103,27 @@ jobs:
       - name: Build
         if: steps.changes.outputs.llm == 'true'
         run: npm run build
-      - name: Run LLM Capability Matrix
+      - name: Run LLM Capability Matrix (${{ matrix.group }})
         if: steps.changes.outputs.llm == 'true'
-        run: LOG_LEVEL=warn npm run test:llm:matrix
+        run: LOG_LEVEL=warn APP_MODELS="${{ matrix.models }}" npm run test:llm:matrix
         env:
           ANTHROPIC_API_KEY: ${{ secrets.CICD_ANTHROPIC_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.CICD_GEMINI_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.CICD_OPENAI_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.CICD_OPENROUTER_API_KEY }}
           XAI_API_KEY: ${{ secrets.CICD_XAI_API_KEY }}
+
+  test-llm-matrix-complete:
+    name: LLM Capability Matrix (conditional)
+    needs: test-llm-matrix
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check matrix group results
+        run: |
+          result="${{ needs.test-llm-matrix.result }}"
+          if [[ "$result" == "failure" ]]; then
+            echo "One or more LLM matrix groups failed"
+            exit 1
+          fi
+          echo "All LLM matrix groups passed (result: $result)"

--- a/.github/workflows/npm-deploy.yml
+++ b/.github/workflows/npm-deploy.yml
@@ -182,9 +182,21 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.CICD_OPENAI_API_KEY }}
           XAI_API_KEY: ${{ secrets.CICD_XAI_API_KEY }}
   test-llm-matrix:
-    name: LLM Capability Matrix
+    name: LLM Capability Matrix (${{ matrix.group }})
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - group: anthropic
+            models: "claude-sonnet-4-5,claude-sonnet-4-6,claude-opus-4-1,claude-opus-4-5,claude-opus-4-7,claude-haiku-4-5"
+          - group: openai
+            models: "gpt-5,gpt-5.1,gpt-5-pro,gpt-5.4,gpt-5.4-mini,gpt-5.4-nano,gpt-5.5"
+          - group: gemini-xai
+            models: "gemini-3.1-pro-preview,gemini-3-flash-preview,gemini-3.1-flash-lite-preview,grok-4.20-0309-reasoning,grok-4.20-0309-non-reasoning,grok-4-1-fast-non-reasoning"
+          - group: openrouter
+            models: "anthropic/claude-sonnet-4.6,google/gemini-3.1-pro-preview,moonshotai/kimi-k2.6,openai/gpt-5.5,x-ai/grok-4.20"
     steps:
       - uses: actions/checkout@v6
       - name: Use Node.js 24
@@ -196,8 +208,8 @@ jobs:
         run: npm install
       - name: Build
         run: npm run build
-      - name: Run LLM Capability Matrix
-        run: LOG_LEVEL=warn npm run test:llm:matrix
+      - name: Run LLM Capability Matrix (${{ matrix.group }})
+        run: LOG_LEVEL=warn APP_MODELS="${{ matrix.models }}" npm run test:llm:matrix
         env:
           ANTHROPIC_API_KEY: ${{ secrets.CICD_ANTHROPIC_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.CICD_GEMINI_API_KEY }}


### PR DESCRIPTION
## Summary
- Split 168 sequential API calls (24 models × 7 capabilities) across 4 parallel GitHub Actions matrix jobs
- Provider groups: anthropic, openai, gemini-xai, openrouter — each ~35-49 cells ≈ 7-10 minutes
- Reduced per-job timeout from 30 → 20 minutes; total wall time drops from ~35+ min to ~10 min
- Added `test-llm-matrix-complete` consolidation job in `npm-check.yml` to satisfy branch ruleset required check name `LLM Capability Matrix (conditional)`

## Test plan
- [ ] Verify each of the 4 matrix groups completes under 20 minutes in CI
- [ ] Verify `LLM Capability Matrix (conditional)` consolidation job passes
- [ ] Verify `npm-deploy.yml` matrix jobs also run in parallel on merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)