### PR TITLE
feat(llm): set ANTHROPIC.LARGE to claude-opus-4-8

### DIFF
--- a/.github/workflows/npm-check.yml
+++ b/.github/workflows/npm-check.yml
@@ -118,11 +118,11 @@ jobs:
       matrix:
         include:
           - group: anthropic
-            models: "claude-sonnet-4-5,claude-sonnet-4-6,claude-opus-4-5,claude-opus-4-6,claude-opus-4-7,claude-haiku-4-5"
+            models: "claude-sonnet-4-5,claude-sonnet-4-6,claude-opus-4-7,claude-opus-4-8,claude-haiku-4-5"
           - group: openai
-            models: "gpt-5,gpt-5.4,gpt-5.4-mini,gpt-5.4-nano,gpt-5.5"
+            models: "gpt-5.4,gpt-5.4-mini,gpt-5.4-nano,gpt-5.5"
           - group: gemini-xai
-            models: "gemini-3.1-pro-preview,gemini-3-flash-preview,gemini-3.1-flash-lite-preview,grok-latest,grok-4.3-latest,grok-4-1-fast-reasoning,grok-4-1-fast-non-reasoning"
+            models: "gemini-3.1-pro-preview,gemini-3-flash-preview,gemini-3.1-flash-lite-preview,grok-4.3-latest,grok-4.20-0309-reasoning,grok-4.20-0309-non-reasoning,grok-4-1-fast-reasoning,grok-4-1-fast-non-reasoning"
           - group: openrouter
             models: "anthropic/claude-sonnet-4.6,google/gemini-3.1-pro-preview,openai/gpt-5.5,x-ai/grok-4.20"
           - group: bedrock

--- a/.github/workflows/npm-deploy.yml
+++ b/.github/workflows/npm-deploy.yml
@@ -240,11 +240,11 @@ jobs:
       matrix:
         include:
           - group: anthropic
-            models: "claude-sonnet-4-5,claude-sonnet-4-6,claude-opus-4-5,claude-opus-4-6,claude-opus-4-7,claude-haiku-4-5"
+            models: "claude-sonnet-4-5,claude-sonnet-4-6,claude-opus-4-7,claude-opus-4-8,claude-haiku-4-5"
           - group: openai
-            models: "gpt-5,gpt-5.4,gpt-5.4-mini,gpt-5.4-nano,gpt-5.5"
+            models: "gpt-5.4,gpt-5.4-mini,gpt-5.4-nano,gpt-5.5"
           - group: gemini-xai
-            models: "gemini-3.1-pro-preview,gemini-3-flash-preview,gemini-3.1-flash-lite-preview,grok-latest,grok-4.3-latest,grok-4-1-fast-reasoning,grok-4-1-fast-non-reasoning"
+            models: "gemini-3.1-pro-preview,gemini-3-flash-preview,gemini-3.1-flash-lite-preview,grok-4.3-latest,grok-4.20-0309-reasoning,grok-4.20-0309-non-reasoning,grok-4-1-fast-reasoning,grok-4-1-fast-non-reasoning"
           - group: openrouter
             models: "anthropic/claude-sonnet-4.6,google/gemini-3.1-pro-preview,openai/gpt-5.5,x-ai/grok-4.20"
           - group: bedrock

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,12 @@
 ### Error Handling
 - Never throw vanilla `Error`
 - Use `@jaypie/errors` package (ConfigurationError, etc.) for proper error types
+### LLM Models
+When updating LLM model constants, keep all four files in sync:
+- `packages/llm/src/constants.ts` — provider DEFAULT/LARGE/SMALL/TINY constants
+- `packages/llm/test/models.ts` — `MODELS` list exercised by tests
+- `.github/workflows/npm-check.yml` — CI test matrix `models`
+- `.github/workflows/npm-deploy.yml` — deploy test matrix `models`
 ### Lore
 - These are golden numbers: 0.021, 0.146, 0.236, 0.382, and 0.618
 - Start with 0.618 when user suggests "partial" and down as they want less

--- a/package-lock.json
+++ b/package-lock.json
@@ -29419,7 +29419,7 @@
         "typescript-eslint": "^8.46.1"
       },
       "peerDependencies": {
-        "@jaypie/llm": "^1.2.36",
+        "@jaypie/llm": "^1.2.37",
         "@jaypie/mongoose": "^1.2.2"
       },
       "peerDependenciesMeta": {
@@ -29528,7 +29528,7 @@
     },
     "packages/llm": {
       "name": "@jaypie/llm",
-      "version": "1.2.36",
+      "version": "1.2.37",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "*",

--- a/packages/jaypie/package.json
+++ b/packages/jaypie/package.json
@@ -54,7 +54,7 @@
     "typescript-eslint": "^8.46.1"
   },
   "peerDependencies": {
-    "@jaypie/llm": "^1.2.36",
+    "@jaypie/llm": "^1.2.37",
     "@jaypie/mongoose": "^1.2.2"
   },
   "peerDependenciesMeta": {

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/llm",
-  "version": "1.2.36",
+  "version": "1.2.37",
   "description": "Large language model utilities",
   "repository": {
     "type": "git",

--- a/packages/llm/src/constants.ts
+++ b/packages/llm/src/constants.ts
@@ -2,7 +2,7 @@ const FIRST_CLASS_PROVIDER = {
   // https://docs.anthropic.com/en/docs/about-claude/models/overview
   ANTHROPIC: {
     DEFAULT: "claude-sonnet-4-6" as const,
-    LARGE: "claude-opus-4-7" as const,
+    LARGE: "claude-opus-4-8" as const,
     SMALL: "claude-sonnet-4-6" as const,
     TINY: "claude-haiku-4-5" as const,
   },

--- a/packages/llm/test/models.ts
+++ b/packages/llm/test/models.ts
@@ -65,34 +65,31 @@ export const MODELS: readonly ModelConfig[] = [
   // Note: Anthropic does not expose bare-name aliases like `claude-sonnet-4`
   // or `claude-opus-4` — only the dated/versioned ids resolve.
   { model: "claude-sonnet-4-5" },
-  { model: "claude-sonnet-4-6" }, // constants ANTHROPIC.DEFAULT/SMALL
+  { model: "claude-sonnet-4-6" },
 
   // ─── Anthropic Opus 4 ────────────────────────────────────────────────
-  { model: "claude-opus-4-1" },
-  { model: "claude-opus-4-5" },
-  { model: "claude-opus-4-7" }, // constants ANTHROPIC.LARGE
+  { model: "claude-opus-4-6" },
+  { model: "claude-opus-4-7" },
+  { model: "claude-opus-4-8" },
 
   // ─── Anthropic Haiku 4 ───────────────────────────────────────────────
-  { model: "claude-haiku-4-5" }, // constants ANTHROPIC.TINY
+  { model: "claude-haiku-4-5" },
 
   // ─── OpenAI GPT-5 ────────────────────────────────────────────────────
-  { model: "gpt-5" },
-  { model: "gpt-5.1" },
-  { model: "gpt-5-pro" },
-  { model: "gpt-5.4" }, // constants OPENAI.DEFAULT
-  { model: "gpt-5.4-mini" }, // constants OPENAI.SMALL
-  { model: "gpt-5.4-nano" }, // constants OPENAI.TINY
-  { model: "gpt-5.5" }, // constants OPENAI.LARGE
+  { model: "gpt-5.4" },
+  { model: "gpt-5.4-mini" },
+  { model: "gpt-5.4-nano" },
+  { model: "gpt-5.5" },
 
   // ─── Google Gemini 3 ─────────────────────────────────────────────────
-  { model: "gemini-3.1-pro-preview" }, // constants GEMINI.DEFAULT/LARGE
-  { model: "gemini-3-flash-preview" }, // constants GEMINI.SMALL
-  { model: "gemini-3.1-flash-lite-preview" }, // constants GEMINI.TINY
+  { model: "gemini-3.1-pro-preview" },
+  { model: "gemini-3-flash-preview" },
+  { model: "gemini-3.1-flash-lite-preview" },
 
   // ─── xAI Grok 4 ──────────────────────────────────────────────────────
-  { model: "grok-4.20-0309-reasoning" }, // constants XAI.DEFAULT/LARGE
-  { model: "grok-4.20-0309-non-reasoning" }, // constants XAI.SMALL
-  { model: "grok-4-1-fast-non-reasoning" }, // constants XAI.TINY
+  { model: "grok-4.3-latest" },
+  { model: "grok-4.20-0309-reasoning" },
+  { model: "grok-4.20-0309-non-reasoning" },
 
   // ─── OpenRouter routes ───────────────────────────────────────────────
   // OpenRouter forwards image_url and file content parts to the selected

--- a/packages/mcp/release-notes/llm/1.2.37.md
+++ b/packages/mcp/release-notes/llm/1.2.37.md
@@ -1,0 +1,12 @@
+---
+version: 1.2.37
+date: 2026-05-29
+summary: Update Anthropic LARGE model constant to claude-opus-4-8
+---
+
+## @jaypie/llm 1.2.37
+
+### Changes
+
+- **Model constants**: Updated Anthropic `LARGE` to `claude-opus-4-8`
+- **Tests/CI**: Refreshed the Anthropic, OpenAI, and xAI model matrices to current releases


### PR DESCRIPTION
## Summary
- Set `@jaypie/llm` `ANTHROPIC.LARGE` constant to `claude-opus-4-8`
- Refresh the Anthropic, OpenAI, and xAI model matrices in NPM Check/Deploy workflows and `test/models.ts`
- Document keeping the four model-list files in sync in top-level `CLAUDE.md`
- Bump `@jaypie/llm` to 1.2.37, update `jaypie` peer dep range, add release note

🤖 Generated with [Claude Code](https://claude.com/claude-code)