### PR TITLE
fix(constructs): restore JaypieEnvSecret id-based export names + model matrix updates

### DIFF
--- a/.github/workflows/npm-check.yml
+++ b/.github/workflows/npm-check.yml
@@ -76,13 +76,13 @@ jobs:
       matrix:
         include:
           - group: anthropic
-            models: "claude-sonnet-4-5,claude-sonnet-4-6,claude-opus-4-1,claude-opus-4-5,claude-opus-4-7,claude-haiku-4-5"
+            models: "claude-sonnet-4-5,claude-sonnet-4-6,claude-opus-4-5,claude-opus-4-6,claude-opus-4-7,claude-haiku-4-5"
           - group: openai
-            models: "gpt-5,gpt-5.1,gpt-5-pro,gpt-5.4,gpt-5.4-mini,gpt-5.4-nano,gpt-5.5"
+            models: "gpt-5,gpt-5.4,gpt-5.4-mini,gpt-5.4-nano,gpt-5.5"
           - group: gemini-xai
-            models: "gemini-3.1-pro-preview,gemini-3-flash-preview,gemini-3.1-flash-lite-preview,grok-4.20-0309-reasoning,grok-4.20-0309-non-reasoning,grok-4-1-fast-non-reasoning"
+            models: "gemini-3.1-pro-preview,gemini-3-flash-preview,gemini-3.1-flash-lite-preview,grok-latest,grok-4.3-latest,grok-4-1-fast-reasoning,grok-4-1-fast-non-reasoning"
           - group: openrouter
-            models: "anthropic/claude-sonnet-4.6,google/gemini-3.1-pro-preview,moonshotai/kimi-k2.6,openai/gpt-5.5,x-ai/grok-4.20"
+            models: "anthropic/claude-sonnet-4.6,google/gemini-3.1-pro-preview,openai/gpt-5.5,x-ai/grok-4.20"
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v4

--- a/.github/workflows/npm-deploy.yml
+++ b/.github/workflows/npm-deploy.yml
@@ -190,13 +190,13 @@ jobs:
       matrix:
         include:
           - group: anthropic
-            models: "claude-sonnet-4-5,claude-sonnet-4-6,claude-opus-4-1,claude-opus-4-5,claude-opus-4-7,claude-haiku-4-5"
+            models: "claude-sonnet-4-5,claude-sonnet-4-6,claude-opus-4-5,claude-opus-4-6,claude-opus-4-7,claude-haiku-4-5"
           - group: openai
-            models: "gpt-5,gpt-5.1,gpt-5-pro,gpt-5.4,gpt-5.4-mini,gpt-5.4-nano,gpt-5.5"
+            models: "gpt-5,gpt-5.4,gpt-5.4-mini,gpt-5.4-nano,gpt-5.5"
           - group: gemini-xai
-            models: "gemini-3.1-pro-preview,gemini-3-flash-preview,gemini-3.1-flash-lite-preview,grok-4.20-0309-reasoning,grok-4.20-0309-non-reasoning,grok-4-1-fast-non-reasoning"
+            models: "gemini-3.1-pro-preview,gemini-3-flash-preview,gemini-3.1-flash-lite-preview,grok-latest,grok-4.3-latest,grok-4-1-fast-reasoning,grok-4-1-fast-non-reasoning"
           - group: openrouter
-            models: "anthropic/claude-sonnet-4.6,google/gemini-3.1-pro-preview,moonshotai/kimi-k2.6,openai/gpt-5.5,x-ai/grok-4.20"
+            models: "anthropic/claude-sonnet-4.6,google/gemini-3.1-pro-preview,openai/gpt-5.5,x-ai/grok-4.20"
     steps:
       - uses: actions/checkout@v6
       - name: Use Node.js 24

--- a/package-lock.json
+++ b/package-lock.json
@@ -28389,7 +28389,7 @@
     },
     "packages/constructs": {
       "name": "@jaypie/constructs",
-      "version": "1.2.56",
+      "version": "1.2.57",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29239,7 +29239,7 @@
         "typescript-eslint": "^8.46.1"
       },
       "peerDependencies": {
-        "@jaypie/llm": "^1.2.35",
+        "@jaypie/llm": "^1.2.36",
         "@jaypie/mongoose": "^1.2.2"
       },
       "peerDependenciesMeta": {
@@ -29348,7 +29348,7 @@
     },
     "packages/llm": {
       "name": "@jaypie/llm",
-      "version": "1.2.35",
+      "version": "1.2.36",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "*",
@@ -29471,7 +29471,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.59",
+      "version": "0.8.60",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.4",

--- a/packages/constructs/package.json
+++ b/packages/constructs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/constructs",
-  "version": "1.2.56",
+  "version": "1.2.57",
   "description": "CDK constructs for Jaypie applications",
   "repository": {
     "type": "git",

--- a/packages/constructs/src/JaypieEnvSecret.ts
+++ b/packages/constructs/src/JaypieEnvSecret.ts
@@ -120,7 +120,12 @@ export class JaypieEnvSecret extends Construct implements ISecret {
     let exportName;
 
     if (!exportParam) {
-      exportName = exportEnvName(envKey || id, process.env, consumer);
+      // When shorthand detection is active, use the full construct id (which
+      // includes the "EnvSecret_" prefix) so the export name matches what was
+      // produced by earlier versions of this construct. Using the raw envKey
+      // here produces a shorter name that breaks existing cross-stack imports.
+      const exportSource = treatAsEnvKey ? id : envKey || id;
+      exportName = exportEnvName(exportSource, process.env, consumer);
     } else {
       exportName = cleanName(exportParam);
     }

--- a/packages/constructs/src/__tests__/JaypieEnvSecret.spec.ts
+++ b/packages/constructs/src/__tests__/JaypieEnvSecret.spec.ts
@@ -171,7 +171,7 @@ describe("JaypieSecret", () => {
       process.env = { ...originalEnv };
     });
 
-    it("provider shorthand export name uses key, not prefixed construct id", () => {
+    it("provider shorthand export name uses prefixed construct id for backward compatibility", () => {
       process.env.MY_SECRET = "my-value";
       process.env.PROJECT_ENV = CDK.ENV.SANDBOX;
       process.env.PROJECT_KEY = "testproject";
@@ -186,7 +186,7 @@ describe("JaypieSecret", () => {
         .map((o: any) => o.Export.Name);
 
       expect(exportNames.length).toBe(1);
-      expect(exportNames[0]).toBe("env-sandbox-testproject-MYSECRET");
+      expect(exportNames[0]).toBe("env-sandbox-testproject-EnvSecretMYSECRET");
     });
 
     it("consumer:true export name uses sandbox format without relying on PROJECT_ENV=personal", () => {
@@ -199,7 +199,7 @@ describe("JaypieSecret", () => {
       const template = Template.fromStack(stack);
 
       const templateStr = JSON.stringify(template.toJSON());
-      expect(templateStr).toContain("env-sandbox-testproject-MYSECRET");
+      expect(templateStr).toContain("env-sandbox-testproject-EnvSecretMYSECRET");
       expect(templateStr).not.toContain("undefined");
     });
 

--- a/packages/jaypie/package.json
+++ b/packages/jaypie/package.json
@@ -54,7 +54,7 @@
     "typescript-eslint": "^8.46.1"
   },
   "peerDependencies": {
-    "@jaypie/llm": "^1.2.35",
+    "@jaypie/llm": "^1.2.36",
     "@jaypie/mongoose": "^1.2.2"
   },
   "peerDependenciesMeta": {

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/llm",
-  "version": "1.2.35",
+  "version": "1.2.36",
   "description": "Large language model utilities",
   "repository": {
     "type": "git",

--- a/packages/llm/src/constants.ts
+++ b/packages/llm/src/constants.ts
@@ -10,7 +10,7 @@ const FIRST_CLASS_PROVIDER = {
   GEMINI: {
     DEFAULT: "gemini-3.1-pro-preview" as const,
     LARGE: "gemini-3.1-pro-preview" as const,
-    SMALL: "gemini-3-flash-preview" as const,
+    SMALL: "gemini-3.1-flash-lite-preview" as const,
     TINY: "gemini-3.1-flash-lite-preview" as const,
   },
   // https://developers.openai.com/api/docs/models
@@ -22,9 +22,9 @@ const FIRST_CLASS_PROVIDER = {
   },
   // https://docs.x.ai/developers/models
   XAI: {
-    DEFAULT: "grok-4.20-0309-reasoning" as const,
-    LARGE: "grok-4.20-0309-reasoning" as const,
-    SMALL: "grok-4.20-0309-non-reasoning" as const,
+    DEFAULT: "grok-latest" as const,
+    LARGE: "grok-4.3-latest" as const,
+    SMALL: "grok-4-1-fast-reasoning" as const,
     TINY: "grok-4-1-fast-non-reasoning" as const,
   },
 };

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.59",
+  "version": "0.8.60",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/constructs/1.2.57.md
+++ b/packages/mcp/release-notes/constructs/1.2.57.md
@@ -1,0 +1,11 @@
+---
+version: 1.2.57
+date: 2026-05-11
+summary: Fix JaypieEnvSecret shorthand export name to use prefixed construct id for backward compatibility with deployed stacks
+---
+
+## @jaypie/constructs 1.2.57
+
+### Bug Fixes
+
+- **JaypieEnvSecret**: Restored id-based export naming for the shorthand constructor pattern. When using shorthand (e.g., `new JaypieEnvSecret(stack, "ANTHROPIC_API_KEY")`), the cross-stack export name now uses the construct id (`EnvSecretANTHROPICAPIKEY`) rather than the raw env key (`ANTHROPICAPIKEY`). This matches the format produced by earlier construct versions and unblocks deployments where downstream stacks import these exports.

--- a/packages/mcp/release-notes/llm/1.2.36.md
+++ b/packages/mcp/release-notes/llm/1.2.36.md
@@ -1,0 +1,12 @@
+---
+version: 1.2.36
+date: 2026-05-11
+summary: Update model constants for Gemini, xAI Grok, and remove deprecated models
+---
+
+## @jaypie/llm 1.2.36
+
+### Changes
+
+- **Model constants**: Updated xAI Grok defaults — `DEFAULT` is now `grok-latest`, `LARGE` is `grok-4.3-latest`, `SMALL` is `grok-4-1-fast-reasoning`
+- **Model constants**: Updated Gemini `SMALL` to `gemini-3.1-flash-lite-preview`

--- a/packages/mcp/release-notes/mcp/0.8.60.md
+++ b/packages/mcp/release-notes/mcp/0.8.60.md
@@ -1,0 +1,12 @@
+---
+version: 0.8.60
+date: 2026-05-11
+summary: Add release notes for constructs 1.2.57 and llm 1.2.36
+---
+
+## @jaypie/mcp 0.8.60
+
+### Changes
+
+- Added release notes for `@jaypie/constructs` 1.2.57 (JaypieEnvSecret export name backward compatibility fix)
+- Added release notes for `@jaypie/llm` 1.2.36 (model constant updates)


### PR DESCRIPTION
## Summary

- **constructs 1.2.57**: Restores id-based cross-stack export naming in `JaypieEnvSecret` shorthand constructor — fixes follow-up to #347 where existing deployments (17 legacy secrets with `EnvSecret<KEY>` export format) were blocked by renamed exports
- **llm 1.2.36**: Updated xAI Grok and Gemini model constants; removes deprecated model names
- **ci**: Updated LLM capability matrix — removes `gpt-5.1`, `gpt-5-pro`, `claude-opus-4-1`, `moonshotai/kimi-k2.6`; adds `claude-opus-4-6`, `grok-latest`, `grok-4.3-latest`, `grok-4-1-fast-reasoning`

## Test plan

- [ ] All constructs tests pass (542 tests)
- [ ] `JaypieEnvSecret` shorthand export name is `env-<env>-<key>-EnvSecret<KEY>` (backward-compatible with deployed stacks)
- [ ] Provider and consumer export names continue to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)