### PR TITLE
docs(mcp): document request envelope in skill("api")

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29656,7 +29656,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.65",
+      "version": "0.8.66",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.4",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.65",
+  "version": "0.8.66",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/mcp/0.8.66.md
+++ b/packages/mcp/release-notes/mcp/0.8.66.md
@@ -1,0 +1,14 @@
+---
+version: 0.8.66
+date: 2026-06-05
+summary: Document request envelope in skill("api") — requests use the same { data } object-vs-array rules as responses
+---
+
+## Changed
+
+- **`api` skill** now documents the **request envelope**. Request bodies follow
+  the same `{ data }` convention as responses: `{ data: {} }` for a single record
+  (object), `{ data: [] }` for an array of records. The request rule was
+  previously undocumented in every skill file — only response format was covered.
+- Retitled the skill to **API Request and Response Format** and added a request
+  rule to the shared rules list.

--- a/packages/mcp/skills/api.md
+++ b/packages/mcp/skills/api.md
@@ -1,11 +1,27 @@
 ---
-description: API response format and conventions
+description: API request and response format and conventions
 related: express, handlers, style
 ---
 
-# API Response Format
+# API Request and Response Format
 
-All API responses follow a consistent envelope format.
+All API requests and responses follow a consistent envelope format.
+
+## Request Envelope
+
+Request bodies follow the same `{ data }` envelope as responses.
+
+```json
+// Single record
+{ "data": { "name": "Example" } }
+
+// Array of records
+{ "data": [{ "name": "First" }, { "name": "Second" }] }
+```
+
+- `{ data: {} }` — single record (object)
+- `{ data: [] }` — array of records (even if zero or one result)
+- No other top-level keys at the root
 
 ## Response Envelope
 
@@ -39,8 +55,9 @@ Every response body is a JSON object with one top-level key:
 
 ### Rules
 
-1. A response contains either `data` or `errors`, never both
-2. Single records use an object: `{ data: {} }`
-3. Multiple records use an array: `{ data: [] }`
-4. Errors always use an array: `{ errors: [] }`
-5. No other top-level keys (no `status`, `message`, `meta` at the root)
+1. Requests and responses both use the `{ data }` envelope
+2. A response contains either `data` or `errors`, never both
+3. Single records use an object: `{ data: {} }`
+4. Multiple records use an array: `{ data: [] }`
+5. Errors always use an array: `{ errors: [] }` (responses only)
+6. No other top-level keys (no `status`, `message`, `meta` at the root)


### PR DESCRIPTION
## Summary

`skill("api")` documented the `{ data }` envelope for **responses** only — request body format was undocumented in every skill file. A fan-out search across all 60 skill files confirmed the `data: {} | []` rule lived only in `api.md` and only for responses.

This adds a **Request Envelope** section: request bodies follow the same `{ data: {} }` (single record) / `{ data: [] }` (array) convention as responses.

## Changes

- 📝 `skills/api.md` — retitled to **API Request and Response Format**; added Request Envelope section + shared rule; scoped `errors` array to responses only; updated frontmatter description
- 🆕 `release-notes/mcp/0.8.66.md`
- ⬆️ `@jaypie/mcp` 0.8.65 → 0.8.66 (patch) + lockfile

## Verification

typecheck ✅ · lint ✅ · test (41 passed) ✅ · skill renders correctly via MCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)