### PR TITLE
docs(dynamodb): import ConflictError from jaypie, not @jaypie/dynamodb

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29656,7 +29656,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.62",
+      "version": "0.8.63",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.4",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.62",
+  "version": "0.8.63",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/mcp/0.8.63.md
+++ b/packages/mcp/release-notes/mcp/0.8.63.md
@@ -1,0 +1,15 @@
+---
+version: 0.8.63
+date: 2026-05-31
+summary: Fix the dynamodb skill's Atomic Conditional Writes example to import ConflictError from jaypie, not @jaypie/dynamodb
+---
+
+## Fixed
+
+- **`dynamodb` skill**. The "Atomic Conditional Writes" example imported
+  `ConflictError` from `@jaypie/dynamodb`, which does not re-export it — the
+  import threw at runtime. `ConflictError` lives in `@jaypie/errors` (and the
+  `jaypie` umbrella); the example now imports it from `jaypie` while keeping
+  `transactWriteEntities` from `@jaypie/dynamodb`.
+
+Issue: [#357](https://github.com/finlaysonstudio/jaypie/issues/357)

--- a/packages/mcp/skills/dynamodb.md
+++ b/packages/mcp/skills/dynamodb.md
@@ -181,8 +181,11 @@ await destroyEntity({ id: "abc-123" });
 
 Use `conditionalCreate` to write an entity **and** a uniqueness-sentinel row in a single transaction -- both commit or neither does:
 
+`ConflictError` is thrown from `@jaypie/errors` (re-exported by the `jaypie` umbrella); `@jaypie/dynamodb` does not re-export it.
+
 ```typescript
-import { ConflictError, transactWriteEntities } from "@jaypie/dynamodb";
+import { ConflictError } from "jaypie"; // or "@jaypie/errors"
+import { transactWriteEntities } from "@jaypie/dynamodb";
 
 try {
   await transactWriteEntities({


### PR DESCRIPTION
## Summary

Follow-up to #357. The dynamodb skill's **Atomic Conditional Writes** example imported `ConflictError` from `@jaypie/dynamodb`, which does **not** re-export it — the documented single-import threw at runtime.

`ConflictError` ships from `@jaypie/errors` and is re-exported by the `jaypie` umbrella. The example now imports it from `jaypie` while keeping `transactWriteEntities` from `@jaypie/dynamodb`, with a note clarifying where the error lives.

```ts
import { ConflictError } from "jaypie"; // or "@jaypie/errors"
import { transactWriteEntities } from "@jaypie/dynamodb";
```

Verified against installed `@jaypie/dynamodb@0.6.3`: `ConflictError` is `undefined`, `transactWriteEntities` is a function.

## Version
`@jaypie/mcp` 0.8.62 → 0.8.63 (skill content) + release note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)