### PR TITLE
feat(dynamodb): add table-rebuild migration primitives

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28666,7 +28666,7 @@
     },
     "packages/dynamodb": {
       "name": "@jaypie/dynamodb",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.726.1",
@@ -29656,7 +29656,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.60",
+      "version": "0.8.61",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.4",
@@ -30061,7 +30061,7 @@
     },
     "packages/testkit": {
       "name": "@jaypie/testkit",
-      "version": "1.2.38",
+      "version": "1.2.39",
       "license": "MIT",
       "dependencies": {
         "jest-extended": "^4.0.2",

--- a/packages/dynamodb/CLAUDE.md
+++ b/packages/dynamodb/CLAUDE.md
@@ -65,10 +65,22 @@ src/
 | Export | Description |
 |--------|-------------|
 | `initClient(config)` | Initialize the DynamoDB client (call once at startup) |
+| `getClient()` | Get the raw DynamoDB client (control-plane: CreateTable/DeleteTable) |
 | `getDocClient()` | Get the initialized Document Client |
 | `getTableName()` | Get the configured table name |
 | `isInitialized()` | Check if client is initialized |
 | `resetClient()` | Reset client state (for testing) |
+
+### Scan and Table Administration
+
+These power table rebuilds (see [Rebuilding a table](#rebuilding-a-table-04--06)). All honor the `initClient` config, so they target real AWS or local alike.
+
+| Export | Description |
+|--------|-------------|
+| `scanTable({ tableName?, pageSize? })` | Async generator yielding every raw item via a schema-agnostic `Scan` (paginates internally). `tableName` defaults to the initialized table -- pass the **old** table to read it. |
+| `countTable({ tableName? })` | Total item count via a paginated `COUNT` scan (validation) |
+| `createTable({ tableName?, billingMode?, wait? })` | Create a table with the current registered-model GSI schema; waits until `ACTIVE` by default. Returns `{ created, message, tableName }` |
+| `destroyTable({ tableName })` | Delete a table. `tableName` is **required** (no default) -- destroying is intentional |
 
 ### Query Functions
 
@@ -474,6 +486,73 @@ Version 0.5.0 is a breaking change. **Tables must be recreated** (pre-1.0 breaki
 5. **Remove** manual `createdAt`/`updatedAt` assignment -- `indexEntity` handles it
 6. **Replace** `buildIndexScope`/`buildIndexAlias`/etc. with `buildCompositeKey`
 7. **Update** `scope` from required to optional in query call sites (if desired)
+
+### Rebuilding a table (0.4 → 0.6)
+
+The 0.5.0 primary-key change means a table **cannot be migrated in place** -- DynamoDB cannot alter a primary key. The pattern is a one-off, human-in-the-loop cutover to a new physical table, validated before the old one is destroyed. (0.6 adds the `putEntity` → `createEntity`/`updateEntity` rename on top, but no further schema change.)
+
+This is **not** a deploy-step migration. Run it once per environment (local → sandbox → production), watching each step. The package provides the verbs; you provide the transform.
+
+#### Cutover shape (CDK-managed table name, maintenance window)
+
+1. **Deploy the new table** alongside the old one (CDK), with its own name.
+2. **Pause writes** (maintenance window) so the copy can't go stale.
+3. **Run the migration script** below: scan OLD → transform → write NEW, single pass.
+4. **Validate**: `countTable(NEW)` matches `countTable(OLD)`; spot-check a few records.
+5. **Flip** `DYNAMODB_TABLE_NAME` (via `CDK_ENV`) to the new table in a CDK deploy, then resume.
+6. **Destroy the old table** later with `destroyTable({ tableName: OLD })`, once you're confident. It sits untouched as instant rollback until then.
+
+#### Migration script
+
+```ts
+import {
+  createTable,
+  countTable,
+  initClient,
+  scanTable,
+  updateEntity,
+  type StorableEntity,
+} from "@jaypie/dynamodb";
+import { fabricIndex, registerModel } from "@jaypie/fabric";
+
+const OLD = process.env.OLD_TABLE_NAME!;
+const NEW = process.env.DYNAMODB_TABLE_NAME!;
+
+// Register models so createTable builds the 0.6 GSIs
+registerModel({ model: "record", indexes: [fabricIndex(), fabricIndex("alias")] });
+
+// Singleton points at the DESTINATION; scanTable reads the OLD table explicitly
+initClient({ tableName: NEW });
+
+// 0.4 → 0.6 transform: drop `sequence`, strip the old pk/sk attrs.
+// `model` and `scope` survive as plain attributes; indexEntity (inside
+// updateEntity) recomputes every GSI key and the timestamps on write.
+function transform(item: Record<string, unknown>): StorableEntity {
+  const { sequence, pk, sk, ...rest } = item;
+  void sequence;
+  void pk;
+  void sk;
+  return rest as StorableEntity;
+}
+
+await createTable({ tableName: NEW }); // waits until ACTIVE
+
+let migrated = 0;
+for await (const item of scanTable({ tableName: OLD })) {
+  await updateEntity({ entity: transform(item) });
+  migrated += 1;
+}
+
+const sourceCount = await countTable({ tableName: OLD });
+console.log(`Migrated ${migrated} of ${sourceCount} records`);
+if (migrated !== sourceCount) {
+  throw new Error("Count mismatch -- do NOT destroy the old table");
+}
+// Validation passed. Flip CDK_ENV to NEW, deploy, then later:
+//   await destroyTable({ tableName: OLD });
+```
+
+The transform is yours because field semantics are app-specific. `scanTable` issues a raw `Scan`, so it reads the old table regardless of its (now-mismatched) GSI shape; `updateEntity` re-indexes each record into the new schema.
 
 ## Dependencies
 

--- a/packages/dynamodb/package.json
+++ b/packages/dynamodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/dynamodb",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"

--- a/packages/dynamodb/src/__tests__/client.spec.ts
+++ b/packages/dynamodb/src/__tests__/client.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  getClient,
   getDocClient,
   getTableName,
   initClient,
@@ -83,6 +84,22 @@ describe("Client", () => {
       initClient({ tableName: "test-table" });
       expect(() => getDocClient()).not.toThrow();
       expect(getDocClient()).toBeDefined();
+    });
+  });
+
+  describe("getClient", () => {
+    it("is a function", () => {
+      expect(getClient).toBeFunction();
+    });
+
+    it("throws ConfigurationError when not initialized", () => {
+      expect(() => getClient()).toThrow("DynamoDB client not initialized");
+    });
+
+    it("returns the raw client when initialized", () => {
+      initClient({ tableName: "test-table" });
+      expect(() => getClient()).not.toThrow();
+      expect(getClient()).toBeDefined();
     });
   });
 

--- a/packages/dynamodb/src/__tests__/scan.spec.ts
+++ b/packages/dynamodb/src/__tests__/scan.spec.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as clientModule from "../client.js";
+import { countTable, scanTable } from "../scan.js";
+
+const send = vi.fn();
+
+vi.mock("../client.js", async () => {
+  const actual = await vi.importActual("../client.js");
+  return {
+    ...actual,
+    getDocClient: vi.fn(),
+    getTableName: vi.fn(),
+  };
+});
+
+describe("Scan Utilities", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(clientModule.getDocClient).mockReturnValue({
+      send,
+    } as unknown as ReturnType<typeof clientModule.getDocClient>);
+    vi.mocked(clientModule.getTableName).mockReturnValue("default-table");
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("scanTable", () => {
+    it("is a function", () => {
+      expect(scanTable).toBeFunction();
+    });
+
+    it("yields every item across pages", async () => {
+      send
+        .mockResolvedValueOnce({
+          Items: [{ id: "a" }, { id: "b" }],
+          LastEvaluatedKey: { id: "b" },
+        })
+        .mockResolvedValueOnce({ Items: [{ id: "c" }] });
+
+      const items: Array<Record<string, unknown>> = [];
+      for await (const item of scanTable()) {
+        items.push(item);
+      }
+
+      expect(items).toEqual([{ id: "a" }, { id: "b" }, { id: "c" }]);
+      expect(send).toHaveBeenCalledTimes(2);
+    });
+
+    it("defaults to the initialized table name", async () => {
+      send.mockResolvedValueOnce({ Items: [] });
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      for await (const _ of scanTable()) {
+        // drain
+      }
+      const command = send.mock.calls[0][0];
+      expect(command.input.TableName).toBe("default-table");
+    });
+
+    it("scans an explicit table name", async () => {
+      send.mockResolvedValueOnce({ Items: [] });
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      for await (const _ of scanTable({ tableName: "old-table" })) {
+        // drain
+      }
+      const command = send.mock.calls[0][0];
+      expect(command.input.TableName).toBe("old-table");
+    });
+
+    it("handles an empty table", async () => {
+      send.mockResolvedValueOnce({ Items: [] });
+      const items: Array<Record<string, unknown>> = [];
+      for await (const item of scanTable()) {
+        items.push(item);
+      }
+      expect(items).toEqual([]);
+    });
+  });
+
+  describe("countTable", () => {
+    it("is a function", () => {
+      expect(countTable).toBeFunction();
+    });
+
+    it("sums counts across pages", async () => {
+      send
+        .mockResolvedValueOnce({ Count: 2, LastEvaluatedKey: { id: "b" } })
+        .mockResolvedValueOnce({ Count: 3 });
+
+      const count = await countTable({ tableName: "old-table" });
+      expect(count).toBe(5);
+      expect(send).toHaveBeenCalledTimes(2);
+    });
+
+    it("returns 0 for an empty table", async () => {
+      send.mockResolvedValueOnce({ Count: 0 });
+      expect(await countTable()).toBe(0);
+    });
+  });
+});

--- a/packages/dynamodb/src/__tests__/tables.spec.ts
+++ b/packages/dynamodb/src/__tests__/tables.spec.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as clientModule from "../client.js";
+import { createTable, destroyTable } from "../tables.js";
+
+const send = vi.fn();
+
+vi.mock("@aws-sdk/client-dynamodb", () => ({
+  CreateTableCommand: vi.fn().mockImplementation((input) => ({ input })),
+  DeleteTableCommand: vi.fn().mockImplementation((input) => ({ input })),
+  DescribeTableCommand: vi.fn().mockImplementation((input) => ({ input })),
+  waitUntilTableExists: vi.fn().mockResolvedValue({ state: "SUCCESS" }),
+}));
+
+vi.mock("@jaypie/fabric", async () => {
+  const actual = await vi.importActual("@jaypie/fabric");
+  return {
+    ...actual,
+    getAllRegisteredIndexes: vi.fn().mockReturnValue([]),
+  };
+});
+
+vi.mock("../client.js", async () => {
+  const actual = await vi.importActual("../client.js");
+  return {
+    ...actual,
+    getClient: vi.fn(),
+    getTableName: vi.fn(),
+  };
+});
+
+const notFound = Object.assign(new Error("not found"), {
+  name: "ResourceNotFoundException",
+});
+
+describe("Table Administration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(clientModule.getClient).mockReturnValue({
+      send,
+    } as unknown as ReturnType<typeof clientModule.getClient>);
+    vi.mocked(clientModule.getTableName).mockReturnValue("default-table");
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("createTable", () => {
+    it("is a function", () => {
+      expect(createTable).toBeFunction();
+    });
+
+    it("creates a new table and waits for ACTIVE", async () => {
+      send
+        .mockRejectedValueOnce(notFound) // DescribeTable -> not found
+        .mockResolvedValueOnce({}); // CreateTable
+
+      const { CreateTableCommand, waitUntilTableExists } =
+        await import("@aws-sdk/client-dynamodb");
+
+      const result = await createTable({ tableName: "new-table" });
+
+      expect(result.created).toBe(true);
+      expect(result.tableName).toBe("new-table");
+      expect(CreateTableCommand).toHaveBeenCalled();
+      expect(waitUntilTableExists).toHaveBeenCalled();
+    });
+
+    it("does not wait when wait is false", async () => {
+      send.mockRejectedValueOnce(notFound).mockResolvedValueOnce({});
+      const { waitUntilTableExists } = await import("@aws-sdk/client-dynamodb");
+
+      await createTable({ tableName: "new-table", wait: false });
+      expect(waitUntilTableExists).not.toHaveBeenCalled();
+    });
+
+    it("returns created: false when the table already exists", async () => {
+      send.mockResolvedValueOnce({ Table: { TableName: "existing" } });
+      const { CreateTableCommand } = await import("@aws-sdk/client-dynamodb");
+
+      const result = await createTable({ tableName: "existing" });
+
+      expect(result.created).toBe(false);
+      expect(CreateTableCommand).not.toHaveBeenCalled();
+    });
+
+    it("defaults to the initialized table name", async () => {
+      send.mockRejectedValueOnce(notFound).mockResolvedValueOnce({});
+      const result = await createTable();
+      expect(result.tableName).toBe("default-table");
+    });
+
+    it("rethrows non-NotFound describe errors", async () => {
+      send.mockRejectedValueOnce(new Error("boom"));
+      await expect(createTable({ tableName: "x" })).rejects.toThrow("boom");
+    });
+  });
+
+  describe("destroyTable", () => {
+    it("is a function", () => {
+      expect(destroyTable).toBeFunction();
+    });
+
+    it("deletes the named table", async () => {
+      send.mockResolvedValueOnce({});
+      const { DeleteTableCommand } = await import("@aws-sdk/client-dynamodb");
+
+      const result = await destroyTable({ tableName: "old-table" });
+
+      expect(result.destroyed).toBe(true);
+      expect(result.tableName).toBe("old-table");
+      expect(DeleteTableCommand).toHaveBeenCalledWith({
+        TableName: "old-table",
+      });
+    });
+  });
+});

--- a/packages/dynamodb/src/client.ts
+++ b/packages/dynamodb/src/client.ts
@@ -16,6 +16,7 @@ const LOCAL_CREDENTIALS = {
 };
 
 // Module-level state
+let client: DynamoDBClient | null = null;
 let docClient: DynamoDBDocumentClient | null = null;
 let tableName: string | null = null;
 
@@ -42,19 +43,34 @@ export function initClient(config: DynamoClientConfig = {}): void {
     config.credentials ??
     (isLocalEndpoint(endpoint) ? LOCAL_CREDENTIALS : undefined);
 
-  const dynamoClient = new DynamoDBClient({
+  client = new DynamoDBClient({
     ...(credentials && { credentials }),
     ...(endpoint && { endpoint }),
     region,
   });
 
-  docClient = DynamoDBDocumentClient.from(dynamoClient, {
+  docClient = DynamoDBDocumentClient.from(client, {
     marshallOptions: {
       removeUndefinedValues: true,
     },
   });
 
   tableName = config.tableName ?? process.env[ENV_DYNAMODB_TABLE_NAME] ?? null;
+}
+
+/**
+ * Get the initialized raw DynamoDB client (control-plane operations).
+ * Use for table-level commands (CreateTable, DeleteTable); use
+ * `getDocClient()` for item operations.
+ * @throws ConfigurationError if client has not been initialized
+ */
+export function getClient(): DynamoDBClient {
+  if (!client) {
+    throw new ConfigurationError(
+      "DynamoDB client not initialized. Call initClient() first.",
+    );
+  }
+  return client;
 }
 
 /**
@@ -94,6 +110,7 @@ export function isInitialized(): boolean {
  * Reset the client state (primarily for testing)
  */
 export function resetClient(): void {
+  client = null;
   docClient = null;
   tableName = null;
 }

--- a/packages/dynamodb/src/index.ts
+++ b/packages/dynamodb/src/index.ts
@@ -1,5 +1,6 @@
 // Client initialization
 export {
+  getClient,
   getDocClient,
   getTableName,
   initClient,
@@ -45,6 +46,14 @@ export {
 // Unified query function with auto-detect
 export { query } from "./query.js";
 export type { QueryParams } from "./query.js";
+
+// Table scan utilities (schema-agnostic; migration source reader)
+export { countTable, scanTable } from "./scan.js";
+export type { ScanTableOptions } from "./scan.js";
+
+// Table administration (create/destroy; honors initClient config)
+export { createTable, destroyTable } from "./tables.js";
+export type { CreateTableOptions, CreateTableResult } from "./tables.js";
 
 // Seed and export utilities
 export {

--- a/packages/dynamodb/src/mcp/admin/createTable.ts
+++ b/packages/dynamodb/src/mcp/admin/createTable.ts
@@ -3,103 +3,13 @@ import {
   DescribeTableCommand,
   DynamoDBClient,
 } from "@aws-sdk/client-dynamodb";
-import {
-  fabricService,
-  getAllRegisteredIndexes,
-  getGsiAttributeNames,
-  type IndexDefinition,
-} from "@jaypie/fabric";
+import { fabricService } from "@jaypie/fabric";
+
+import { createTableParams } from "../../tableSchema.js";
 
 const DEFAULT_ENDPOINT = "http://127.0.0.1:8000";
 const DEFAULT_REGION = "us-east-1";
 const DEFAULT_TABLE_NAME = "jaypie-local";
-
-// =============================================================================
-// Index → GSI Conversion
-// =============================================================================
-
-/**
- * Build attribute definitions from registered indexes.
- * Primary key is `id` (STRING) only; GSI pk and composite sk attributes
- * are all STRING. A single-field sk (e.g., raw `updatedAt`) is also STRING.
- */
-function buildAttributeDefinitions(
-  indexes: IndexDefinition[],
-): Array<{ AttributeName: string; AttributeType: "S" | "N" }> {
-  const attrs = new Map<string, "S" | "N">();
-
-  // Primary key: id only
-  attrs.set("id", "S");
-
-  for (const index of indexes) {
-    const { pk, sk } = getGsiAttributeNames(index);
-    // All pk attributes are composite strings
-    if (!attrs.has(pk)) attrs.set(pk, "S");
-    if (sk && !attrs.has(sk)) {
-      // Single-field `sequence` remains NUMBER for back-compat callers;
-      // every other sk attribute (composite or not) is STRING.
-      attrs.set(sk, sk === "sequence" ? "N" : "S");
-    }
-  }
-
-  return Array.from(attrs.entries())
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([name, type]) => ({
-      AttributeName: name,
-      AttributeType: type,
-    }));
-}
-
-/**
- * Build GSI definitions from registered indexes
- */
-function buildGSIs(indexes: IndexDefinition[]): Array<{
-  IndexName: string;
-  KeySchema: Array<{ AttributeName: string; KeyType: "HASH" | "RANGE" }>;
-  Projection: { ProjectionType: "ALL" };
-}> {
-  const gsiProjection = { ProjectionType: "ALL" as const };
-
-  return indexes.map((index) => {
-    const { pk, sk } = getGsiAttributeNames(index);
-    const keySchema: Array<{
-      AttributeName: string;
-      KeyType: "HASH" | "RANGE";
-    }> = [{ AttributeName: pk, KeyType: "HASH" }];
-    if (sk) {
-      keySchema.push({ AttributeName: sk, KeyType: "RANGE" });
-    }
-    return {
-      IndexName: pk,
-      KeySchema: keySchema,
-      Projection: gsiProjection,
-    };
-  });
-}
-
-// =============================================================================
-// Table Creation
-// =============================================================================
-
-/**
- * DynamoDB table schema with Jaypie GSI pattern.
- * Primary key is `id` only. GSIs come from models registered via
- * `registerModel()`, shaped by `fabricIndex()`.
- */
-function createTableParams(
-  tableName: string,
-  billingMode: "PAY_PER_REQUEST" | "PROVISIONED",
-) {
-  const allIndexes = getAllRegisteredIndexes();
-
-  return {
-    AttributeDefinitions: buildAttributeDefinitions(allIndexes),
-    BillingMode: billingMode,
-    GlobalSecondaryIndexes: buildGSIs(allIndexes),
-    KeySchema: [{ AttributeName: "id", KeyType: "HASH" as const }],
-    TableName: tableName,
-  };
-}
 
 /**
  * Create DynamoDB table with Jaypie GSI schema

--- a/packages/dynamodb/src/queries.ts
+++ b/packages/dynamodb/src/queries.ts
@@ -12,11 +12,9 @@ import { getDocClient, getTableName } from "./client.js";
 import { ARCHIVED_SUFFIX, DELETED_SUFFIX } from "./constants.js";
 import { buildCompositeKey } from "./keyBuilders.js";
 import type {
-  QueryByAliasParams,
   QueryByCategoryParams,
   QueryByScopeParams,
   QueryByTypeParams,
-  QueryByXidParams,
   QueryResult,
   StorableEntity,
 } from "./types.js";

--- a/packages/dynamodb/src/scan.ts
+++ b/packages/dynamodb/src/scan.ts
@@ -1,0 +1,84 @@
+import { ScanCommand } from "@aws-sdk/lib-dynamodb";
+
+import { getDocClient, getTableName } from "./client.js";
+
+/**
+ * Options for table scans
+ */
+export interface ScanTableOptions {
+  /** Items requested per page (DynamoDB Scan Limit); defaults to AWS max */
+  pageSize?: number;
+  /** Table to scan; defaults to the initialized table name */
+  tableName?: string;
+}
+
+/**
+ * Scan every item in a table, schema-agnostic.
+ *
+ * Yields raw items one at a time, paginating internally via
+ * `LastEvaluatedKey` so large tables stay memory-safe. Unlike the query
+ * functions, this issues a full table `Scan` and does not depend on the
+ * GSI shape -- making it the source-side reader for table rebuilds, where
+ * the old table's indexes no longer match the registered models.
+ *
+ * @param options - Scan options; `tableName` defaults to the initialized table
+ */
+export async function* scanTable(
+  options: ScanTableOptions = {},
+): AsyncGenerator<Record<string, unknown>> {
+  const { pageSize } = options;
+  const docClient = getDocClient();
+  const tableName = options.tableName ?? getTableName();
+
+  let startKey: Record<string, unknown> | undefined;
+
+  do {
+    const { Items, LastEvaluatedKey } = await docClient.send(
+      new ScanCommand({
+        ...(pageSize !== undefined && { Limit: pageSize }),
+        ...(startKey && { ExclusiveStartKey: startKey }),
+        TableName: tableName,
+      }),
+    );
+
+    for (const item of Items ?? []) {
+      yield item as Record<string, unknown>;
+    }
+
+    startKey = LastEvaluatedKey;
+  } while (startKey);
+}
+
+/**
+ * Count every item in a table via a paginated `COUNT` scan.
+ *
+ * Useful for validating a migration -- compare the source and destination
+ * counts before destroying the old table.
+ *
+ * @param options - Scan options; `tableName` defaults to the initialized table
+ * @returns Total item count
+ */
+export async function countTable(
+  options: ScanTableOptions = {},
+): Promise<number> {
+  const docClient = getDocClient();
+  const tableName = options.tableName ?? getTableName();
+
+  let count = 0;
+  let startKey: Record<string, unknown> | undefined;
+
+  do {
+    const { Count, LastEvaluatedKey } = await docClient.send(
+      new ScanCommand({
+        Select: "COUNT",
+        ...(startKey && { ExclusiveStartKey: startKey }),
+        TableName: tableName,
+      }),
+    );
+
+    count += Count ?? 0;
+    startKey = LastEvaluatedKey;
+  } while (startKey);
+
+  return count;
+}

--- a/packages/dynamodb/src/tableSchema.ts
+++ b/packages/dynamodb/src/tableSchema.ts
@@ -1,0 +1,83 @@
+import {
+  getAllRegisteredIndexes,
+  getGsiAttributeNames,
+  type IndexDefinition,
+} from "@jaypie/fabric";
+
+export type BillingMode = "PAY_PER_REQUEST" | "PROVISIONED";
+
+/**
+ * Build attribute definitions from registered indexes.
+ * Primary key is `id` (STRING) only; GSI pk and composite sk attributes
+ * are all STRING. A single-field sk (e.g., raw `updatedAt`) is also STRING.
+ */
+export function buildAttributeDefinitions(
+  indexes: IndexDefinition[],
+): Array<{ AttributeName: string; AttributeType: "S" | "N" }> {
+  const attrs = new Map<string, "S" | "N">();
+
+  // Primary key: id only
+  attrs.set("id", "S");
+
+  for (const index of indexes) {
+    const { pk, sk } = getGsiAttributeNames(index);
+    // All pk attributes are composite strings
+    if (!attrs.has(pk)) attrs.set(pk, "S");
+    if (sk && !attrs.has(sk)) {
+      // Single-field `sequence` remains NUMBER for back-compat callers;
+      // every other sk attribute (composite or not) is STRING.
+      attrs.set(sk, sk === "sequence" ? "N" : "S");
+    }
+  }
+
+  return Array.from(attrs.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([name, type]) => ({
+      AttributeName: name,
+      AttributeType: type,
+    }));
+}
+
+/**
+ * Build GSI definitions from registered indexes
+ */
+export function buildGSIs(indexes: IndexDefinition[]): Array<{
+  IndexName: string;
+  KeySchema: Array<{ AttributeName: string; KeyType: "HASH" | "RANGE" }>;
+  Projection: { ProjectionType: "ALL" };
+}> {
+  const gsiProjection = { ProjectionType: "ALL" as const };
+
+  return indexes.map((index) => {
+    const { pk, sk } = getGsiAttributeNames(index);
+    const keySchema: Array<{
+      AttributeName: string;
+      KeyType: "HASH" | "RANGE";
+    }> = [{ AttributeName: pk, KeyType: "HASH" }];
+    if (sk) {
+      keySchema.push({ AttributeName: sk, KeyType: "RANGE" });
+    }
+    return {
+      IndexName: pk,
+      KeySchema: keySchema,
+      Projection: gsiProjection,
+    };
+  });
+}
+
+/**
+ * Build DynamoDB CreateTable params for the Jaypie GSI pattern.
+ * Primary key is `id` only. GSIs come from models registered via
+ * `registerModel()`, shaped by `fabricIndex()`.
+ */
+export function createTableParams(tableName: string, billingMode: BillingMode) {
+  const allIndexes = getAllRegisteredIndexes();
+
+  return {
+    AttributeDefinitions: buildAttributeDefinitions(allIndexes),
+    BillingMode: billingMode,
+    GlobalSecondaryIndexes: buildGSIs(allIndexes),
+    KeySchema: [{ AttributeName: "id", KeyType: "HASH" as const }],
+    TableName: tableName,
+  };
+}

--- a/packages/dynamodb/src/tables.ts
+++ b/packages/dynamodb/src/tables.ts
@@ -1,0 +1,101 @@
+import {
+  CreateTableCommand,
+  DeleteTableCommand,
+  DescribeTableCommand,
+  waitUntilTableExists,
+} from "@aws-sdk/client-dynamodb";
+
+import { getClient, getTableName } from "./client.js";
+import { type BillingMode, createTableParams } from "./tableSchema.js";
+
+const DEFAULT_WAIT_SECONDS = 120;
+
+/**
+ * Options for `createTable`
+ */
+export interface CreateTableOptions {
+  /** DynamoDB billing mode (default: PAY_PER_REQUEST) */
+  billingMode?: BillingMode;
+  /** Table name to create; defaults to the initialized table name */
+  tableName?: string;
+  /** Wait until the table is ACTIVE before resolving (default: true) */
+  wait?: boolean;
+}
+
+/**
+ * Result of `createTable`
+ */
+export interface CreateTableResult {
+  /** Whether a table was created (false if it already existed) */
+  created: boolean;
+  /** Human-readable outcome */
+  message: string;
+  /** The table name */
+  tableName: string;
+}
+
+/**
+ * Create a DynamoDB table with the Jaypie GSI schema.
+ *
+ * GSIs are derived from models registered via `registerModel()`. Uses the
+ * initialized client (`initClient`), so it targets real AWS or local
+ * depending on that config. Waits until the table is ACTIVE by default --
+ * required before writing during a migration.
+ *
+ * @param options - Create options; `tableName` defaults to the initialized table
+ */
+export async function createTable(
+  options: CreateTableOptions = {},
+): Promise<CreateTableResult> {
+  const { billingMode = "PAY_PER_REQUEST", wait = true } = options;
+  const client = getClient();
+  const tableName = options.tableName ?? getTableName();
+
+  try {
+    await client.send(new DescribeTableCommand({ TableName: tableName }));
+    return {
+      created: false,
+      message: `Table "${tableName}" already exists`,
+      tableName,
+    };
+  } catch (error) {
+    if ((error as { name?: string }).name !== "ResourceNotFoundException") {
+      throw error;
+    }
+  }
+
+  await client.send(
+    new CreateTableCommand(createTableParams(tableName, billingMode)),
+  );
+
+  if (wait) {
+    await waitUntilTableExists(
+      { client, maxWaitTime: DEFAULT_WAIT_SECONDS },
+      { TableName: tableName },
+    );
+  }
+
+  return {
+    created: true,
+    message: `Table "${tableName}" created`,
+    tableName,
+  };
+}
+
+/**
+ * Delete a DynamoDB table.
+ *
+ * `tableName` is required with no default -- deleting a table is destructive
+ * and must be intentional. Uses the initialized client (`initClient`).
+ *
+ * @param params - Must specify the table name to delete
+ */
+export async function destroyTable({
+  tableName,
+}: {
+  tableName: string;
+}): Promise<{ destroyed: boolean; tableName: string }> {
+  const client = getClient();
+  await client.send(new DeleteTableCommand({ TableName: tableName }));
+  return { destroyed: true, tableName };
+}

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.60",
+  "version": "0.8.61",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/dynamodb/0.6.2.md
+++ b/packages/mcp/release-notes/dynamodb/0.6.2.md
@@ -1,0 +1,32 @@
+---
+version: 0.6.2
+date: 2026-05-29
+summary: Add schema-agnostic scanTable/countTable and createTable/destroyTable to support table-rebuild migrations
+---
+
+## New
+
+Table-rebuild primitives. The 0.5.0 primary-key change cannot be migrated in
+place, so moving from 0.4.x requires copying records into a new table. These
+exports provide the verbs; the per-record transform stays application-specific.
+
+- **`scanTable({ tableName?, pageSize? })`**: async generator yielding every
+  raw item via a schema-agnostic `Scan`, paginating internally. Unlike the
+  query functions it does not depend on the GSI shape, so it reads an old
+  (0.4.x) table whose indexes no longer match the registered models. Pass an
+  explicit `tableName` to read a table other than the initialized one.
+- **`countTable({ tableName? })`**: total item count via a paginated `COUNT`
+  scan -- compare source and destination before destroying the old table.
+- **`createTable({ tableName?, billingMode?, wait? })`**: create a table with
+  the registered-model GSI schema, honoring the `initClient` config (real AWS
+  or local). Waits until the table is `ACTIVE` by default.
+- **`destroyTable({ tableName })`**: delete a table. `tableName` is required
+  with no default -- deleting is destructive and must be intentional.
+- **`getClient()`**: the raw `DynamoDBClient` (control-plane), alongside the
+  existing `getDocClient()` (data-plane).
+
+## Docs
+
+- New "Rebuilding a table (0.4 → 0.6)" guide documenting the CDK-managed,
+  maintenance-window cutover: deploy new table → scan/transform/write →
+  validate counts → flip `DYNAMODB_TABLE_NAME` → destroy old table later.

--- a/packages/mcp/release-notes/mcp/0.8.61.md
+++ b/packages/mcp/release-notes/mcp/0.8.61.md
@@ -1,0 +1,13 @@
+---
+version: 0.8.61
+date: 2026-05-29
+summary: Document @jaypie/dynamodb table-rebuild primitives and the table-rebuild migration pattern
+---
+
+## Changes
+
+- `skill("dynamodb")`: document `getClient`, `scanTable`, `countTable`,
+  `createTable`, and `destroyTable`, plus a "Rebuilding a table" section
+  covering the one-off, validated cutover from a 0.4.x table to the 0.5.0+
+  schema (distinct from the deploy-time `JaypieMigration` in
+  `skill("migrations")`).

--- a/packages/mcp/release-notes/testkit/1.2.39.md
+++ b/packages/mcp/release-notes/testkit/1.2.39.md
@@ -1,0 +1,11 @@
+---
+version: 1.2.39
+date: 2026-05-29
+summary: Mock the new @jaypie/dynamodb table-rebuild exports
+---
+
+## Changes
+
+- Add mocks for `@jaypie/dynamodb` 0.6.2 exports: `getClient`, `scanTable`
+  (empty async generator), `countTable` (resolves `0`), `createTable`
+  (resolves a success result), and `destroyTable`.

--- a/packages/mcp/skills/dynamodb.md
+++ b/packages/mcp/skills/dynamodb.md
@@ -68,10 +68,22 @@ initClient({
 | Function | Description |
 |----------|-------------|
 | `initClient(config?)` | Initialize the DynamoDB client (call once) |
+| `getClient()` | Get the raw client for control-plane ops (CreateTable/DeleteTable) |
 | `getDocClient()` | Get the initialized Document Client |
 | `getTableName()` | Get the configured table name |
 | `isInitialized()` | Check if client is initialized |
 | `resetClient()` | Reset client state (for testing) |
+
+### Scan and Table Administration
+
+Schema-agnostic table operations that honor the `initClient` config (real AWS or local). These are the building blocks for table rebuilds.
+
+| Function | Description |
+|----------|-------------|
+| `scanTable({ tableName?, pageSize? })` | Async generator yielding every raw item via a full `Scan` (paginates internally). Reads any table regardless of GSI shape -- pass the old table during a rebuild. |
+| `countTable({ tableName? })` | Total item count via paginated `COUNT` scan (validation) |
+| `createTable({ tableName?, billingMode?, wait? })` | Create a table with the registered-model GSI schema; waits until `ACTIVE` by default |
+| `destroyTable({ tableName })` | Delete a table; `tableName` required (no default) |
 
 ### Constants
 
@@ -438,6 +450,30 @@ Version 0.5.0 is a breaking change. **Tables must be recreated** (pre-1.0 breaki
 | `buildIndexScope`, `buildIndexAlias`, etc. | Removed; use `buildCompositeKey` |
 | `DEFAULT_INDEXES` implicit fallback | Must `registerModel()` with `fabricIndex()` before querying |
 | Callers set `createdAt`/`updatedAt` | `indexEntity` manages both automatically |
+
+### Rebuilding a table
+
+The 0.5.0 primary-key change cannot be applied in place (DynamoDB cannot alter a primary key). The migration is a one-off, human-in-the-loop cutover to a new physical table, validated before destroying the old one. Run it once per environment, not as a deploy step. (Distinct from `JaypieMigration` in `skill("migrations")`, which runs CDK custom resources on every deploy.)
+
+Cutover (CDK-managed table name, maintenance window):
+
+1. Deploy the new table alongside the old (CDK).
+2. Pause writes so the copy can't go stale.
+3. Run a script: `scanTable({ tableName: OLD })` → transform → `updateEntity` (writes to the new table = the `initClient` singleton).
+4. Validate: `countTable(NEW)` matches `countTable(OLD)`; spot-check records.
+5. Flip `DYNAMODB_TABLE_NAME` (via `CDK_ENV`) to the new table and deploy; resume.
+6. `destroyTable({ tableName: OLD })` later, once confident (it is your rollback until then).
+
+```ts
+initClient({ tableName: NEW });        // singleton → destination
+await createTable({ tableName: NEW }); // new schema, waits ACTIVE
+for await (const item of scanTable({ tableName: OLD })) {
+  const { sequence, pk, sk, ...rest } = item;   // 0.4 → 0.6 transform
+  await updateEntity({ entity: rest });          // re-indexes + re-timestamps
+}
+```
+
+`scanTable` issues a raw `Scan`, so it reads the old table despite its mismatched GSIs; the transform is yours (field semantics are app-specific).
 
 ## See Also
 

--- a/packages/testkit/package.json
+++ b/packages/testkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/testkit",
-  "version": "1.2.38",
+  "version": "1.2.39",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"

--- a/packages/testkit/src/mock/dynamodb.ts
+++ b/packages/testkit/src/mock/dynamodb.ts
@@ -1,11 +1,14 @@
 import * as original from "@jaypie/dynamodb";
 import type {
   BaseQueryOptions,
+  CreateTableOptions,
+  CreateTableResult,
   DynamoClientConfig,
   ExportResult,
   ParentReference,
   QueryParams,
   QueryResult,
+  ScanTableOptions,
   SeedOptions,
   SeedResult,
   StorableEntity,
@@ -47,6 +50,10 @@ export const initClient = createMockFunction<
 >(() => {
   // No-op in mock
 });
+
+export const getClient = createMockFunction(() => ({
+  send: createMockResolvedFunction({}),
+}));
 
 export const getDocClient = createMockFunction(() => ({
   send: createMockResolvedFunction({ Items: [] }),
@@ -211,13 +218,43 @@ export const exportEntitiesToJson = createMockFunction<
   (model: string, scope: string, pretty?: boolean) => Promise<string>
 >(async () => "[]");
 
+// Scan utilities — yields nothing by default
+export const scanTable = createMockFunction<
+  (options?: ScanTableOptions) => AsyncGenerator<Record<string, unknown>>
+>(async function* () {
+  // No items in mock
+});
+
+export const countTable = createMockFunction<
+  (options?: ScanTableOptions) => Promise<number>
+>(async () => 0);
+
+// Table administration — no-op success by default
+export const createTable = createMockFunction<
+  (options?: CreateTableOptions) => Promise<CreateTableResult>
+>(async (options) => ({
+  created: true,
+  message: "Table created",
+  tableName: options?.tableName ?? "mock-table",
+}));
+
+export const destroyTable = createMockFunction<
+  (params: { tableName: string }) => Promise<{
+    destroyed: boolean;
+    tableName: string;
+  }>
+>(async ({ tableName }) => ({ destroyed: true, tableName }));
+
 // Re-export types for convenience
 export type {
   BaseQueryOptions,
+  CreateTableOptions,
+  CreateTableResult,
   ExportResult,
   ParentReference,
   QueryParams,
   QueryResult,
+  ScanTableOptions,
   SeedOptions,
   SeedResult,
   StorableEntity,

--- a/workspaces/documentation/docs/experimental/dynamodb.md
+++ b/workspaces/documentation/docs/experimental/dynamodb.md
@@ -51,6 +51,15 @@ npm install @jaypie/dynamodb
 | `exportEntities` | Export entities by model/scope |
 | `exportEntitiesToJson` | Export as JSON string |
 
+### Scan and Table Administration
+
+| Function | Purpose |
+|----------|---------|
+| `scanTable` | Async generator over every raw item (schema-agnostic `Scan`) |
+| `countTable` | Total item count via paginated `COUNT` scan |
+| `createTable` | Create a table with the registered-model GSI schema |
+| `destroyTable` | Delete a table (`tableName` required) |
+
 ## StorableEntity Interface
 
 All entities implement this interface:
@@ -298,13 +307,51 @@ const json = await exportEntitiesToJson("lang", APEX);        // Pretty
 const compact = await exportEntitiesToJson("lang", APEX, false); // Compact
 ```
 
+## Rebuilding a Table
+
+The 0.5.0 primary-key change cannot be applied in place — DynamoDB cannot alter a primary key. Moving a populated 0.4.x table forward is a one-off, validated cutover to a new physical table. Run it once per environment (not on every deploy; that is `JaypieMigration`).
+
+With a CDK-managed table name and a maintenance window:
+
+1. Deploy the new table alongside the old (CDK).
+2. Pause writes so the copy cannot go stale.
+3. Scan the old table, transform each record, write to the new table.
+4. Validate: `countTable` matches on both; spot-check records.
+5. Flip `DYNAMODB_TABLE_NAME` to the new table via CDK deploy; resume.
+6. `destroyTable` the old table later, once confident — it is your rollback until then.
+
+```typescript
+import {
+  countTable,
+  createTable,
+  initClient,
+  scanTable,
+  updateEntity,
+} from "@jaypie/dynamodb";
+
+initClient({ tableName: NEW });        // singleton → destination
+await createTable({ tableName: NEW }); // new schema, waits until ACTIVE
+
+for await (const item of scanTable({ tableName: OLD })) {
+  const { sequence, pk, sk, ...rest } = item; // 0.4 → 0.6 transform
+  await updateEntity({ entity: rest });        // re-indexes + re-timestamps
+}
+
+if ((await countTable({ tableName: OLD })) !== (await countTable())) {
+  throw new Error("Count mismatch — do NOT destroy the old table");
+}
+// Validated. Flip CDK_ENV to NEW, deploy, then later: destroyTable({ tableName: OLD })
+```
+
+`scanTable` issues a raw `Scan`, so it reads the old table despite its mismatched GSIs. The transform is application-specific; `updateEntity` recomputes every GSI key and timestamp on write.
+
 ## MCP Tools
 
 Local development tools via `@jaypie/mcp`:
 
 - `dynamodb_query` - Query entities
 - `dynamodb_get` - Get single entity
-- `dynamodb_put` - Create entity
+- `dynamodb_create` - Create entity
 - `dynamodb_update` - Update entity
 - `dynamodb_delete` - Delete entity
 


### PR DESCRIPTION
## Summary

Adds schema-agnostic table-rebuild primitives to `@jaypie/dynamodb` to support the 0.4 → 0.6 migration (primary-key change requires a physical table rebuild).

- `scanTable` — async generator over every raw item (schema-agnostic `Scan`, reads tables despite mismatched GSIs)
- `countTable` — total item count via paginated `COUNT` scan (validation)
- `createTable` / `destroyTable` — control-plane table provisioning with the registered-model GSI schema
- `getClient` — exposes the raw `DynamoDBClient` for control-plane work
- Extracted shared `tableSchema.ts` (`createTableParams`) used by both the MCP admin handler and `createTable`

The rebuild pattern composes: `scanTable(OLD)` → user transform → `updateEntity(NEW)` → `countTable` validation → `destroyTable(OLD)`.

## Docs & Mocks

- Migration guide added to `packages/dynamodb/CLAUDE.md`, `packages/mcp/skills/dynamodb.md`, and jaypie.net experimental docs
- testkit mocks added for all new exports
- Release notes for dynamodb 0.6.2, testkit 1.2.39, mcp 0.8.61

## Versions

- `@jaypie/dynamodb` 0.6.1 → 0.6.2
- `@jaypie/testkit` 1.2.38 → 1.2.39
- `@jaypie/mcp` 0.8.60 → 0.8.61

🤖 Generated with [Claude Code](https://claude.com/claude-code)
