### PR TITLE
feat(constructs): JaypieSecret base construct + serviceTag on lambdas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28569,7 +28569,7 @@
     },
     "packages/constructs": {
       "name": "@jaypie/constructs",
-      "version": "1.2.58",
+      "version": "1.2.59",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*",
@@ -29656,7 +29656,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.63",
+      "version": "0.8.64",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.4",

--- a/packages/constructs/CLAUDE.md
+++ b/packages/constructs/CLAUDE.md
@@ -75,7 +75,8 @@ packages/constructs/
 
 | Construct | Description |
 |-----------|-------------|
-| `JaypieEnvSecret` | Environment-aware secrets (provider/consumer pattern) |
+| `JaypieSecret` | Plain Secrets Manager secret (no provider/consumer pattern) |
+| `JaypieEnvSecret` | Environment-aware secrets (provider/consumer pattern; deprecated, removed in 2.0) |
 | `JaypieDatadogSecret` | Datadog API key secret |
 | `JaypieMongoDbSecret` | MongoDB connection secret |
 | `JaypieOpenAiSecret` | OpenAI API key secret |
@@ -379,6 +380,25 @@ export default config;
 ```
 
 Without this configuration, the Lambda Function URL returns a JSON envelope `{ statusCode, headers, body }` instead of streaming HTML, because Lambda's `RESPONSE_STREAM` invoke mode requires the handler to use `streamifyResponse` (which OpenNext's `aws-lambda-streaming` wrapper provides).
+
+### Plain Secret (no provider/consumer)
+
+`JaypieSecret` always creates a secret in the current stack — it never imports across stacks or emits CloudFormation exports. It reads from `process.env[envKey]`, an explicit `value`, or `generateSecretString`, and supports the same SCREAMING_SNAKE_CASE shorthand as `JaypieEnvSecret`. Accepts `roleTag`/`vendorTag`/`removalPolicy` like `JaypieEnvSecret`.
+
+```typescript
+import { JaypieSecret } from "@jaypie/constructs";
+
+// Reads process.env.MY_API_KEY (throws ConfigurationError if unset)
+new JaypieSecret(this, "MY_API_KEY");
+
+// Explicit value or generated string
+new JaypieSecret(this, "DbPassword", {
+  envKey: "DB_PASSWORD",
+  generateSecretString: { excludePunctuation: true, passwordLength: 32 },
+});
+```
+
+`JaypieEnvSecret` extends `JaypieSecret` and is accepted anywhere a `JaypieSecret` is (including `JaypieLambda` `secrets`). `JaypieEnvSecret` is deprecated and will be removed in 2.0.
 
 ### Provider/Consumer Secrets Pattern
 

--- a/packages/constructs/package.json
+++ b/packages/constructs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/constructs",
-  "version": "1.2.58",
+  "version": "1.2.59",
   "description": "CDK constructs for Jaypie applications",
   "repository": {
     "type": "git",

--- a/packages/constructs/src/JaypieBucketQueuedLambda.ts
+++ b/packages/constructs/src/JaypieBucketQueuedLambda.ts
@@ -28,7 +28,13 @@ export class JaypieBucketQueuedLambda
     props.fifo = false; // S3 event notifications are not supported for FIFO queues
     super(scope, id, props);
 
-    const { bucketName, roleTag, vendorTag, bucketOptions = {} } = props;
+    const {
+      bucketName,
+      roleTag,
+      serviceTag,
+      vendorTag,
+      bucketOptions = {},
+    } = props;
 
     // Create S3 Bucket
     this._bucket = new s3.Bucket(this, "Bucket", {
@@ -40,6 +46,9 @@ export class JaypieBucketQueuedLambda
     // Add tags to bucket
     if (roleTag) {
       Tags.of(this._bucket).add(CDK.TAG.ROLE, roleTag);
+    }
+    if (serviceTag) {
+      Tags.of(this._bucket).add(CDK.TAG.SERVICE, serviceTag);
     }
     if (vendorTag) {
       Tags.of(this._bucket).add(CDK.TAG.VENDOR, vendorTag);

--- a/packages/constructs/src/JaypieEnvSecret.ts
+++ b/packages/constructs/src/JaypieEnvSecret.ts
@@ -1,30 +1,15 @@
 import { Construct } from "constructs";
-import {
-  CfnOutput,
-  Fn,
-  SecretValue,
-  Tags,
-  RemovalPolicy,
-  Stack,
-} from "aws-cdk-lib";
+import { CfnOutput, Fn, RemovalPolicy, SecretValue, Tags } from "aws-cdk-lib";
 import * as secretsmanager from "aws-cdk-lib/aws-secretsmanager";
-import {
-  ISecret,
-  ISecretAttachmentTarget,
-  RotationSchedule,
-  RotationScheduleOptions,
-} from "aws-cdk-lib/aws-secretsmanager";
-import { IKey } from "aws-cdk-lib/aws-kms";
-import {
-  Grant,
-  IGrantable,
-  PolicyStatement,
-  AddToResourcePolicyResult,
-} from "aws-cdk-lib/aws-iam";
 
 import { ConfigurationError } from "@jaypie/errors";
 
 import { CDK } from "./constants";
+import {
+  BuildSecretContext,
+  JaypieSecret,
+  JaypieSecretProps,
+} from "./JaypieSecret";
 
 // It is a consumer if the environment is ephemeral
 function checkEnvIsConsumer(env = process.env): boolean {
@@ -64,46 +49,33 @@ function exportEnvName(
   return cleanName(rawName);
 }
 
-export interface JaypieEnvSecretProps {
+export interface JaypieEnvSecretProps extends JaypieSecretProps {
   consumer?: boolean;
-  envKey?: string;
   export?: string;
-  generateSecretString?: secretsmanager.SecretStringGenerator;
   provider?: boolean;
-  removalPolicy?: boolean | RemovalPolicy;
-  roleTag?: string;
-  vendorTag?: string;
-  value?: string;
 }
 
-export class JaypieEnvSecret extends Construct implements ISecret {
-  private readonly _envKey?: string;
-  private readonly _secret: secretsmanager.ISecret;
+/**
+ * @deprecated Use {@link JaypieSecret}. JaypieEnvSecret layers an
+ * environment-driven provider/consumer cross-stack pattern on top of
+ * JaypieSecret and will be removed in 2.0.
+ */
+export class JaypieEnvSecret extends JaypieSecret {
+  protected static readonly shorthandPrefix: string = "EnvSecret_";
 
   constructor(
     scope: Construct,
     idOrEnvKey: string,
     props?: JaypieEnvSecretProps,
   ) {
-    // Shorthand detection: treat idOrEnvKey as envKey when envKey prop is
-    // not set and idOrEnvKey either looks like a SCREAMING_SNAKE_CASE env
-    // var name or is already present in process.env. Convention-based
-    // detection ensures missing env vars still go through envKey validation
-    // instead of silently creating an empty secret.
-    const looksLikeEnvKey = /^[A-Z][A-Z0-9_]*$/.test(idOrEnvKey);
-    const treatAsEnvKey =
-      (!props || props.envKey === undefined) &&
-      (looksLikeEnvKey ||
-        (typeof process.env[idOrEnvKey] === "string" &&
-          process.env[idOrEnvKey] !== ""));
+    super(scope, idOrEnvKey, props);
+  }
 
-    const id = treatAsEnvKey ? `EnvSecret_${idOrEnvKey}` : idOrEnvKey;
-
-    super(scope, id);
-
+  protected buildSecret(context: BuildSecretContext): secretsmanager.ISecret {
+    const { envKey, id, treatAsEnvKey } = context;
+    const props = context.props as JaypieEnvSecretProps;
     const {
       consumer = checkEnvIsConsumer(),
-      envKey: envKeyProp,
       export: exportParam,
       generateSecretString,
       provider = checkEnvIsProvider(),
@@ -111,11 +83,7 @@ export class JaypieEnvSecret extends Construct implements ISecret {
       roleTag,
       vendorTag,
       value,
-    } = props || {};
-
-    const envKey = treatAsEnvKey ? idOrEnvKey : envKeyProp;
-
-    this._envKey = envKey;
+    } = props;
 
     let exportName;
 
@@ -144,7 +112,7 @@ export class JaypieEnvSecret extends Construct implements ISecret {
 
     if (consumer) {
       const secretName = Fn.importValue(exportName);
-      this._secret = secretsmanager.Secret.fromSecretNameV2(
+      const secret = secretsmanager.Secret.fromSecretNameV2(
         this,
         id,
         secretName,
@@ -152,134 +120,52 @@ export class JaypieEnvSecret extends Construct implements ISecret {
 
       // Add CfnOutput for consumer secrets
       new CfnOutput(this, `ConsumedName`, {
-        value: this._secret.secretName,
+        value: secret.secretName,
+      });
+
+      return secret;
+    }
+
+    const secretValue =
+      envKey && process.env[envKey] ? process.env[envKey] : value;
+
+    const secret = new secretsmanager.Secret(this, id, {
+      generateSecretString,
+      secretStringValue:
+        !generateSecretString && secretValue
+          ? SecretValue.unsafePlainText(secretValue)
+          : undefined,
+    });
+
+    if (removalPolicy !== undefined) {
+      const policy =
+        typeof removalPolicy === "boolean"
+          ? removalPolicy
+            ? RemovalPolicy.RETAIN
+            : RemovalPolicy.DESTROY
+          : removalPolicy;
+      secret.applyRemovalPolicy(policy);
+    }
+
+    if (roleTag) {
+      Tags.of(secret).add(CDK.TAG.ROLE, roleTag);
+    }
+
+    if (vendorTag) {
+      Tags.of(secret).add(CDK.TAG.VENDOR, vendorTag);
+    }
+
+    if (provider) {
+      new CfnOutput(this, `ProvidedName`, {
+        value: secret.secretName,
+        exportName,
       });
     } else {
-      const secretValue =
-        envKey && process.env[envKey] ? process.env[envKey] : value;
-
-      const secretProps: secretsmanager.SecretProps = {
-        generateSecretString,
-        secretStringValue:
-          !generateSecretString && secretValue
-            ? SecretValue.unsafePlainText(secretValue)
-            : undefined,
-      };
-
-      this._secret = new secretsmanager.Secret(this, id, secretProps);
-
-      if (removalPolicy !== undefined) {
-        const policy =
-          typeof removalPolicy === "boolean"
-            ? removalPolicy
-              ? RemovalPolicy.RETAIN
-              : RemovalPolicy.DESTROY
-            : removalPolicy;
-        this._secret.applyRemovalPolicy(policy);
-      }
-
-      if (roleTag) {
-        Tags.of(this._secret).add(CDK.TAG.ROLE, roleTag);
-      }
-
-      if (vendorTag) {
-        Tags.of(this._secret).add(CDK.TAG.VENDOR, vendorTag);
-      }
-
-      if (provider) {
-        new CfnOutput(this, `ProvidedName`, {
-          value: this._secret.secretName,
-          exportName,
-        });
-      } else {
-        new CfnOutput(this, `CreatedName`, {
-          value: this._secret.secretName,
-        });
-      }
+      new CfnOutput(this, `CreatedName`, {
+        value: secret.secretName,
+      });
     }
-  }
 
-  // IResource implementation
-  public get stack(): Stack {
-    return Stack.of(this);
-  }
-
-  public get env(): { account: string; region: string } {
-    return {
-      account: Stack.of(this).account,
-      region: Stack.of(this).region,
-    };
-  }
-
-  public applyRemovalPolicy(policy: RemovalPolicy): void {
-    this._secret.applyRemovalPolicy(policy);
-  }
-
-  // ISecret implementation
-  public get secretArn(): string {
-    return this._secret.secretArn;
-  }
-
-  public get secretFullArn(): string | undefined {
-    return this._secret.secretFullArn;
-  }
-
-  public get secretName(): string {
-    return this._secret.secretName;
-  }
-
-  public get secretRef(): secretsmanager.SecretReference {
-    return this._secret.secretRef;
-  }
-
-  public get encryptionKey(): IKey | undefined {
-    return this._secret.encryptionKey;
-  }
-
-  public get secretValue(): SecretValue {
-    return this._secret.secretValue;
-  }
-
-  public secretValueFromJson(key: string): SecretValue {
-    return this._secret.secretValueFromJson(key);
-  }
-
-  public grantRead(grantee: IGrantable, versionStages?: string[]): Grant {
-    return this._secret.grantRead(grantee, versionStages);
-  }
-
-  public grantWrite(grantee: IGrantable): Grant {
-    return this._secret.grantWrite(grantee);
-  }
-
-  public addRotationSchedule(
-    id: string,
-    options: RotationScheduleOptions,
-  ): RotationSchedule {
-    return this._secret.addRotationSchedule(id, options);
-  }
-
-  public addToResourcePolicy(
-    statement: PolicyStatement,
-  ): AddToResourcePolicyResult {
-    return this._secret.addToResourcePolicy(statement);
-  }
-
-  public denyAccountRootDelete(): void {
-    this._secret.denyAccountRootDelete();
-  }
-
-  public attach(target: ISecretAttachmentTarget): ISecret {
-    return this._secret.attach(target);
-  }
-
-  public cfnDynamicReferenceKey(
-    options?: Parameters<ISecret["cfnDynamicReferenceKey"]>[0],
-  ): string {
-    return this._secret.cfnDynamicReferenceKey(options);
-  }
-
-  public get envKey(): string | undefined {
-    return this._envKey;
+    return secret;
   }
 }

--- a/packages/constructs/src/JaypieLambda.ts
+++ b/packages/constructs/src/JaypieLambda.ts
@@ -79,6 +79,7 @@ export interface JaypieLambdaProps {
    */
   secrets?: SecretsArrayItem[];
   securityGroups?: ec2.ISecurityGroup[];
+  serviceTag?: string;
   timeout?: Duration | number;
   tracing?: lambda.Tracing;
   vendorTag?: string;
@@ -130,6 +131,7 @@ export class JaypieLambda extends Construct implements lambda.IFunction {
       runtimeManagementMode,
       secrets: secretsInput = [],
       securityGroups,
+      serviceTag,
       timeout = Duration.seconds(CDK.DURATION.LAMBDA_WORKER),
       tracing,
       vendorTag,
@@ -277,6 +279,9 @@ export class JaypieLambda extends Construct implements lambda.IFunction {
 
     if (roleTag) {
       Tags.of(this._lambda).add(CDK.TAG.ROLE, roleTag);
+    }
+    if (serviceTag) {
+      Tags.of(this._lambda).add(CDK.TAG.SERVICE, serviceTag);
     }
     if (vendorTag) {
       Tags.of(this._lambda).add(CDK.TAG.VENDOR, vendorTag);

--- a/packages/constructs/src/JaypieLambda.ts
+++ b/packages/constructs/src/JaypieLambda.ts
@@ -72,8 +72,8 @@ export interface JaypieLambdaProps {
   /**
    * Secrets to make available to the Lambda function.
    *
-   * Supports both JaypieEnvSecret instances and strings:
-   * - JaypieEnvSecret: used directly
+   * Supports both JaypieSecret instances and strings:
+   * - JaypieSecret (including JaypieEnvSecret): used directly
    * - String: creates a JaypieEnvSecret with the string as envKey
    *   (reuses existing secrets within the same scope)
    */
@@ -143,7 +143,7 @@ export class JaypieLambda extends Construct implements lambda.IFunction {
     // Get base environment with defaults
     const environment = jaypieLambdaEnv({ initialEnvironment });
 
-    // Resolve secrets from mixed array (strings and JaypieEnvSecret instances)
+    // Resolve secrets from mixed array (strings and JaypieSecret instances)
     // Use Stack.of(this) to ensure secrets are shared at stack level across all constructs
     const secrets = resolveSecrets(Stack.of(this), secretsInput);
 
@@ -162,7 +162,7 @@ export class JaypieLambda extends Construct implements lambda.IFunction {
       {},
     );
 
-    // Process JaypieEnvSecret array
+    // Process JaypieSecret array
     const jaypieSecretsEnvironment = secrets.reduce<{ [key: string]: string }>(
       (acc, secret) => {
         if (secret.envKey) {
@@ -244,7 +244,7 @@ export class JaypieLambda extends Construct implements lambda.IFunction {
       secret.grantRead(this._lambda);
     });
 
-    // Grant read permissions for JaypieEnvSecrets
+    // Grant read permissions for JaypieSecrets
     secrets.forEach((secret) => {
       secret.grantRead(this._lambda);
     });

--- a/packages/constructs/src/JaypieNextJs.ts
+++ b/packages/constructs/src/JaypieNextJs.ts
@@ -61,8 +61,8 @@ export interface JaypieNextjsProps {
   /**
    * Secrets to make available to the Next.js application.
    *
-   * Supports both JaypieEnvSecret instances and strings:
-   * - JaypieEnvSecret: used directly
+   * Supports both JaypieSecret instances and strings:
+   * - JaypieSecret (including JaypieEnvSecret): used directly
    * - String: creates a JaypieEnvSecret with the string as envKey
    *   (reuses existing secrets within the same scope)
    */
@@ -111,7 +111,7 @@ export class JaypieNextJs extends Construct {
       : props?.nextjsPath || path.join(process.cwd(), "..", "nextjs");
     const paramsAndSecrets = resolveParamsAndSecrets();
 
-    // Resolve secrets from mixed array (strings and JaypieEnvSecret instances)
+    // Resolve secrets from mixed array (strings and JaypieSecret instances)
     // Use Stack.of(this) to ensure secrets are shared at stack level across all constructs
     const secrets = resolveSecrets(Stack.of(this), props?.secrets);
 
@@ -124,7 +124,7 @@ export class JaypieNextJs extends Construct {
       {},
     );
 
-    // Process JaypieEnvSecret array
+    // Process JaypieSecret array
     const jaypieSecretsEnvironment = secrets.reduce<{ [key: string]: string }>(
       (acc, secret) => {
         if (secret.envKey) {
@@ -214,7 +214,7 @@ export class JaypieNextJs extends Construct {
       secret.grantRead(nextjs.serverFunction.lambdaFunction);
     });
 
-    // Grant read permissions for JaypieEnvSecrets
+    // Grant read permissions for JaypieSecrets
     secrets.forEach((secret) => {
       secret.grantRead(nextjs.serverFunction.lambdaFunction);
     });

--- a/packages/constructs/src/JaypieQueuedLambda.ts
+++ b/packages/constructs/src/JaypieQueuedLambda.ts
@@ -62,6 +62,7 @@ export class JaypieQueuedLambda
       runtimeManagementMode,
       secrets = [],
       securityGroups,
+      serviceTag,
       tables = [],
       timeout = Duration.seconds(CDK.DURATION.LAMBDA_WORKER),
       tracing,
@@ -81,6 +82,9 @@ export class JaypieQueuedLambda
     });
     if (roleTag) {
       Tags.of(this._queue).add(CDK.TAG.ROLE, roleTag);
+    }
+    if (serviceTag) {
+      Tags.of(this._queue).add(CDK.TAG.SERVICE, serviceTag);
     }
     if (vendorTag) {
       Tags.of(this._queue).add(CDK.TAG.VENDOR, vendorTag);
@@ -120,6 +124,7 @@ export class JaypieQueuedLambda
       runtimeManagementMode,
       secrets,
       securityGroups,
+      serviceTag,
       tables,
       timeout,
       tracing,

--- a/packages/constructs/src/JaypieSecret.ts
+++ b/packages/constructs/src/JaypieSecret.ts
@@ -1,0 +1,217 @@
+import { Construct } from "constructs";
+import { RemovalPolicy, SecretValue, Stack, Tags } from "aws-cdk-lib";
+import * as secretsmanager from "aws-cdk-lib/aws-secretsmanager";
+import {
+  ISecret,
+  ISecretAttachmentTarget,
+  RotationSchedule,
+  RotationScheduleOptions,
+} from "aws-cdk-lib/aws-secretsmanager";
+import { IKey } from "aws-cdk-lib/aws-kms";
+import {
+  AddToResourcePolicyResult,
+  Grant,
+  IGrantable,
+  PolicyStatement,
+} from "aws-cdk-lib/aws-iam";
+
+import { ConfigurationError } from "@jaypie/errors";
+
+import { CDK } from "./constants";
+
+export interface JaypieSecretProps {
+  envKey?: string;
+  generateSecretString?: secretsmanager.SecretStringGenerator;
+  removalPolicy?: boolean | RemovalPolicy;
+  roleTag?: string;
+  vendorTag?: string;
+  value?: string;
+}
+
+/**
+ * Context handed to {@link JaypieSecret.buildSecret} so subclasses can build the
+ * underlying secret differently (e.g. import vs. create) while reusing the
+ * shared id/envKey resolution and the full ISecret passthrough.
+ */
+export interface BuildSecretContext {
+  envKey?: string;
+  id: string;
+  props: JaypieSecretProps;
+  treatAsEnvKey: boolean;
+}
+
+export class JaypieSecret extends Construct implements ISecret {
+  // Construct id prefix used when an envKey is detected via shorthand.
+  // Subclasses override this to preserve their own naming conventions.
+  protected static readonly shorthandPrefix: string = "Secret_";
+
+  protected readonly _envKey?: string;
+  protected readonly _secret: secretsmanager.ISecret;
+
+  constructor(scope: Construct, idOrEnvKey: string, props?: JaypieSecretProps) {
+    // Shorthand detection: treat idOrEnvKey as envKey when envKey prop is
+    // not set and idOrEnvKey either looks like a SCREAMING_SNAKE_CASE env
+    // var name or is already present in process.env. Convention-based
+    // detection ensures missing env vars still go through envKey validation
+    // instead of silently creating an empty secret.
+    const prefix = (new.target as typeof JaypieSecret).shorthandPrefix;
+    const looksLikeEnvKey = /^[A-Z][A-Z0-9_]*$/.test(idOrEnvKey);
+    const treatAsEnvKey =
+      (!props || props.envKey === undefined) &&
+      (looksLikeEnvKey ||
+        (typeof process.env[idOrEnvKey] === "string" &&
+          process.env[idOrEnvKey] !== ""));
+
+    const id = treatAsEnvKey ? `${prefix}${idOrEnvKey}` : idOrEnvKey;
+
+    super(scope, id);
+
+    const envKey = treatAsEnvKey ? idOrEnvKey : props?.envKey;
+    this._envKey = envKey;
+
+    this._secret = this.buildSecret({
+      envKey,
+      id,
+      props: props || {},
+      treatAsEnvKey,
+    });
+  }
+
+  /**
+   * Builds the underlying secret. The base implementation always creates a new
+   * Secrets Manager secret from an envKey value, an explicit value, or a
+   * generated string. Subclasses may override to import an existing secret or
+   * emit cross-stack outputs.
+   */
+  protected buildSecret(context: BuildSecretContext): secretsmanager.ISecret {
+    const { envKey, id, props } = context;
+    const { generateSecretString, removalPolicy, roleTag, vendorTag, value } =
+      props;
+
+    if (
+      envKey &&
+      !process.env[envKey] &&
+      value === undefined &&
+      !generateSecretString
+    ) {
+      throw new ConfigurationError(
+        `JaypieSecret(${id}): envKey "${envKey}" is empty in process.env and no value or generateSecretString was provided`,
+      );
+    }
+
+    const secretValue =
+      envKey && process.env[envKey] ? process.env[envKey] : value;
+
+    const secret = new secretsmanager.Secret(this, id, {
+      generateSecretString,
+      secretStringValue:
+        !generateSecretString && secretValue
+          ? SecretValue.unsafePlainText(secretValue)
+          : undefined,
+    });
+
+    if (removalPolicy !== undefined) {
+      const policy =
+        typeof removalPolicy === "boolean"
+          ? removalPolicy
+            ? RemovalPolicy.RETAIN
+            : RemovalPolicy.DESTROY
+          : removalPolicy;
+      secret.applyRemovalPolicy(policy);
+    }
+
+    if (roleTag) {
+      Tags.of(secret).add(CDK.TAG.ROLE, roleTag);
+    }
+
+    if (vendorTag) {
+      Tags.of(secret).add(CDK.TAG.VENDOR, vendorTag);
+    }
+
+    return secret;
+  }
+
+  // IResource implementation
+  public get stack(): Stack {
+    return Stack.of(this);
+  }
+
+  public get env(): { account: string; region: string } {
+    return {
+      account: Stack.of(this).account,
+      region: Stack.of(this).region,
+    };
+  }
+
+  public applyRemovalPolicy(policy: RemovalPolicy): void {
+    this._secret.applyRemovalPolicy(policy);
+  }
+
+  // ISecret implementation
+  public get secretArn(): string {
+    return this._secret.secretArn;
+  }
+
+  public get secretFullArn(): string | undefined {
+    return this._secret.secretFullArn;
+  }
+
+  public get secretName(): string {
+    return this._secret.secretName;
+  }
+
+  public get secretRef(): secretsmanager.SecretReference {
+    return this._secret.secretRef;
+  }
+
+  public get encryptionKey(): IKey | undefined {
+    return this._secret.encryptionKey;
+  }
+
+  public get secretValue(): SecretValue {
+    return this._secret.secretValue;
+  }
+
+  public secretValueFromJson(key: string): SecretValue {
+    return this._secret.secretValueFromJson(key);
+  }
+
+  public grantRead(grantee: IGrantable, versionStages?: string[]): Grant {
+    return this._secret.grantRead(grantee, versionStages);
+  }
+
+  public grantWrite(grantee: IGrantable): Grant {
+    return this._secret.grantWrite(grantee);
+  }
+
+  public addRotationSchedule(
+    id: string,
+    options: RotationScheduleOptions,
+  ): RotationSchedule {
+    return this._secret.addRotationSchedule(id, options);
+  }
+
+  public addToResourcePolicy(
+    statement: PolicyStatement,
+  ): AddToResourcePolicyResult {
+    return this._secret.addToResourcePolicy(statement);
+  }
+
+  public denyAccountRootDelete(): void {
+    this._secret.denyAccountRootDelete();
+  }
+
+  public attach(target: ISecretAttachmentTarget): ISecret {
+    return this._secret.attach(target);
+  }
+
+  public cfnDynamicReferenceKey(
+    options?: Parameters<ISecret["cfnDynamicReferenceKey"]>[0],
+  ): string {
+    return this._secret.cfnDynamicReferenceKey(options);
+  }
+
+  public get envKey(): string | undefined {
+    return this._envKey;
+  }
+}

--- a/packages/constructs/src/__tests__/JaypieLambda.spec.ts
+++ b/packages/constructs/src/__tests__/JaypieLambda.spec.ts
@@ -82,6 +82,27 @@ describe("JaypieLambda", () => {
       });
     });
 
+    it("adds service tag when provided", () => {
+      const stack = new Stack();
+      const construct = new JaypieLambda(stack, "TestConstruct", {
+        code: lambda.Code.fromInline("exports.handler = () => {}"),
+        handler: "index.handler",
+        serviceTag: "TEST_SERVICE",
+      });
+      const template = Template.fromStack(stack);
+
+      expect(construct).toBeDefined();
+
+      const mainFunction = findMainLambdaFunction(template);
+      expect(mainFunction).toBeDefined();
+
+      const tags = mainFunction?.Properties?.Tags || [];
+      expect(tags).toContainEqual({
+        Key: CDK.TAG.SERVICE,
+        Value: "TEST_SERVICE",
+      });
+    });
+
     it("adds both role and vendor tags when provided", () => {
       const stack = new Stack();
       const construct = new JaypieLambda(stack, "TestConstruct", {

--- a/packages/constructs/src/__tests__/JaypieSecret.spec.ts
+++ b/packages/constructs/src/__tests__/JaypieSecret.spec.ts
@@ -1,0 +1,271 @@
+import { ConfigurationError } from "@jaypie/errors";
+import { expect, it, describe, afterEach } from "vitest";
+import { RemovalPolicy, Stack } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { JaypieEnvSecret } from "../JaypieEnvSecret.js";
+import { JaypieSecret } from "../JaypieSecret.js";
+import { CDK } from "../constants";
+
+describe("JaypieSecret", () => {
+  describe("Base Cases", () => {
+    it("is a function", () => {
+      expect(JaypieSecret).toBeFunction();
+    });
+
+    it("creates a secret", () => {
+      const stack = new Stack();
+      const secret = new JaypieSecret(stack, "TestSecret");
+      const template = Template.fromStack(stack);
+
+      template.hasResourceProperties("AWS::SecretsManager::Secret", {});
+      expect(secret).toBeDefined();
+    });
+
+    it("is a JaypieSecret and JaypieEnvSecret extends it", () => {
+      const stack = new Stack();
+      const secret = new JaypieSecret(stack, "TestSecret");
+      const envSecret = new JaypieEnvSecret(stack, "TestEnvSecret");
+
+      expect(secret).toBeInstanceOf(JaypieSecret);
+      expect(envSecret).toBeInstanceOf(JaypieSecret);
+      expect(envSecret).toBeInstanceOf(JaypieEnvSecret);
+    });
+  });
+
+  describe("Features", () => {
+    it("adds role tag", () => {
+      const stack = new Stack();
+      const secret = new JaypieSecret(stack, "TestSecret", {
+        roleTag: CDK.ROLE.API,
+      });
+      const template = Template.fromStack(stack);
+
+      expect(secret).toBeDefined();
+      template.resourceCountIs("AWS::SecretsManager::Secret", 1);
+      template.hasResourceProperties("AWS::SecretsManager::Secret", {
+        Tags: [
+          {
+            Key: CDK.TAG.ROLE,
+            Value: CDK.ROLE.API,
+          },
+        ],
+      });
+    });
+
+    it("adds vendor tag", () => {
+      const stack = new Stack();
+      new JaypieSecret(stack, "TestSecret", {
+        vendorTag: CDK.VENDOR.MONGODB,
+      });
+      const template = Template.fromStack(stack);
+
+      template.hasResourceProperties("AWS::SecretsManager::Secret", {
+        Tags: [
+          {
+            Key: CDK.TAG.VENDOR,
+            Value: CDK.VENDOR.MONGODB,
+          },
+        ],
+      });
+    });
+
+    it("uses environment variable value when envKey is set", () => {
+      process.env.TEST_SECRET_VALUE = "env-secret-value";
+      const stack = new Stack();
+      const secret = new JaypieSecret(stack, "TestSecret", {
+        envKey: "TEST_SECRET_VALUE",
+      });
+      const template = Template.fromStack(stack);
+
+      expect(secret).toBeDefined();
+      template.resourceCountIs("AWS::SecretsManager::Secret", 1);
+      template.hasResourceProperties("AWS::SecretsManager::Secret", {
+        SecretString: "env-secret-value",
+      });
+      delete process.env.TEST_SECRET_VALUE;
+    });
+
+    it("falls back to value param when envKey is not in process.env", () => {
+      const stack = new Stack();
+      const secret = new JaypieSecret(stack, "TestSecret", {
+        envKey: "NONEXISTENT_ENV_VALUE",
+        value: "fallback-value",
+      });
+      const template = Template.fromStack(stack);
+
+      expect(secret).toBeDefined();
+      template.resourceCountIs("AWS::SecretsManager::Secret", 1);
+      template.hasResourceProperties("AWS::SecretsManager::Secret", {
+        SecretString: "fallback-value",
+      });
+    });
+
+    it("sets string value when value is string", () => {
+      const stack = new Stack();
+      const secret = new JaypieSecret(stack, "TestSecret", {
+        value: "secret-value",
+      });
+      const template = Template.fromStack(stack);
+
+      expect(secret).toBeDefined();
+      template.resourceCountIs("AWS::SecretsManager::Secret", 1);
+      template.hasResourceProperties("AWS::SecretsManager::Secret", {
+        SecretString: "secret-value",
+      });
+    });
+
+    it("exposes envKey through getter", () => {
+      process.env.TEST_ENV_KEY = "test-value";
+      const stack = new Stack();
+      const secret = new JaypieSecret(stack, "TestSecret", {
+        envKey: "TEST_ENV_KEY",
+      });
+
+      expect(secret.envKey).toBe("TEST_ENV_KEY");
+      delete process.env.TEST_ENV_KEY;
+    });
+
+    it("applies RETAIN removal policy when removalPolicy is true", () => {
+      const stack = new Stack();
+      new JaypieSecret(stack, "TestSecret", {
+        removalPolicy: true,
+      });
+      const template = Template.fromStack(stack);
+
+      template.hasResource("AWS::SecretsManager::Secret", {
+        DeletionPolicy: "Retain",
+        UpdateReplacePolicy: "Retain",
+      });
+    });
+
+    it("applies DESTROY removal policy when removalPolicy is false", () => {
+      const stack = new Stack();
+      new JaypieSecret(stack, "TestSecret", {
+        removalPolicy: false,
+      });
+      const template = Template.fromStack(stack);
+
+      template.hasResource("AWS::SecretsManager::Secret", {
+        DeletionPolicy: "Delete",
+        UpdateReplacePolicy: "Delete",
+      });
+    });
+
+    it("accepts RemovalPolicy enum directly", () => {
+      const stack = new Stack();
+      new JaypieSecret(stack, "TestSecret", {
+        removalPolicy: RemovalPolicy.RETAIN,
+      });
+      const template = Template.fromStack(stack);
+
+      template.hasResource("AWS::SecretsManager::Secret", {
+        DeletionPolicy: "Retain",
+        UpdateReplacePolicy: "Retain",
+      });
+    });
+  });
+
+  describe("No producer/consumer behavior", () => {
+    const originalEnv = { ...process.env };
+
+    afterEach(() => {
+      process.env = { ...originalEnv };
+    });
+
+    it("never imports a secret, even in a personal (consumer) environment", () => {
+      process.env.MY_SECRET = "my-value";
+      process.env.PROJECT_ENV = CDK.ENV.PERSONAL;
+      process.env.PROJECT_KEY = "testproject";
+
+      const stack = new Stack();
+      new JaypieSecret(stack, "MY_SECRET");
+      const template = Template.fromStack(stack);
+
+      // A real secret is created rather than imported via Fn::ImportValue
+      template.resourceCountIs("AWS::SecretsManager::Secret", 1);
+    });
+
+    it("never emits a cross-stack export, even in a sandbox (provider) environment", () => {
+      process.env.MY_SECRET = "my-value";
+      process.env.PROJECT_ENV = CDK.ENV.SANDBOX;
+      process.env.PROJECT_KEY = "testproject";
+
+      const stack = new Stack();
+      new JaypieSecret(stack, "MY_SECRET");
+      const template = Template.fromStack(stack);
+
+      const outputs = template.findOutputs("*");
+      expect(Object.keys(outputs).length).toBe(0);
+    });
+  });
+
+  describe("Error Cases", () => {
+    it("throws ConfigurationError when envKey is set but env var is missing and no value or generateSecretString", () => {
+      delete process.env.MISSING_SECRET;
+      const stack = new Stack();
+      expect(() => {
+        new JaypieSecret(stack, "TestSecret", {
+          envKey: "MISSING_SECRET",
+        });
+      }).toThrow(ConfigurationError);
+    });
+
+    it("throws ConfigurationError when envKey is set but env var is empty string", () => {
+      process.env.EMPTY_SECRET = "";
+      const stack = new Stack();
+      expect(() => {
+        new JaypieSecret(stack, "TestSecret", {
+          envKey: "EMPTY_SECRET",
+        });
+      }).toThrow(ConfigurationError);
+      delete process.env.EMPTY_SECRET;
+    });
+
+    it("does not throw when envKey is missing but value is provided", () => {
+      delete process.env.MISSING_SECRET;
+      const stack = new Stack();
+      expect(() => {
+        new JaypieSecret(stack, "TestSecret", {
+          envKey: "MISSING_SECRET",
+          value: "fallback",
+        });
+      }).not.toThrow();
+    });
+
+    it("does not throw when envKey is missing but generateSecretString is provided", () => {
+      delete process.env.MISSING_SECRET;
+      const stack = new Stack();
+      expect(() => {
+        new JaypieSecret(stack, "TestSecret", {
+          envKey: "MISSING_SECRET",
+          generateSecretString: {},
+        });
+      }).not.toThrow();
+    });
+
+    it("does not throw when no envKey is set (plain secret)", () => {
+      const stack = new Stack();
+      expect(() => {
+        new JaypieSecret(stack, "TestSecret");
+      }).not.toThrow();
+    });
+
+    it("throws ConfigurationError when shorthand env key is missing from process.env", () => {
+      delete process.env.MISSING_SHORTHAND_SECRET;
+      const stack = new Stack();
+      expect(() => {
+        new JaypieSecret(stack, "MISSING_SHORTHAND_SECRET");
+      }).toThrow(ConfigurationError);
+    });
+
+    it("does not throw when shorthand env key is missing but value is provided", () => {
+      delete process.env.MISSING_SHORTHAND_SECRET;
+      const stack = new Stack();
+      expect(() => {
+        new JaypieSecret(stack, "MISSING_SHORTHAND_SECRET", {
+          value: "fallback",
+        });
+      }).not.toThrow();
+    });
+  });
+});

--- a/packages/constructs/src/helpers/resolveSecrets.ts
+++ b/packages/constructs/src/helpers/resolveSecrets.ts
@@ -54,11 +54,11 @@ function getOrCreateSecret(
 }
 
 /**
- * Resolves secrets input to an array of JaypieEnvSecret instances.
+ * Resolves secrets input to an array of JaypieSecret instances.
  *
- * When an item is already a JaypieEnvSecret, it's passed through as-is.
- * When an item is a string, a JaypieEnvSecret is created (or reused from cache)
- * with the string as the envKey.
+ * When an item is already a JaypieSecret (including a JaypieEnvSecret), it's
+ * passed through as-is. When an item is a string, a JaypieEnvSecret is created
+ * (or reused from cache) with the string as the envKey.
  *
  * Secrets are cached per scope to avoid creating duplicate secrets when
  * multiple constructs in the same scope reference the same secret.

--- a/packages/constructs/src/helpers/resolveSecrets.ts
+++ b/packages/constructs/src/helpers/resolveSecrets.ts
@@ -1,27 +1,28 @@
 import { Construct } from "constructs";
 
 import { JaypieEnvSecret, JaypieEnvSecretProps } from "../JaypieEnvSecret.js";
+import { JaypieSecret } from "../JaypieSecret.js";
 
 /**
- * Secrets input type that supports both JaypieEnvSecret instances and strings
- * - JaypieEnvSecret: passed through as-is
- * - string: converted to JaypieEnvSecret with the string as envKey
+ * Secrets input type that supports both JaypieSecret instances and strings
+ * - JaypieSecret (including JaypieEnvSecret subclasses): passed through as-is
+ * - string: converted to a JaypieEnvSecret with the string as envKey
  */
-export type SecretsArrayItem = JaypieEnvSecret | string;
+export type SecretsArrayItem = JaypieSecret | string;
 
 /**
  * Cache for secrets by scope to avoid creating duplicates.
  * Uses WeakMap to allow garbage collection when scopes are no longer referenced.
  */
-const secretsByScope = new WeakMap<Construct, Map<string, JaypieEnvSecret>>();
+const secretsByScope = new WeakMap<Construct, Map<string, JaypieSecret>>();
 
 /**
  * Gets or creates the secrets cache for a given scope.
  */
-function getSecretsCache(scope: Construct): Map<string, JaypieEnvSecret> {
+function getSecretsCache(scope: Construct): Map<string, JaypieSecret> {
   let cache = secretsByScope.get(scope);
   if (!cache) {
-    cache = new Map<string, JaypieEnvSecret>();
+    cache = new Map<string, JaypieSecret>();
     secretsByScope.set(scope, cache);
   }
   return cache;
@@ -35,7 +36,7 @@ function getOrCreateSecret(
   scope: Construct,
   envKey: string,
   props?: Omit<JaypieEnvSecretProps, "envKey">,
-): JaypieEnvSecret {
+): JaypieSecret {
   const cache = getSecretsCache(scope);
   const existingSecret = cache.get(envKey);
 
@@ -88,7 +89,7 @@ function getOrCreateSecret(
 export function resolveSecrets(
   scope: Construct,
   secrets?: SecretsArrayItem[],
-): JaypieEnvSecret[] {
+): JaypieSecret[] {
   if (!secrets || secrets.length === 0) {
     return [];
   }
@@ -97,7 +98,7 @@ export function resolveSecrets(
     if (typeof item === "string") {
       return getOrCreateSecret(scope, item);
     }
-    // Already a JaypieEnvSecret instance
+    // Already a JaypieSecret (or JaypieEnvSecret) instance
     return item;
   });
 }

--- a/packages/constructs/src/index.ts
+++ b/packages/constructs/src/index.ts
@@ -54,6 +54,7 @@ export {
   JaypieOrganizationTrailProps,
 } from "./JaypieOrganizationTrail";
 export { JaypieQueuedLambda } from "./JaypieQueuedLambda";
+export { JaypieSecret, JaypieSecretProps } from "./JaypieSecret";
 export {
   AccountAssignments,
   JaypieSsoPermissions,

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.63",
+  "version": "0.8.64",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/constructs/1.2.59.md
+++ b/packages/mcp/release-notes/constructs/1.2.59.md
@@ -1,0 +1,14 @@
+---
+version: 1.2.59
+date: 2026-06-03
+summary: Add JaypieSecret base construct and serviceTag on lambda constructs
+---
+
+## @jaypie/constructs 1.2.59
+
+### Features
+
+- **JaypieSecret**: New base construct — a plain AWS Secrets Manager secret without the environment-driven provider/consumer cross-stack pattern. Reads its value from `process.env[envKey]`, an explicit `value`, or `generateSecretString`, and throws `ConfigurationError` when an `envKey` resolves to nothing. Supports the same SCREAMING_SNAKE_CASE shorthand as `JaypieEnvSecret` (construct id `Secret_${envKey}`).
+- **JaypieEnvSecret** now extends `JaypieSecret`, layering the env-aware provider/consumer behavior on top via a `buildSecret` override. Existing behavior — including issue #347 cross-stack export names — is preserved. `JaypieEnvSecret` is deprecated and will be removed in 2.0.
+- **resolveSecrets / lambda `secrets`**: `SecretsArrayItem` widened to `JaypieSecret | string`, so any `JaypieSecret` (including `JaypieEnvSecret`) is accepted wherever secrets are passed. Strings still create env-aware `JaypieEnvSecret` instances.
+- **serviceTag**: `JaypieLambda` (and `JaypieExpressLambda`, `JaypieWebSocketLambda` by inheritance) accepts a `serviceTag` prop that applies `CDK.TAG.SERVICE` alongside `roleTag` and `vendorTag`. `JaypieQueuedLambda` propagates it to the SQS queue and `JaypieBucketQueuedLambda` to the S3 bucket.

--- a/packages/mcp/skills/secrets.md
+++ b/packages/mcp/skills/secrets.md
@@ -5,7 +5,30 @@ related: apikey, aws, cdk, variables
 
 # Secret Management
 
-Jaypie uses AWS Secrets Manager for secure credential storage. The `JaypieEnvSecret` construct creates secrets at deploy time from environment variables, and `getEnvSecret` retrieves them at runtime.
+Jaypie uses AWS Secrets Manager for secure credential storage. The `JaypieSecret` and `JaypieEnvSecret` constructs create secrets at deploy time from environment variables, and `getEnvSecret` retrieves them at runtime.
+
+## JaypieSecret vs JaypieEnvSecret
+
+- **`JaypieSecret`** — a plain secret. Always creates a secret in the current stack from `process.env[envKey]`, an explicit `value`, or `generateSecretString`. No cross-stack imports or exports. This is the construct to reach for.
+- **`JaypieEnvSecret`** — extends `JaypieSecret` and adds the environment-driven provider/consumer cross-stack pattern (see [Provider/Consumer Pattern](#providerconsumer-pattern) below). **Deprecated; will be removed in 2.0.**
+
+`JaypieEnvSecret` is a `JaypieSecret`, so it is accepted anywhere a `JaypieSecret` is — including the `secrets` array on `JaypieLambda`. Strings in that array still create env-aware `JaypieEnvSecret` instances.
+
+```typescript
+import { JaypieSecret } from "@jaypie/constructs";
+
+// Reads process.env.MY_API_KEY at deploy time
+// Throws ConfigurationError if unset and no value/generateSecretString given
+new JaypieSecret(this, "MY_API_KEY");
+
+// Generated secret, no env var needed
+new JaypieSecret(this, "DbPassword", {
+  envKey: "DB_PASSWORD",
+  generateSecretString: { excludePunctuation: true, passwordLength: 32 },
+});
+```
+
+Everything below that uses `JaypieEnvSecret` works the same on `JaypieSecret`, except the provider/consumer cross-stack behavior, which is `JaypieEnvSecret`-only.
 
 ## The Pattern
 


### PR DESCRIPTION
## Summary

- Add **`JaypieSecret`**, a plain Secrets Manager construct without the environment-driven producer/consumer cross-stack pattern.
- Refactor **`JaypieEnvSecret`** to extend `JaypieSecret`, overriding only the `buildSecret` seam (consumer import / provider export) and its `EnvSecret_` shorthand prefix — all existing behavior preserved, including issue #347 export names. `JaypieEnvSecret` is deprecated for removal in 2.0.
- Widen `SecretsArrayItem` to `JaypieSecret | string` so any `JaypieSecret` is accepted wherever `JaypieEnvSecret` was (e.g. `JaypieLambda` `secrets`). Strings still create env-aware `JaypieEnvSecret` instances.
- Add a **`serviceTag`** prop (`CDK.TAG.SERVICE`) to `JaypieLambda` (inherited by `JaypieExpressLambda`/`JaypieWebSocketLambda`), propagated to the SQS queue in `JaypieQueuedLambda` and the S3 bucket in `JaypieBucketQueuedLambda`.

## Versions

- `@jaypie/constructs` 1.2.58 → 1.2.59
- `@jaypie/mcp` 0.8.63 → 0.8.64 (release note)

## Tests

- New `JaypieSecret.spec.ts` (21 tests) mirroring the `JaypieEnvSecret` suite plus no-producer/consumer + inheritance checks.
- New `serviceTag` test in `JaypieLambda.spec.ts`.
- Full constructs suite 564 passing; mcp 41 passing.

## Docs

- `packages/constructs/CLAUDE.md` — Secrets table + Plain Secret usage section.
- `packages/mcp/skills/secrets.md` — JaypieSecret vs JaypieEnvSecret.
- `packages/mcp/release-notes/constructs/1.2.59.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)