### PR TITLE
chore: document and restrict JaypieCicd to sandbox

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -1,0 +1,35 @@
+# .github — GitHub Actions
+
+Composite actions in `actions/` and workflows in `workflows/`. See subdirectory CLAUDEs for detail.
+
+## Structure
+
+```
+.github/
+├── actions/           # Reusable composite actions — see actions/CLAUDE.md
+│   ├── cdk-deploy/
+│   ├── configure-aws/
+│   ├── npm-install-build/
+│   ├── setup-environment/
+│   └── setup-node-and-cache/
+└── workflows/         # CI/CD workflows — see workflows/CLAUDE.md
+    ├── deploy-env-development.yml
+    ├── deploy-env-production.yml
+    ├── deploy-env-sandbox.yml
+    ├── deploy-stacks.yml
+    ├── npm-check.yml
+    └── npm-deploy.yml
+```
+
+## IAM Bootstrap Prerequisite
+
+Workflows authenticate via OIDC using `configure-aws`, which assumes the role ARN in `AWS_ROLE_ARN`. Those roles are provisioned by the `JaypieCicd` CDK stack (`workspaces/cdk/lib/cicd-stack.ts`).
+
+**Deploy `JaypieCicd` first** in any new AWS account via Actions → "Deploy Stacks (Manual)". It is not included in `all` and is not triggered automatically.
+
+## Adding a New IAM Role for CI/CD
+
+1. Add the role to `workspaces/cdk/lib/cicd-stack.ts`
+2. Export its ARN as a `CfnOutput`
+3. Set the ARN as a GitHub environment variable in the relevant environment
+4. Manually deploy `JaypieCicd` via `deploy-stacks.yml`

--- a/.github/actions/CLAUDE.md
+++ b/.github/actions/CLAUDE.md
@@ -1,0 +1,17 @@
+# GitHub Composite Actions
+
+| Action | Purpose | Required Inputs |
+|---|---|---|
+| `setup-environment` | Maps GitHub vars to env vars with defaults; outputs `aws-region` and `aws-role-arn` | GitHub Settings vars |
+| `configure-aws` | OIDC role assumption; roles provisioned by `JaypieCicd` CDK stack — see `configure-aws/CLAUDE.md` | `role-arn` (from `AWS_ROLE_ARN`) |
+| `setup-node-and-cache` | Checkout + Node.js + node_modules cache; includes checkout — no prior checkout step needed | none |
+| `npm-install-build` | `npm ci` + `npm run build` | none |
+| `cdk-deploy` | Builds CDK with content-hash cache, deploys named stacks; default `cdk-package-path` is `packages/cdk` but jaypie uses `workspaces/cdk` | `stack-name` |
+
+## Typical Workflow Order
+
+1. `setup-environment` — provides outputs consumed by `configure-aws`
+2. `configure-aws` — consumes `aws-region` and `aws-role-arn` from step 1
+3. `setup-node-and-cache` — handles checkout
+4. `npm-install-build`
+5. `cdk-deploy`

--- a/.github/actions/configure-aws/CLAUDE.md
+++ b/.github/actions/configure-aws/CLAUDE.md
@@ -1,0 +1,27 @@
+# configure-aws
+
+Composite action that authenticates with AWS via OIDC.
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `role-arn` | yes | — | IAM role ARN to assume |
+| `aws-region` | no | `us-east-1` | AWS region |
+| `role-session-name` | no | `DeployRoleForGitHubSession` | Role session name |
+
+## How It Works
+
+Wraps `aws-actions/configure-aws-credentials@v6`. The `role-arn` value comes from the `AWS_ROLE_ARN` GitHub environment variable, set by the `setup-environment` action.
+
+## IAM Role Provisioning
+
+The roles assumed here are provisioned by the `JaypieCicd` CDK stack (`workspaces/cdk/lib/cicd-stack.ts`). That stack must be deployed first in any new AWS account before workflows using this action will succeed.
+
+## Bedrock Two-Step Assumption
+
+Bedrock integration test workflows use a two-step role assumption:
+
+1. Assume `AWS_ROLE_ARN` via this action
+2. Query the CloudFormation `jaypie-cicd` stack for `BedrockCicdRoleArn`
+3. Assume that role directly via `aws-actions/configure-aws-credentials`

--- a/.github/actions/setup-environment/CLAUDE.md
+++ b/.github/actions/setup-environment/CLAUDE.md
@@ -1,0 +1,43 @@
+# setup-environment
+
+Composite action that maps GitHub vars/secrets to environment variables for CDK deployments.
+
+## Inputs
+
+Inputs mirror GitHub Settings scopes (org, repo, env):
+
+**Org-level:**
+- `aws-region` (default: `us-east-1`)
+- `log-level` (default: `debug`)
+- `module-log-level` (default: `warn`)
+- `project-sponsor` (default: `finlaysonstudio`)
+
+**Repo-level:**
+- `aws-hosted-zone` (default: `jaypie.net`)
+- `project-key` (default: `jaypie`)
+- `project-service` (default: `workspaces`)
+
+**Env-level:**
+- `aws-role-arn`
+- `datadog-api-key-arn`
+- `project-env` (default: `sandbox`)
+- `project-nonce` (random 8-char hex if not set)
+
+## Derived Values
+
+Set automatically, not passed as inputs:
+
+- `CDK_DEFAULT_ACCOUNT` — extracted from `aws-role-arn` (5th colon-delimited field)
+- `PROJECT_VERSION` — from `package.json` via `node -p`
+- `PROJECT_COMMIT` — from `github.sha`
+- `CDK_ENV_REPO` — from `github.repository`
+
+## Outputs
+
+- `aws-region`
+- `aws-role-arn`
+- `project-env`
+
+## Environment Variables Set
+
+`AWS_REGION`, `AWS_ROLE_ARN`, `CDK_DEFAULT_ACCOUNT`, `CDK_DEFAULT_REGION`, `CDK_ENV_DATADOG_API_KEY_ARN`, `CDK_ENV_HOSTED_ZONE`, `CDK_ENV_REPO`, `LOG_LEVEL`, `MODULE_LOG_LEVEL`, `PROJECT_COMMIT`, `PROJECT_ENV`, `PROJECT_KEY`, `PROJECT_NONCE`, `PROJECT_SERVICE`, `PROJECT_SPONSOR`, `PROJECT_VERSION`

--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -1,0 +1,117 @@
+# .github/workflows
+
+Six workflow files. All `deploy-env-*.yml` workflows use concurrency groups (by environment name) without `cancel-in-progress`, so queued runs wait rather than abort.
+
+---
+
+## deploy-env-sandbox.yml — Build Stacks to Sandbox
+
+**Triggers:** push to `branch/*`, `claude/*`, `feat/*`, `fix/*`, `sandbox/*`; tags `sandbox-*`
+
+**Path filter:** `workspaces/**`, `.github/actions/**`, `.github/workflows/deploy-env-*.yml`, `.github/workflows/deploy-stack-*.yml`
+
+**Concurrency:** `deploy-env-sandbox`
+
+**Jobs:** `deploy`, `lint`, `test`
+
+- `deploy` has no `needs` — runs immediately with no lint/test gate
+- Deploys stacks: `JaypieDocumentation JaypieGardenData JaypieGardenApi JaypieGardenNextjs`
+- Builds docs site (`npm run docs:build`), queries CloudFormation for bucket/role/distribution outputs, assumes `DeployRoleArn`, syncs to S3, invalidates CloudFront
+
+---
+
+## deploy-env-development.yml — Build Stacks to Development
+
+**Triggers:** push to `main`, `development/*`; tags `development-*`
+
+**Path filter:** same as sandbox
+
+**Concurrency:** `deploy-env-development`
+
+**Jobs:** `lint`, `test`, `deploy`
+
+- `deploy` requires `needs: [lint, test]`
+- Same stacks and docs deployment as sandbox
+
+---
+
+## deploy-env-production.yml — Build Stacks to Production
+
+**Triggers:** push to `main` (path filter: `workspaces/**`); `workflow_dispatch`
+
+**Concurrency:** `deploy-env-production`
+
+**Jobs:** `lint`, `test`, `deploy`
+
+- `deploy` uses `if: always() && needs.lint.result == 'success' && needs.test.result == 'success'`
+- Logs version number from `package.json` at deploy time via `::notice::`
+- Same stacks and docs deployment as sandbox/development
+
+---
+
+## deploy-stacks.yml — Deploy Stacks (Manual)
+
+**Triggers:** `workflow_dispatch` only
+
+**Concurrency:** `deploy-stacks-${{ github.event.inputs.environment }}`
+
+**Inputs:**
+- `environment`: choice — `sandbox` / `development` / `production` (default: `sandbox`)
+- `stacks`: choice — `all`, `JaypieCicd`, `JaypieDocumentation`, `JaypieGardenApi`, `JaypieGardenNextjs`, `JaypieGardenData`, `JaypieGardenApi JaypieGardenNextjs`, `JaypieGardenData JaypieGardenApi JaypieGardenNextjs`
+- `custom_stacks`: free text — overrides `stacks` if provided
+
+`all` resolves to: `JaypieDocumentation JaypieGardenData JaypieGardenApi JaypieGardenNextjs`
+
+`JaypieCicd` is available as an explicit choice but NOT included in `all`.
+
+No docs deployment step (unlike `deploy-env-*.yml`).
+
+---
+
+## npm-check.yml — NPM Check
+
+**Triggers:** push to `branch/*`, `claude/*`, `codex/*`, `devin/*`, `fix/*`, `feat/*`; tags `check-*`
+
+**Jobs:**
+
+| Job | Notes |
+|-----|-------|
+| `lint` | Node 24 |
+| `typecheck` | `continue-on-error: true` |
+| `test` | Node 24 (stable) + 25 (experimental, `continue-on-error: true`) |
+| `build-llm` | Detects changes to `packages/llm/**` via `dorny/paths-filter`; builds and uploads artifact |
+| `test-llm-matrix` | Only runs when `packages/llm/**` changed; matrix: `anthropic`, `openai`, `gemini-xai`, `openrouter`, `bedrock` |
+| `test-llm-matrix-complete` | Aggregator job — fails if any matrix group failed |
+
+**Bedrock two-step role assumption** (matrix group `bedrock`):
+1. `configure-aws` with `vars.AWS_ROLE_ARN` (sandbox environment)
+2. Query CloudFormation: `aws cloudformation describe-stacks --stack-name jaypie-cicd` for `BedrockCicdRoleArn`
+3. `aws-actions/configure-aws-credentials` to assume that Bedrock role
+
+Requires `JaypieCicd` stack deployed.
+
+---
+
+## npm-deploy.yml — NPM Deploy
+
+**Triggers:** push to `main`; tags `deploy-*`, `dev-*`, `rc-*`
+
+**Jobs:** `lint`, `typecheck`, `test`, `deploy`, `build-llm`, `test-llm-client`, `test-llm-matrix`
+
+`deploy` runs independently (no `needs`). Iterates `packages/*/`, skips private packages and already-published versions.
+
+**Tag-based publish targets:**
+- `dev-*` tag + version contains `-dev.` → `--tag dev`
+- `rc-*` tag + version contains `-rc.` → `--tag rc`
+- otherwise → latest (no tag flag)
+
+**test job:** optionally wraps `npm test` with Datadog tracing when `DATADOG_CICD_API_KEY` is set.
+
+**test-llm-client:** always runs (no path filter), uses sandbox environment, Bedrock two-step role assumption.
+
+**test-llm-matrix:** always runs (no path filter), same matrix groups as npm-check, Bedrock two-step role assumption for `bedrock` group.
+
+**Bedrock two-step role assumption** (same pattern as npm-check):
+1. `configure-aws` with `vars.AWS_ROLE_ARN` (sandbox environment)
+2. Query CloudFormation `jaypie-cicd` stack for `BedrockCicdRoleArn`
+3. Assume that role via `aws-actions/configure-aws-credentials`

--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -15,7 +15,8 @@ Six workflow files. All `deploy-env-*.yml` workflows use concurrency groups (by 
 **Jobs:** `deploy`, `lint`, `test`
 
 - `deploy` has no `needs` — runs immediately with no lint/test gate
-- Deploys stacks: `JaypieDocumentation JaypieGardenData JaypieGardenApi JaypieGardenNextjs`
+- Deploys stacks: `JaypieCicd JaypieDocumentation JaypieGardenData JaypieGardenApi JaypieGardenNextjs`
+- `JaypieCicd` only deploys here — not in development or production workflows
 - Builds docs site (`npm run docs:build`), queries CloudFormation for bucket/role/distribution outputs, assumes `DeployRoleArn`, syncs to S3, invalidates CloudFront
 
 ---
@@ -57,12 +58,12 @@ Six workflow files. All `deploy-env-*.yml` workflows use concurrency groups (by 
 
 **Inputs:**
 - `environment`: choice — `sandbox` / `development` / `production` (default: `sandbox`)
-- `stacks`: choice — `all`, `JaypieCicd`, `JaypieDocumentation`, `JaypieGardenApi`, `JaypieGardenNextjs`, `JaypieGardenData`, `JaypieGardenApi JaypieGardenNextjs`, `JaypieGardenData JaypieGardenApi JaypieGardenNextjs`
+- `stacks`: choice — `all`, `JaypieDocumentation`, `JaypieGardenApi`, `JaypieGardenNextjs`, `JaypieGardenData`, `JaypieGardenApi JaypieGardenNextjs`, `JaypieGardenData JaypieGardenApi JaypieGardenNextjs`
 - `custom_stacks`: free text — overrides `stacks` if provided
 
 `all` resolves to: `JaypieDocumentation JaypieGardenData JaypieGardenApi JaypieGardenNextjs`
 
-`JaypieCicd` is available as an explicit choice but NOT included in `all`.
+`JaypieCicd` is not available here — it deploys automatically with sandbox via `deploy-env-sandbox.yml`.
 
 No docs deployment step (unlike `deploy-env-*.yml`).
 

--- a/.github/workflows/deploy-env-sandbox.yml
+++ b/.github/workflows/deploy-env-sandbox.yml
@@ -65,7 +65,7 @@ jobs:
         uses: ./.github/actions/cdk-deploy
         with:
           cdk-package-path: workspaces/cdk
-          stack-name: JaypieDocumentation JaypieGardenData JaypieGardenApi JaypieGardenNextjs
+          stack-name: JaypieCicd JaypieDocumentation JaypieGardenData JaypieGardenApi JaypieGardenNextjs
         env:
           AUTH0_CLIENT_ID: ${{ vars.AUTH0_CLIENT_ID }}
           AUTH0_CLIENT_SECRET: ${{ secrets.AUTH0_CLIENT_SECRET }}

--- a/.github/workflows/deploy-stacks.yml
+++ b/.github/workflows/deploy-stacks.yml
@@ -19,7 +19,6 @@ on:
         type: choice
         options:
           - all
-          - JaypieCicd
           - JaypieDocumentation
           - JaypieGardenApi
           - JaypieGardenNextjs

--- a/workspaces/cdk/CLAUDE.md
+++ b/workspaces/cdk/CLAUDE.md
@@ -19,11 +19,32 @@ workspaces/cdk/
 │   ├── garden-data-stack.ts    # Garden shared DynamoDB table
 │   └── garden-nextjs-stack.ts  # Garden UI site
 ├── cdk.json             # CDK configuration
+├── lib/
+│   ├── cicd-stack.ts           # CI/CD IAM roles (bootstrap prerequisite)
 ├── package.json
 └── tsconfig.json
 ```
 
 ## Stacks
+
+### CicdStack ⚠️ Bootstrap Prerequisite
+
+Provisions IAM roles required by GitHub Actions workflows. **Must be deployed before other stacks can run in a new AWS account.**
+
+**Stack ID:** `JaypieCicd`
+
+**Resources Created:**
+- IAM role `jaypie-cicd-bedrock-test` — assumed by GitHub Actions via OIDC for Bedrock integration tests
+  - Permissions: `bedrock:InvokeModel`, `bedrock:InvokeModelWithResponseStream`
+  - Trusted repo: `finlaysonstudio/jaypie`
+- CloudFormation output `jaypie-cicd-bedrock-role-arn` — consumed by CI workflows as `AWS_ROLE_ARN`
+
+**Deployment:**
+- **Not included in `all`** in `deploy-stacks.yml` — must be selected explicitly
+- **Not triggered by any branch/tag push** — manual `workflow_dispatch` only via `deploy-stacks.yml`
+- Re-deploy when adding new IAM roles needed by CI/CD
+
+**Connection to workflows:** `.github/actions/configure-aws` assumes the role ARN stored in the GitHub environment variable `AWS_ROLE_ARN`. The Bedrock test role ARN output from this stack is what gets set as that variable.
 
 ### DocumentationStack
 
@@ -284,7 +305,9 @@ Add to workflow:
    - Use `JaypieGitHubDeployRole` construct or manually create OIDC provider
    - Export the provider ARN as `github-oidc-provider` in CloudFormation
 
-3. **Hosted Zone**: Ensure `jaypie.net` hosted zone exists in Route53
+3. **Deploy `JaypieCicd` stack**: Provisions IAM roles consumed by GitHub Actions workflows (see [CicdStack](#cicdstack--bootstrap-prerequisite)). Must be deployed manually via `deploy-stacks.yml` before other workflows can authenticate with AWS.
+
+4. **Hosted Zone**: Ensure `jaypie.net` hosted zone exists in Route53
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

- Added CLAUDE.md files across `.github/` documenting composite actions, workflows, and the IAM bootstrap dependency on `JaypieCicd`
- Restricted `JaypieCicd` stack: now auto-deploys with sandbox (`deploy-env-sandbox.yml`) and removed as a selectable option in `deploy-stacks.yml` (prevents accidental deployment to dev/prod)
- Updated `workspaces/cdk/CLAUDE.md` with `CicdStack` bootstrap prerequisite section and AWS Prerequisites step

## Test plan

- [ ] Verify `deploy-env-sandbox.yml` includes `JaypieCicd` in stack deploy list
- [ ] Verify `deploy-stacks.yml` no longer lists `JaypieCicd` as a dropdown option
- [ ] Confirm CLAUDE.md files render correctly in each directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)