### PR TITLE
feat(kit): add HTTP.HEADER.WEBHOOK_SIGNATURE constant

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6974,7 +6974,6 @@
     },
     "node_modules/@microsoft/api-extractor": {
       "version": "7.57.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@microsoft/api-extractor-model": "7.33.4",
@@ -7007,7 +7006,6 @@
     },
     "node_modules/@microsoft/api-extractor/node_modules/balanced-match": {
       "version": "4.0.4",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
@@ -7015,7 +7013,6 @@
     },
     "node_modules/@microsoft/api-extractor/node_modules/brace-expansion": {
       "version": "5.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -7026,7 +7023,6 @@
     },
     "node_modules/@microsoft/api-extractor/node_modules/lru-cache": {
       "version": "6.0.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -7037,7 +7033,6 @@
     },
     "node_modules/@microsoft/api-extractor/node_modules/minimatch": {
       "version": "10.2.3",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.2"
@@ -7051,7 +7046,6 @@
     },
     "node_modules/@microsoft/api-extractor/node_modules/semver": {
       "version": "7.5.4",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -7065,7 +7059,6 @@
     },
     "node_modules/@microsoft/api-extractor/node_modules/typescript": {
       "version": "5.8.2",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -7077,7 +7070,6 @@
     },
     "node_modules/@microsoft/api-extractor/node_modules/yallist": {
       "version": "4.0.0",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/@microsoft/tsdoc": {
@@ -8452,7 +8444,6 @@
     },
     "node_modules/@rushstack/rig-package": {
       "version": "0.7.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve": "~1.22.1",
@@ -13738,7 +13729,6 @@
     },
     "node_modules/diff": {
       "version": "8.0.3",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -29412,7 +29402,7 @@
         "@jaypie/datadog": "^1.2.2",
         "@jaypie/errors": "^1.2.1",
         "@jaypie/express": "^1.2.23",
-        "@jaypie/kit": "^1.2.8",
+        "@jaypie/kit": "^1.2.9",
         "@jaypie/lambda": "^1.2.8",
         "@jaypie/logger": "^1.2.15"
       },
@@ -29456,7 +29446,7 @@
     },
     "packages/kit": {
       "name": "@jaypie/kit",
-      "version": "1.2.8",
+      "version": "1.2.9",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*",

--- a/packages/jaypie/package.json
+++ b/packages/jaypie/package.json
@@ -37,7 +37,7 @@
     "@jaypie/datadog": "^1.2.2",
     "@jaypie/errors": "^1.2.1",
     "@jaypie/express": "^1.2.23",
-    "@jaypie/kit": "^1.2.8",
+    "@jaypie/kit": "^1.2.9",
     "@jaypie/lambda": "^1.2.8",
     "@jaypie/logger": "^1.2.15"
   },

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/kit",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Utility functions for Jaypie applications",
   "repository": {
     "type": "git",

--- a/packages/kit/src/lib/http.lib.ts
+++ b/packages/kit/src/lib/http.lib.ts
@@ -88,6 +88,7 @@ const HTTP = {
     },
     USER_AGENT: "User-Agent",
     VIA: "Via",
+    WEBHOOK_SIGNATURE: "X-Webhook-Signature",
     WEBHOOK_TOKEN: "X-Webhook-Token",
   },
   METHOD: {

--- a/packages/mcp/release-notes/kit/1.2.9.md
+++ b/packages/mcp/release-notes/kit/1.2.9.md
@@ -1,0 +1,9 @@
+---
+version: 1.2.9
+date: 2026-05-26
+summary: Add X-Webhook-Signature HTTP header constant
+---
+
+## Changes
+
+- Added `HTTP.HEADER.WEBHOOK_SIGNATURE` (`"X-Webhook-Signature"`) to the HTTP header constants


### PR DESCRIPTION
## Summary

- Adds `HTTP.HEADER.WEBHOOK_SIGNATURE` (`"X-Webhook-Signature"`) to `@jaypie/kit` HTTP header constants
- Bumps `@jaypie/kit` to `1.2.9` and updates `jaypie` dependency range

## Test plan

- [ ] NPM Check passes (lint, test, typecheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)