### PR TITLE
fix(lambda): migrationHandler discriminator broken — onEvent must return Data for isComplete polls (#350)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29214,7 +29214,7 @@
       "license": "MIT"
     },
     "packages/jaypie": {
-      "version": "1.2.47",
+      "version": "1.2.48",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "^1.2.8",
@@ -29223,7 +29223,7 @@
         "@jaypie/errors": "^1.2.1",
         "@jaypie/express": "^1.2.23",
         "@jaypie/kit": "^1.2.8",
-        "@jaypie/lambda": "^1.2.6",
+        "@jaypie/lambda": "^1.2.8",
         "@jaypie/logger": "^1.2.15"
       },
       "devDependencies": {
@@ -29315,7 +29315,7 @@
     },
     "packages/lambda": {
       "name": "@jaypie/lambda",
-      "version": "1.2.7",
+      "version": "1.2.8",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-typescript": "^12.1.2",

--- a/packages/jaypie/package.json
+++ b/packages/jaypie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jaypie",
-  "version": "1.2.47",
+  "version": "1.2.48",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"
@@ -38,7 +38,7 @@
     "@jaypie/errors": "^1.2.1",
     "@jaypie/express": "^1.2.23",
     "@jaypie/kit": "^1.2.8",
-    "@jaypie/lambda": "^1.2.6",
+    "@jaypie/lambda": "^1.2.8",
     "@jaypie/logger": "^1.2.15"
   },
   "devDependencies": {

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/lambda",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"

--- a/packages/lambda/src/__tests__/migrationHandler.spec.ts
+++ b/packages/lambda/src/__tests__/migrationHandler.spec.ts
@@ -46,6 +46,24 @@ describe("migrationHandler", () => {
         );
         expect(result).toMatchObject({ PhysicalResourceId: "my-migration-123" });
       });
+
+      it("Returns Data in response so cr.Provider propagates it to isComplete events", async () => {
+        const handler = migrationHandler(async () => ({ status: "complete" }));
+        const result = await handler({ RequestType: "Create" }, {});
+        expect(result).toMatchObject({ Data: expect.any(Object) });
+      });
+
+      it("Correctly discriminates isComplete when using onEvent response as event (cr.Provider round-trip)", async () => {
+        const userHandler = vi.fn().mockResolvedValue({ status: "complete" });
+        const handler = migrationHandler(userHandler);
+        // Simulate cr.Provider: merge cfnRequest with onEvent result to build isComplete event
+        const onEventResult = (await handler({ RequestType: "Create" }, {})) as Record<string, unknown>;
+        // cr.Provider spreads onEventResult into the isComplete event
+        const isCompleteEvent = { RequestType: "Create", ...onEventResult };
+        const isCompleteResult = await handler(isCompleteEvent, {});
+        expect(userHandler).toHaveBeenCalledTimes(1);
+        expect(isCompleteResult).toMatchObject({ IsComplete: true });
+      });
     });
 
     describe("isCompleteHandler mode (event with Data)", () => {

--- a/packages/lambda/src/migrationHandler.ts
+++ b/packages/lambda/src/migrationHandler.ts
@@ -52,11 +52,14 @@ const migrationHandler = function <TEvent = unknown, TResult = unknown>(
       return { Data: result, IsComplete: !pending };
     }
 
-    // onEventHandler: return PhysicalResourceId immediately; the migration runs
-    // in subsequent isCompleteHandler invocations via the Step Functions waiter.
+    // onEventHandler: return PhysicalResourceId and a Data marker immediately.
+    // cr.Provider only propagates Data to isComplete events when onEvent returned it,
+    // so we must include Data here or the "Data" in cfnEvent discriminator will never
+    // be true on isComplete polls.
     return {
       PhysicalResourceId:
         (cfnEvent?.PhysicalResourceId as string | undefined) ?? "migration",
+      Data: { __migration: true },
     };
   };
 };

--- a/packages/mcp/release-notes/jaypie/1.2.48.md
+++ b/packages/mcp/release-notes/jaypie/1.2.48.md
@@ -1,0 +1,13 @@
+---
+version: 1.2.48
+date: 2026-05-11
+summary: pick up @jaypie/lambda 1.2.8 fix for migrationHandler waiter loop (#350)
+---
+
+## Changes
+
+- Updated `@jaypie/lambda` dependency to `^1.2.8`.
+
+## Details
+
+See `@jaypie/lambda` 1.2.8 release notes. Consumers of `jaypie` now automatically pick up the `migrationHandler` discriminator fix that prevented `JaypieMigration` deploys from completing.

--- a/packages/mcp/release-notes/lambda/1.2.8.md
+++ b/packages/mcp/release-notes/lambda/1.2.8.md
@@ -1,0 +1,17 @@
+---
+version: 1.2.8
+date: 2026-05-11
+summary: fix migrationHandler discriminator — onEventHandler now returns Data marker so isComplete polls route correctly (#350)
+---
+
+## Changes
+
+- `migrationHandler`'s `onEventHandler` branch now returns `Data: { __migration: true }` alongside `PhysicalResourceId`.
+
+## Motivation
+
+`cr.Provider` only propagates `Data` into `isComplete` events when `onEvent` returned a `Data` field. The previous implementation returned `{ PhysicalResourceId }` with no `Data`, so every `isComplete` poll also had no `Data`, causing the `"Data" in cfnEvent` discriminator to always take the `onEventHandler` short-circuit branch. The waiter loop never received `IsComplete: true` and ran until `totalTimeout` (default 2 h), then failed the stack.
+
+## Migration
+
+No changes required. Consumers using `@jaypie/constructs@^1.2.56` and `@jaypie/lambda@^1.2.8` together will have working `JaypieMigration` deploys.


### PR DESCRIPTION
## Summary

- `migrationHandler`'s `onEventHandler` branch now returns `Data: { __migration: true }` alongside `PhysicalResourceId`
- Without `Data` in the `onEvent` response, cr.Provider never propagates `Data` to `isComplete` events, so the `"Data" in cfnEvent` discriminator always routes polls to the short-circuit `onEventHandler` branch — looping forever until `totalTimeout` (default 2 h)
- Adds two new tests: one verifying `onEvent` returns `Data`, one simulating the full cr.Provider round-trip

## Test plan

- [ ] All existing `migrationHandler` tests pass
- [ ] New test: `onEventHandler` returns `Data` in response
- [ ] New test: cr.Provider round-trip — `isComplete` event (built from `onEvent` result) correctly routes to `isCompleteHandler` branch

Fixes #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)