### PR TITLE
fix(constructs): validate WAF rule names at synth; extract skill("waf")

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28569,7 +28569,7 @@
     },
     "packages/constructs": {
       "name": "@jaypie/constructs",
-      "version": "1.2.59",
+      "version": "1.2.60",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*",
@@ -29656,7 +29656,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.64",
+      "version": "0.8.65",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.4",

--- a/packages/constructs/CLAUDE.md
+++ b/packages/constructs/CLAUDE.md
@@ -283,6 +283,14 @@ further relax specific (path × sub-rule) intersections. Groups not named in
 `allow` keep their existing single-rule emission. `path` and each rule-group
 value accept either a single string or an array.
 
+**Rule name ≠ label (casing trap):** AWS matches `managedRuleOverrides`/`allow`
+on the exact rule **name**, which differs in casing from the **label** seen in
+WAF logs (label `…:core-rule-set:NoUserAgent_Header` → name `NoUserAgent_HEADER`).
+`assertValidWafRuleNames` (in `helpers/`) validates names against
+`AWS_MANAGED_RULE_GROUPS` at synth and throws `ConfigurationError` listing valid
+names; AWS WAF would otherwise silently ignore an unmatched name and keep
+blocking. Custom (non-AWS) rule groups are not validated.
+
 ### Streaming Lambda
 
 For streaming responses, use `createLambdaStreamHandler` from `@jaypie/express` with `JaypieDistribution`:

--- a/packages/constructs/package.json
+++ b/packages/constructs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/constructs",
-  "version": "1.2.59",
+  "version": "1.2.60",
   "description": "CDK constructs for Jaypie applications",
   "repository": {
     "type": "git",

--- a/packages/constructs/src/JaypieDistribution.ts
+++ b/packages/constructs/src/JaypieDistribution.ts
@@ -12,6 +12,7 @@ import { Construct } from "constructs";
 
 import { CDK } from "./constants";
 import {
+  assertValidWafRuleNames,
   constructEnvName,
   constructWafLogBucketName,
   envHostname,
@@ -611,6 +612,9 @@ export class JaypieDistribution
           managedRules = DEFAULT_MANAGED_RULES,
           rateLimitPerIp = DEFAULT_RATE_LIMIT,
         } = wafConfig;
+
+        // Fail synth on rule names AWS WAF would silently ignore (#362)
+        assertValidWafRuleNames({ allow, managedRuleOverrides });
 
         const allowEntries: JaypieWafAllowEntry[] = allow
           ? Array.isArray(allow)

--- a/packages/constructs/src/JaypieWebDeploymentBucket.ts
+++ b/packages/constructs/src/JaypieWebDeploymentBucket.ts
@@ -27,6 +27,7 @@ import { ConfigurationError } from "@jaypie/errors";
 
 import { CDK } from "./constants";
 import {
+  assertValidWafRuleNames,
   constructEnvName,
   constructWafLogBucketName,
   envHostname,
@@ -588,6 +589,9 @@ export class JaypieWebDeploymentBucket extends Construct implements s3.IBucket {
             managedRules = DEFAULT_MANAGED_RULES,
             rateLimitPerIp = DEFAULT_RATE_LIMIT,
           } = wafConfig;
+
+          // Fail synth on rule names AWS WAF would silently ignore (#362)
+          assertValidWafRuleNames({ managedRuleOverrides });
 
           let priority = 0;
           const rules: wafv2.CfnWebACL.RuleProperty[] = [];

--- a/packages/constructs/src/__tests__/JaypieDistribution.spec.ts
+++ b/packages/constructs/src/__tests__/JaypieDistribution.spec.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ConfigurationError } from "@jaypie/errors";
 import { RemovalPolicy, Stack } from "aws-cdk-lib";
 import { Template, Match } from "aws-cdk-lib/assertions";
 import * as acm from "aws-cdk-lib/aws-certificatemanager";
@@ -1755,7 +1756,7 @@ describe("JaypieDistribution", () => {
             allow: [
               {
                 path: "/hooks/*",
-                AWSManagedRulesCommonRuleSet: ["ExploitablePaths_URIPATH"],
+                AWSManagedRulesCommonRuleSet: ["NoUserAgent_HEADER"],
               },
             ],
           },
@@ -1780,7 +1781,7 @@ describe("JaypieDistribution", () => {
             allow: [
               {
                 path: "/hooks/*",
-                AWSManagedRulesCommonRuleSet: ["ExploitablePaths_URIPATH"],
+                AWSManagedRulesCommonRuleSet: ["NoUserAgent_HEADER"],
               },
             ],
           },
@@ -1795,7 +1796,7 @@ describe("JaypieDistribution", () => {
                   Name: "AWSManagedRulesCommonRuleSet",
                   RuleActionOverrides: Match.arrayWith([
                     {
-                      Name: "ExploitablePaths_URIPATH",
+                      Name: "NoUserAgent_HEADER",
                       ActionToUse: { Count: {} },
                     },
                   ]),
@@ -1824,7 +1825,7 @@ describe("JaypieDistribution", () => {
             allow: [
               {
                 path: "/hooks/*",
-                AWSManagedRulesCommonRuleSet: ["ExploitablePaths_URIPATH"],
+                AWSManagedRulesCommonRuleSet: ["NoUserAgent_HEADER"],
               },
             ],
           },
@@ -1857,7 +1858,7 @@ describe("JaypieDistribution", () => {
             allow: [
               {
                 path: "/exact/path",
-                AWSManagedRulesCommonRuleSet: ["ExploitablePaths_URIPATH"],
+                AWSManagedRulesCommonRuleSet: ["NoUserAgent_HEADER"],
               },
             ],
           },
@@ -1895,7 +1896,7 @@ describe("JaypieDistribution", () => {
             allow: [
               {
                 path: ["/hooks/*", "/webhooks/*"],
-                AWSManagedRulesCommonRuleSet: "ExploitablePaths_URIPATH",
+                AWSManagedRulesCommonRuleSet: "NoUserAgent_HEADER",
               },
             ],
           },
@@ -1927,7 +1928,7 @@ describe("JaypieDistribution", () => {
             name: "test",
             allow: {
               path: "/hooks/*",
-              AWSManagedRulesCommonRuleSet: "ExploitablePaths_URIPATH",
+              AWSManagedRulesCommonRuleSet: "NoUserAgent_HEADER",
             },
           },
         });
@@ -1951,7 +1952,7 @@ describe("JaypieDistribution", () => {
             allow: [
               {
                 path: "/hooks/*",
-                AWSManagedRulesCommonRuleSet: ["ExploitablePaths_URIPATH"],
+                AWSManagedRulesCommonRuleSet: ["NoUserAgent_HEADER"],
               },
             ],
           },
@@ -1984,7 +1985,7 @@ describe("JaypieDistribution", () => {
             allow: [
               {
                 path: "/hooks/*",
-                AWSManagedRulesCommonRuleSet: ["ExploitablePaths_URIPATH"],
+                AWSManagedRulesCommonRuleSet: ["NoUserAgent_HEADER"],
               },
             ],
           },
@@ -2011,14 +2012,14 @@ describe("JaypieDistribution", () => {
           []
         ).map((o: any) => o.Name);
         expect(relaxedOverrideNames).toContain("SizeRestrictions_BODY");
-        expect(relaxedOverrideNames).toContain("ExploitablePaths_URIPATH");
+        expect(relaxedOverrideNames).toContain("NoUserAgent_HEADER");
 
         const strictOverrideNames = (
           strict?.Statement?.ManagedRuleGroupStatement?.RuleActionOverrides ??
           []
         ).map((o: any) => o.Name);
         expect(strictOverrideNames).toContain("SizeRestrictions_BODY");
-        expect(strictOverrideNames).not.toContain("ExploitablePaths_URIPATH");
+        expect(strictOverrideNames).not.toContain("NoUserAgent_HEADER");
       });
 
       it("strict NotStatement excludes the union of paths across all entries for a group", () => {
@@ -2033,7 +2034,7 @@ describe("JaypieDistribution", () => {
             allow: [
               {
                 path: "/hooks/*",
-                AWSManagedRulesCommonRuleSet: ["ExploitablePaths_URIPATH"],
+                AWSManagedRulesCommonRuleSet: ["NoUserAgent_HEADER"],
               },
               {
                 path: "/webhooks/*",
@@ -2061,6 +2062,89 @@ describe("JaypieDistribution", () => {
         );
         expect(searchStrings).toContain("/hooks/");
         expect(searchStrings).toContain("/webhooks/");
+      });
+    });
+
+    describe("waf rule-name validation (#362)", () => {
+      const buildWaf = (waf: any) => () => {
+        const stack = new Stack();
+        const bucket = new s3.Bucket(stack, "TestBucket");
+        const origin = origins.S3BucketOrigin.withOriginAccessControl(bucket);
+        new JaypieDistribution(stack, "TestDistribution", {
+          handler: origin,
+          waf,
+        });
+      };
+
+      it("throws ConfigurationError when allow names an unknown rule", () => {
+        // Mixed-case label casing trap: label is NoUserAgent_Header but the
+        // rule name is NoUserAgent_HEADER
+        expect(
+          buildWaf({
+            name: "test",
+            allow: [
+              {
+                path: "/hooks/*",
+                AWSManagedRulesCommonRuleSet: ["NoUserAgent_Header"],
+              },
+            ],
+          }),
+        ).toThrow(ConfigurationError);
+      });
+
+      it("error message lists the valid rule name", () => {
+        expect(
+          buildWaf({
+            name: "test",
+            allow: [
+              {
+                path: "/hooks/*",
+                AWSManagedRulesCommonRuleSet: ["NoUserAgent_Header"],
+              },
+            ],
+          }),
+        ).toThrow("NoUserAgent_HEADER");
+      });
+
+      it("throws ConfigurationError when managedRuleOverrides names an unknown rule", () => {
+        expect(
+          buildWaf({
+            name: "test",
+            managedRuleOverrides: {
+              AWSManagedRulesCommonRuleSet: [
+                { name: "NotARealRule", actionToUse: { count: {} } },
+              ],
+            },
+          }),
+        ).toThrow(ConfigurationError);
+      });
+
+      it("does not throw for a valid rule name", () => {
+        expect(
+          buildWaf({
+            name: "test",
+            allow: [
+              {
+                path: "/hooks/*",
+                AWSManagedRulesCommonRuleSet: ["NoUserAgent_HEADER"],
+              },
+            ],
+          }),
+        ).not.toThrow();
+      });
+
+      it("does not validate unknown/custom rule groups", () => {
+        expect(
+          buildWaf({
+            name: "test",
+            managedRules: ["MyCompanyCustomRuleGroup"],
+            managedRuleOverrides: {
+              MyCompanyCustomRuleGroup: [
+                { name: "AnythingGoesHere", actionToUse: { count: {} } },
+              ],
+            },
+          }),
+        ).not.toThrow();
       });
     });
 

--- a/packages/constructs/src/__tests__/JaypieWebDeploymentBucket.spec.ts
+++ b/packages/constructs/src/__tests__/JaypieWebDeploymentBucket.spec.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ConfigurationError } from "@jaypie/errors";
 import { Stack } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import * as cloudfront from "aws-cdk-lib/aws-cloudfront";
@@ -254,6 +255,23 @@ describe("JaypieWebDeploymentBucket", () => {
       expect(distribution.Properties.DistributionConfig.WebACLId).toBe(
         externalArn,
       );
+    });
+
+    it("throws ConfigurationError when managedRuleOverrides names an unknown rule (#362)", () => {
+      const { stack, zone } = makeStack();
+      expect(() => {
+        new JaypieWebDeploymentBucket(stack, "Web", {
+          host: "app.example.com",
+          zone,
+          waf: {
+            managedRuleOverrides: {
+              AWSManagedRulesCommonRuleSet: [
+                { name: "NotARealRule", actionToUse: { count: {} } },
+              ],
+            },
+          },
+        });
+      }).toThrow(ConfigurationError);
     });
 
     it("truncates long WAF log bucket names to 63 chars while preserving nonce", () => {

--- a/packages/constructs/src/helpers/index.ts
+++ b/packages/constructs/src/helpers/index.ts
@@ -36,3 +36,7 @@ export {
   clearSecretsCache,
   clearAllSecretsCaches,
 } from "./resolveSecrets";
+export {
+  assertValidWafRuleNames,
+  AWS_MANAGED_RULE_GROUPS,
+} from "./wafManagedRuleNames";

--- a/packages/constructs/src/helpers/wafManagedRuleNames.ts
+++ b/packages/constructs/src/helpers/wafManagedRuleNames.ts
@@ -1,0 +1,163 @@
+import { ConfigurationError } from "@jaypie/errors";
+import * as wafv2 from "aws-cdk-lib/aws-wafv2";
+
+/**
+ * Canonical sub-rule names for each AWS managed rule group, as published in the
+ * AWS WAF developer guide. Used to validate `waf.allow` and
+ * `waf.managedRuleOverrides` rule names at synth time — AWS WAF matches
+ * `RuleActionOverride` on the exact rule *name* and silently ignores names that
+ * match no rule, so a typo or a label/name casing mismatch (e.g. the label
+ * `…:NoUserAgent_Header` vs the rule name `NoUserAgent_HEADER`) becomes an
+ * undiagnosable no-op.
+ *
+ * Groups absent from this map (custom rule groups, or AWS groups not yet
+ * mirrored here) are not validated.
+ *
+ * @see https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-list.html
+ */
+export const AWS_MANAGED_RULE_GROUPS: Record<string, readonly string[]> = {
+  AWSManagedRulesAdminProtectionRuleSet: ["AdminProtection_URIPATH"],
+  AWSManagedRulesAmazonIpReputationList: [
+    "AWSManagedIPDDoSList",
+    "AWSManagedIPReputationList",
+    "AWSManagedReconnaissanceList",
+  ],
+  AWSManagedRulesAnonymousIpList: ["AnonymousIPList", "HostingProviderIPList"],
+  AWSManagedRulesCommonRuleSet: [
+    "CrossSiteScripting_BODY",
+    "CrossSiteScripting_COOKIE",
+    "CrossSiteScripting_QUERYARGUMENTS",
+    "CrossSiteScripting_URIPATH",
+    "EC2MetaDataSSRF_BODY",
+    "EC2MetaDataSSRF_COOKIE",
+    "EC2MetaDataSSRF_QUERYARGUMENTS",
+    "EC2MetaDataSSRF_URIPATH",
+    "GenericLFI_BODY",
+    "GenericLFI_QUERYARGUMENTS",
+    "GenericLFI_URIPATH",
+    "GenericRFI_BODY",
+    "GenericRFI_QUERYARGUMENTS",
+    "GenericRFI_URIPATH",
+    "NoUserAgent_HEADER",
+    "RestrictedExtensions_QUERYARGUMENTS",
+    "RestrictedExtensions_URIPATH",
+    "SizeRestrictions_BODY",
+    "SizeRestrictions_Cookie_HEADER",
+    "SizeRestrictions_QUERYSTRING",
+    "SizeRestrictions_URIPATH",
+    "UserAgent_BadBots_HEADER",
+  ],
+  AWSManagedRulesKnownBadInputsRuleSet: [
+    "ExploitablePaths_URIPATH",
+    "Host_localhost_HEADER",
+    "JavaDeserializationRCE_BODY",
+    "JavaDeserializationRCE_HEADER",
+    "JavaDeserializationRCE_QUERYSTRING",
+    "JavaDeserializationRCE_URIPATH",
+    "Log4JRCE_BODY",
+    "Log4JRCE_HEADER",
+    "Log4JRCE_QUERYSTRING",
+    "Log4JRCE_URIPATH",
+    "PROPFIND_METHOD",
+    "ReactJSRCE_BODY",
+  ],
+  AWSManagedRulesLinuxRuleSet: ["LFI_HEADER", "LFI_QUERYSTRING", "LFI_URIPATH"],
+  AWSManagedRulesPHPRuleSet: [
+    "PHPHighRiskMethodsVariables_BODY",
+    "PHPHighRiskMethodsVariables_HEADER",
+    "PHPHighRiskMethodsVariables_QUERYSTRING",
+    "PHPHighRiskMethodsVariables_URIPATH",
+  ],
+  AWSManagedRulesSQLiRuleSet: [
+    "SQLiExtendedPatterns_BODY",
+    "SQLiExtendedPatterns_HEADER",
+    "SQLiExtendedPatterns_QUERYARGUMENTS",
+    "SQLiExtendedPatterns_URIPATH",
+    "SQLi_BODY",
+    "SQLi_COOKIE",
+    "SQLi_QUERYARGUMENTS",
+    "SQLi_URIPATH",
+  ],
+  AWSManagedRulesUnixRuleSet: [
+    "UNIXShellCommandsVariables_BODY",
+    "UNIXShellCommandsVariables_HEADER",
+    "UNIXShellCommandsVariables_QUERYSTRING",
+  ],
+  AWSManagedRulesWindowsRuleSet: [
+    "PowerShellCommands_BODY",
+    "PowerShellCommands_COOKIE",
+    "PowerShellCommands_QUERYARGUMENTS",
+    "WindowsShellCommands_BODY",
+    "WindowsShellCommands_HEADER",
+    "WindowsShellCommands_QUERYARGUMENTS",
+    "WindowsShellCommands_QUERYSTRING",
+    "WindowsShellCommands_URIPATH",
+  ],
+  AWSManagedRulesWordPressRuleSet: [
+    "WordPressExploitableCommands_QUERYSTRING",
+    "WordPressExploitablePaths_URIPATH",
+  ],
+};
+
+/** One entry in a `waf.allow` list. Mirrors JaypieWafAllowEntry structurally. */
+interface WafAllowEntryLike {
+  path: string | string[];
+  [ruleGroupKey: string]: string | string[] | undefined;
+}
+
+interface AssertValidWafRuleNamesOptions {
+  allow?: WafAllowEntryLike | WafAllowEntryLike[];
+  managedRuleOverrides?: Record<
+    string,
+    wafv2.CfnWebACL.RuleActionOverrideProperty[]
+  >;
+}
+
+/**
+ * Throw a ConfigurationError if any `waf.allow` or `waf.managedRuleOverrides`
+ * rule name does not exist in its AWS managed rule group. Groups not present in
+ * AWS_MANAGED_RULE_GROUPS (custom groups) are skipped. A name that matches no
+ * rule would otherwise be silently ignored by AWS WAF.
+ */
+export function assertValidWafRuleNames({
+  allow,
+  managedRuleOverrides,
+}: AssertValidWafRuleNamesOptions = {}): void {
+  // Collect (group → referenced rule name) pairs from both inputs.
+  const references: Array<{ group: string; ruleName: string }> = [];
+
+  if (managedRuleOverrides) {
+    for (const [group, overrides] of Object.entries(managedRuleOverrides)) {
+      for (const override of overrides ?? []) {
+        if (override?.name) references.push({ group, ruleName: override.name });
+      }
+    }
+  }
+
+  const allowEntries = allow ? (Array.isArray(allow) ? allow : [allow]) : [];
+  for (const entry of allowEntries) {
+    for (const key of Object.keys(entry)) {
+      if (key === "path") continue;
+      const raw = entry[key];
+      if (raw == null) continue;
+      const ruleNames = Array.isArray(raw) ? raw : [raw];
+      for (const ruleName of ruleNames) {
+        references.push({ group: key, ruleName });
+      }
+    }
+  }
+
+  for (const { group, ruleName } of references) {
+    const validNames = AWS_MANAGED_RULE_GROUPS[group];
+    if (!validNames) continue; // Unknown/custom group — cannot validate
+    if (!validNames.includes(ruleName)) {
+      throw new ConfigurationError(
+        `WAF rule "${ruleName}" is not a rule in ${group}. AWS WAF matches ` +
+          `RuleActionOverrides on the exact rule name and silently ignores ` +
+          `unmatched names (note the label/name casing trap, e.g. ` +
+          `"NoUserAgent_HEADER" not "NoUserAgent_Header"). Valid rule names: ` +
+          `${validNames.join(", ")}.`,
+      );
+    }
+  }
+}

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.64",
+  "version": "0.8.65",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/constructs/1.2.60.md
+++ b/packages/mcp/release-notes/constructs/1.2.60.md
@@ -1,0 +1,24 @@
+---
+version: 1.2.60
+date: 2026-06-04
+summary: Validate WAF managedRuleOverrides/allow rule names at synth, throwing ConfigurationError on unknown names
+---
+
+## @jaypie/constructs 1.2.60
+
+### Fixed
+
+- **WAF rule-name validation** (`JaypieDistribution`, `JaypieWebDeploymentBucket`).
+  `waf.allow` and `waf.managedRuleOverrides` rule names are now validated against
+  each AWS managed rule group at synth time. AWS WAF matches `RuleActionOverride`
+  on the exact rule **name** and silently ignores any name that matches no rule —
+  so a typo, or the label/name casing trap (label
+  `…:core-rule-set:NoUserAgent_Header` vs rule name `NoUserAgent_HEADER`), used to
+  produce a WebACL that looked correct but kept blocking. Jaypie now throws a
+  `ConfigurationError` listing the valid rule names for the group. Custom
+  (non-AWS) rule groups are not validated.
+
+  New helper `assertValidWafRuleNames` and the canonical `AWS_MANAGED_RULE_GROUPS`
+  map are exported from the package.
+
+Issue: [#362](https://github.com/finlaysonstudio/jaypie/issues/362)

--- a/packages/mcp/release-notes/mcp/0.8.65.md
+++ b/packages/mcp/release-notes/mcp/0.8.65.md
@@ -1,0 +1,17 @@
+---
+version: 0.8.65
+date: 2026-06-04
+summary: Extract WAF guidance into a dedicated skill("waf") with allow prop and rule-name casing trap coverage
+---
+
+## Changed
+
+- **New `waf` skill**. WAF guidance moved out of `skill("cdk")` into a dedicated
+  `skill("waf")`, mirroring how `dns`, `secrets`, and `streaming` are split out.
+  `skill("cdk")` keeps a one-line **See Also → `skill("waf")`** pointer.
+- **`waf` skill** adds coverage of the `waf.allow` path-scoped relaxation prop
+  and the **rule name ≠ label casing trap** (label
+  `…:core-rule-set:NoUserAgent_Header` vs rule name `NoUserAgent_HEADER`), noting
+  that `@jaypie/constructs` now validates rule names at synth.
+
+Issue: [#362](https://github.com/finlaysonstudio/jaypie/issues/362)

--- a/packages/mcp/skills/agents.md
+++ b/packages/mcp/skills/agents.md
@@ -34,7 +34,7 @@ Complete stack styles, techniques, and traditions.
 
 Contents: index, releasenotes
 Development: apikey, documentation, errors, llm, logs, mocks, monorepo, repokit, style, subpackages, tests, tools
-Infrastructure: apigateway, aws, cdk, cicd, datadog, dns, dynamodb, express, lambda, migrations, secrets, sqs, streaming, variables, web, websockets
+Infrastructure: apigateway, aws, cdk, cicd, datadog, dns, dynamodb, express, lambda, migrations, secrets, sqs, streaming, variables, waf, web, websockets
 Patterns: api, fabric, handlers, models, services, vocabulary
 Recipes: recipe-api-server
 Meta: issues, jaypie, mcp, skills

--- a/packages/mcp/skills/cdk.md
+++ b/packages/mcp/skills/cdk.md
@@ -1,6 +1,6 @@
 ---
 description: CDK constructs and deployment patterns
-related: apikey, aws, cicd, dynamodb, express, lambda, migrations, secrets, streaming, web, websockets
+related: apikey, aws, cicd, dynamodb, express, lambda, migrations, secrets, streaming, waf, web, websockets
 ---
 
 # CDK Constructs
@@ -347,89 +347,13 @@ new JaypieDistribution(this, "Dist", {
 
 ## WAF (Web Application Firewall)
 
-`JaypieDistribution` attaches a WAFv2 WebACL by default with:
+`JaypieDistribution` and `JaypieWebDeploymentBucket` attach a WAFv2 WebACL by
+default (CommonRuleSet, KnownBadInputsRuleSet, IP rate limiting, and WAF logging
+to S3 with Datadog forwarding).
 
-- **AWSManagedRulesCommonRuleSet** — OWASP top 10 (SQLi, XSS, etc.)
-- **AWSManagedRulesKnownBadInputsRuleSet** — known bad patterns (Log4j, etc.)
-- **Rate limiting** — 2000 requests per 5 minutes per IP
-- **WAF logging** — S3 bucket with Datadog forwarder notifications
-
-```typescript
-// Default: WAF enabled with logging
-new JaypieDistribution(this, "Dist", { handler });
-
-// Disable WAF entirely
-new JaypieDistribution(this, "Dist", { handler, waf: false });
-
-// Customize rate limit (name required on any waf config object)
-new JaypieDistribution(this, "Dist", {
-  handler,
-  waf: { name: "api", rateLimitPerIp: 500 },
-});
-
-// Multiple distributions in one env — set a unique waf.name on each to
-// avoid WebACL/S3 bucket name collisions between stacks.
-new JaypieDistribution(this, "Api", { handler: api, waf: { name: "api" } });
-new JaypieDistribution(this, "Mcp", { handler: mcp, waf: { name: "mcp" } });
-
-// Use existing WebACL
-new JaypieDistribution(this, "Dist", {
-  handler,
-  waf: { name: "api", webAclArn: "arn:aws:wafv2:..." },
-});
-
-// Disable WAF logging only
-new JaypieDistribution(this, "Dist", {
-  handler,
-  waf: { name: "api", logBucket: false },
-});
-
-// Bring your own WAF logging bucket
-new JaypieDistribution(this, "Dist", {
-  handler,
-  waf: { name: "api", logBucket: myWafBucket },
-});
-
-// Override specific managed rule actions (e.g., allow large request bodies)
-new JaypieDistribution(this, "Dist", {
-  handler,
-  waf: {
-    name: "api",
-    managedRuleOverrides: {
-      AWSManagedRulesCommonRuleSet: [
-        { name: "SizeRestrictions_BODY", actionToUse: { count: {} } },
-      ],
-    },
-  },
-});
-
-// Scope a managed rule group to (or away from) specific URL patterns
-new JaypieDistribution(this, "Dist", {
-  handler,
-  waf: {
-    name: "api",
-    managedRuleScopeDowns: {
-      // Only run the CommonRuleSet for paths OTHER than /chat — lets /chat
-      // handle large AI-generated request bodies without weakening protection
-      // elsewhere.
-      AWSManagedRulesCommonRuleSet: {
-        notStatement: {
-          statement: {
-            byteMatchStatement: {
-              fieldToMatch: { uriPath: {} },
-              positionalConstraint: "STARTS_WITH",
-              searchString: "/chat",
-              textTransformations: [{ priority: 0, type: "NONE" }],
-            },
-          },
-        },
-      },
-    },
-  },
-});
-```
-
-Cost: $5/month per WebACL + $1/month per rule + $0.60 per million requests. Use `waf: false` to opt out.
+See **`skill("waf")`** for configuration: `rateLimitPerIp`, `webAclArn`,
+`logBucket`, `managedRuleOverrides`, `managedRuleScopeDowns`, the `allow`
+path-scoped relaxation prop, and the rule-name ↔ label casing trap.
 
 ## Organization Trail Security Baseline
 
@@ -465,5 +389,6 @@ new JaypieOrganizationTrail(this, "OrgTrail", {
 - **`skill("secrets")`** - Secret management with JaypieEnvSecret
 - **`skill("streaming")`** - JaypieDistribution and JaypieNextJs streaming configuration
 - **`skill("variables")`** - Environment variables reference
+- **`skill("waf")`** - WAF configuration, managed rule overrides, and the `allow` prop
 - **`skill("web")`** - JaypieWebDeploymentBucket and JaypieStaticWebBucket for static sites
 - **`skill("websockets")`** - JaypieWebSocket and JaypieWebSocketTable constructs

--- a/packages/mcp/skills/skills.md
+++ b/packages/mcp/skills/skills.md
@@ -17,7 +17,7 @@ Look up skills by alias: `mcp__jaypie__skill(alias)`
 |----------|--------|
 | contents | index, releasenotes |
 | development | apikey, documentation, errors, llm, logs, mocks, monorepo, repokit, style, subpackages, tests, tools |
-| infrastructure | apigateway, aws, cdk, cicd, datadog, dns, dynamodb, express, lambda, migrations, secrets, sqs, streaming, variables, web, websockets |
+| infrastructure | apigateway, aws, cdk, cicd, datadog, dns, dynamodb, express, lambda, migrations, secrets, sqs, streaming, variables, waf, web, websockets |
 | patterns | api, fabric, handlers, models, services, vocabulary |
 | recipes | recipe-api-server |
 | meta | issues, jaypie, mcp, skills |

--- a/packages/mcp/skills/waf.md
+++ b/packages/mcp/skills/waf.md
@@ -1,0 +1,154 @@
+---
+description: WAF (Web Application Firewall) configuration for JaypieDistribution
+related: aws, cdk, web
+---
+
+# WAF (Web Application Firewall)
+
+`JaypieDistribution` (and `JaypieWebDeploymentBucket`) attach a WAFv2 WebACL by
+default with:
+
+- **AWSManagedRulesCommonRuleSet** — OWASP top 10 (SQLi, XSS, etc.)
+- **AWSManagedRulesKnownBadInputsRuleSet** — known bad patterns (Log4j, etc.)
+- **Rate limiting** — 2000 requests per 5 minutes per IP
+- **WAF logging** — S3 bucket with Datadog forwarder notifications
+
+```typescript
+// Default: WAF enabled with logging
+new JaypieDistribution(this, "Dist", { handler });
+
+// Disable WAF entirely
+new JaypieDistribution(this, "Dist", { handler, waf: false });
+
+// Customize rate limit (name required on any waf config object)
+new JaypieDistribution(this, "Dist", {
+  handler,
+  waf: { name: "api", rateLimitPerIp: 500 },
+});
+
+// Multiple distributions in one env — set a unique waf.name on each to
+// avoid WebACL/S3 bucket name collisions between stacks.
+new JaypieDistribution(this, "Api", { handler: api, waf: { name: "api" } });
+new JaypieDistribution(this, "Mcp", { handler: mcp, waf: { name: "mcp" } });
+
+// Use existing WebACL
+new JaypieDistribution(this, "Dist", {
+  handler,
+  waf: { name: "api", webAclArn: "arn:aws:wafv2:..." },
+});
+
+// Disable WAF logging only
+new JaypieDistribution(this, "Dist", {
+  handler,
+  waf: { name: "api", logBucket: false },
+});
+
+// Bring your own WAF logging bucket
+new JaypieDistribution(this, "Dist", {
+  handler,
+  waf: { name: "api", logBucket: myWafBucket },
+});
+```
+
+Cost: $5/month per WebACL + $1/month per rule + $0.60 per million requests. Use
+`waf: false` to opt out.
+
+## Override specific managed rule actions
+
+Flip a named sub-rule from `block` to `count` everywhere (e.g. allow large
+request bodies):
+
+```typescript
+new JaypieDistribution(this, "Dist", {
+  handler,
+  waf: {
+    name: "api",
+    managedRuleOverrides: {
+      AWSManagedRulesCommonRuleSet: [
+        { name: "SizeRestrictions_BODY", actionToUse: { count: {} } },
+      ],
+    },
+  },
+});
+```
+
+## Scope a managed rule group to specific URL patterns
+
+```typescript
+new JaypieDistribution(this, "Dist", {
+  handler,
+  waf: {
+    name: "api",
+    managedRuleScopeDowns: {
+      // Only run the CommonRuleSet for paths OTHER than /chat — lets /chat
+      // handle large AI-generated request bodies without weakening protection
+      // elsewhere.
+      AWSManagedRulesCommonRuleSet: {
+        notStatement: {
+          statement: {
+            byteMatchStatement: {
+              fieldToMatch: { uriPath: {} },
+              positionalConstraint: "STARTS_WITH",
+              searchString: "/chat",
+              textTransformations: [{ priority: 0, type: "NONE" }],
+            },
+          },
+        },
+      },
+    },
+  },
+});
+```
+
+## Relaxing a managed rule for specific paths — `waf.allow`
+
+`allow` relaxes named rules to **count** mode for matching paths, leaving full
+blocking everywhere else. Each entry names one or more paths and, per managed
+rule group key, the sub-rule names to flip:
+
+```typescript
+new JaypieDistribution(this, "Dist", {
+  handler,
+  waf: {
+    name: "api",
+    allow: [
+      {
+        path: "/hooks/*", // trailing * → STARTS_WITH; otherwise EXACTLY
+        AWSManagedRulesCommonRuleSet: ["NoUserAgent_HEADER"],
+        AWSManagedRulesKnownBadInputsRuleSet: ["ExploitablePaths_URIPATH"],
+      },
+    ],
+  },
+});
+```
+
+- A `path` ending in `*` compiles to a `STARTS_WITH` byte-match; otherwise
+  `EXACTLY`. `/hooks/*` matches `/hooks/ping` but **not** bare `/hooks`.
+- The key (e.g. `AWSManagedRulesCommonRuleSet`) must be one of the active
+  `managedRules`.
+- `allow` composes with `managedRuleOverrides`: the baseline overrides apply to
+  both the relaxed and strict emissions of a group; entries in `allow` further
+  relax specific (path × sub-rule) intersections. Groups not named in `allow`
+  keep their single-rule emission.
+
+## ⚠️ Rule name ≠ label (casing trap)
+
+AWS uses different casing for a rule's **label** (seen in WAF logs) and its
+**name**. `managedRuleOverrides` / `allow` match on the **rule name**:
+
+| Label (seen in WAF logs)                              | Rule name (use this) |
+| ----------------------------------------------------- | -------------------- |
+| `awswaf:managed:aws:core-rule-set:NoUserAgent_Header` | `NoUserAgent_HEADER` |
+
+Jaypie now validates rule names against each AWS managed rule group at synth and
+throws a `ConfigurationError` listing the valid names on a mismatch (custom rule
+groups are not validated). Historically a name that matched no rule was
+**silently ignored** — the rule kept blocking. If a relaxation "isn't working,"
+read the WAF log `terminatingRule.<NAME>` and copy that exact name (e.g.
+`NoUserAgent_HEADER`, `SizeRestrictions_BODY`, `UserAgent_BadBots_HEADER`).
+
+## See Also
+
+- **`skill("cdk")`** - CDK constructs and deployment patterns
+- **`skill("aws")`** - AWS SDK utilities
+- **`skill("web")`** - JaypieWebDeploymentBucket and JaypieStaticWebBucket


### PR DESCRIPTION
## Summary

Fixes #362. `JaypieDistribution`'s `waf.allow` / `waf.managedRuleOverrides` passed sub-rule names straight into a `RuleActionOverride` with no validation. AWS WAF matches overrides on the exact rule **name** and **silently ignores** unmatched names — so a typo or the label/name casing trap (label `…:core-rule-set:NoUserAgent_Header` vs rule name `NoUserAgent_HEADER`) produced a WebACL that looked correct but kept blocking. The existing `#342` tests even embodied the bug, pairing `ExploitablePaths_URIPATH` (a KnownBadInputs rule) with `AWSManagedRulesCommonRuleSet`.

## Changes

**`@jaypie/constructs` → 1.2.60**
- New `helpers/wafManagedRuleNames.ts`: `AWS_MANAGED_RULE_GROUPS` (canonical rule-name sets for 11 AWS managed rule groups, sourced from the AWS WAF developer guide) + `assertValidWafRuleNames({ allow, managedRuleOverrides })`, which throws `ConfigurationError` listing valid names. Custom/non-AWS groups are skipped.
- Validation wired into both `JaypieDistribution` and `JaypieWebDeploymentBucket` before WebACL build.
- Fixed existing `#342` allow tests; added rule-name validation tests to both specs.

**`@jaypie/mcp` → 0.8.65**
- Extracted WAF docs from `skill("cdk")` into a dedicated `skill("waf")` with the `allow` prop and the casing-trap table; `cdk` keeps a See Also pointer. Updated `skills.md`, `agents.md`, and constructs `CLAUDE.md`.

## Verification

- `constructs` 570 tests ✅ · `mcp` 41 tests ✅
- typecheck (both) ✅ · lint clean ✅ · both packages build ✅
- Release notes added; `package-lock.json` updated.

Closes #362

🤖 Generated with [Claude Code](https://claude.com/claude-code)