### PR TITLE
feat(constructs): set DD_SERVICE from Lambda serviceTag instead of PROJECT_SERVICE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28569,7 +28569,7 @@
     },
     "packages/constructs": {
       "name": "@jaypie/constructs",
-      "version": "1.2.61",
+      "version": "1.2.62",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*",
@@ -29656,7 +29656,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.67",
+      "version": "0.8.68",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.4",

--- a/packages/constructs/CLAUDE.md
+++ b/packages/constructs/CLAUDE.md
@@ -132,7 +132,7 @@ Required by various constructs:
 | `PROJECT_NONCE` | Unique deployment identifier |
 | `PROJECT_COMMIT` | Git commit hash |
 | `PROJECT_VERSION` | Package version |
-| `PROJECT_SERVICE` | Service name (set on Lambdas from the `serviceTag` prop when provided) |
+| `PROJECT_SERVICE` | Service name (passed through to Lambdas from process.env; `serviceTag` prop sets `DD_SERVICE` instead) |
 | `CDK_DEFAULT_ACCOUNT` | AWS account ID |
 | `CDK_DEFAULT_REGION` | AWS region |
 | `CDK_ENV_HOSTED_ZONE` | Default hosted zone domain |

--- a/packages/constructs/package.json
+++ b/packages/constructs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/constructs",
-  "version": "1.2.61",
+  "version": "1.2.62",
   "description": "CDK constructs for Jaypie applications",
   "repository": {
     "type": "git",

--- a/packages/constructs/src/JaypieLambda.ts
+++ b/packages/constructs/src/JaypieLambda.ts
@@ -239,7 +239,10 @@ export class JaypieLambda extends Construct implements lambda.IFunction {
           : undefined,
     });
 
-    addDatadogLayers(this._lambda, { datadogApiKeyArn });
+    addDatadogLayers(this._lambda, {
+      datadogApiKeyArn,
+      serviceTag: environment.DD_SERVICE,
+    });
 
     // Grant secret read permissions
     Object.values(envSecrets).forEach((secret) => {

--- a/packages/constructs/src/__tests__/JaypieLambda.spec.ts
+++ b/packages/constructs/src/__tests__/JaypieLambda.spec.ts
@@ -103,7 +103,7 @@ describe("JaypieLambda", () => {
       });
     });
 
-    it("sets PROJECT_SERVICE environment variable from serviceTag", () => {
+    it("sets DD_SERVICE environment variable from serviceTag", () => {
       const stack = new Stack();
       new JaypieLambda(stack, "TestConstruct", {
         code: lambda.Code.fromInline("exports.handler = () => {}"),
@@ -116,14 +116,14 @@ describe("JaypieLambda", () => {
       expect(mainFunction).toBeDefined();
 
       const envVars = mainFunction?.Properties?.Environment?.Variables || {};
-      expect(envVars.PROJECT_SERVICE).toBe("TEST_SERVICE");
+      expect(envVars.DD_SERVICE).toBe("TEST_SERVICE");
     });
 
-    it("prefers explicit PROJECT_SERVICE environment over serviceTag", () => {
+    it("prefers explicit DD_SERVICE environment over serviceTag", () => {
       const stack = new Stack();
       new JaypieLambda(stack, "TestConstruct", {
         code: lambda.Code.fromInline("exports.handler = () => {}"),
-        environment: { PROJECT_SERVICE: "explicit-service" },
+        environment: { DD_SERVICE: "explicit-service" },
         handler: "index.handler",
         serviceTag: "TEST_SERVICE",
       });
@@ -133,7 +133,7 @@ describe("JaypieLambda", () => {
       expect(mainFunction).toBeDefined();
 
       const envVars = mainFunction?.Properties?.Environment?.Variables || {};
-      expect(envVars.PROJECT_SERVICE).toBe("explicit-service");
+      expect(envVars.DD_SERVICE).toBe("explicit-service");
     });
 
     it("adds both role and vendor tags when provided", () => {

--- a/packages/constructs/src/helpers/__tests__/jaypieLambdaEnv.spec.ts
+++ b/packages/constructs/src/helpers/__tests__/jaypieLambdaEnv.spec.ts
@@ -153,35 +153,34 @@ describe("jaypieLambdaEnv", () => {
   });
 
   describe("serviceTag", () => {
-    it("should set PROJECT_SERVICE from serviceTag", () => {
+    it("should set DD_SERVICE from serviceTag", () => {
       const result = jaypieLambdaEnv({ serviceTag: "my-service" });
 
-      expect(result.PROJECT_SERVICE).toBe("my-service");
+      expect(result.DD_SERVICE).toBe("my-service");
     });
 
-    it("should let explicit initialEnvironment PROJECT_SERVICE win over serviceTag", () => {
+    it("should let explicit initialEnvironment DD_SERVICE win over serviceTag", () => {
       const result = jaypieLambdaEnv({
-        initialEnvironment: { PROJECT_SERVICE: "explicit-service" },
+        initialEnvironment: { DD_SERVICE: "explicit-service" },
         serviceTag: "my-service",
       });
 
-      expect(result.PROJECT_SERVICE).toBe("explicit-service");
+      expect(result.DD_SERVICE).toBe("explicit-service");
     });
 
-    it("should let serviceTag win over process.env.PROJECT_SERVICE", () => {
+    it("should not set PROJECT_SERVICE from serviceTag", () => {
+      const result = jaypieLambdaEnv({ serviceTag: "my-service" });
+
+      expect(result.PROJECT_SERVICE).toBeUndefined();
+    });
+
+    it("should still pass through process.env.PROJECT_SERVICE", () => {
       process.env.PROJECT_SERVICE = "env-service";
 
       const result = jaypieLambdaEnv({ serviceTag: "my-service" });
 
-      expect(result.PROJECT_SERVICE).toBe("my-service");
-    });
-
-    it("should fall back to process.env.PROJECT_SERVICE without serviceTag", () => {
-      process.env.PROJECT_SERVICE = "env-service";
-
-      const result = jaypieLambdaEnv();
-
       expect(result.PROJECT_SERVICE).toBe("env-service");
+      expect(result.DD_SERVICE).toBe("my-service");
     });
   });
 

--- a/packages/constructs/src/helpers/addDatadogLayers.ts
+++ b/packages/constructs/src/helpers/addDatadogLayers.ts
@@ -5,6 +5,7 @@ import { DatadogLambda } from "datadog-cdk-constructs-v2";
 
 export interface AddDatadogLayerOptions {
   datadogApiKeyArn?: string;
+  serviceTag?: string;
 }
 
 export function addDatadogLayers(
@@ -12,6 +13,7 @@ export function addDatadogLayers(
   options: AddDatadogLayerOptions = {},
 ): boolean {
   const datadogApiKeyArn = options?.datadogApiKeyArn;
+  const resolvedService = options?.serviceTag || process.env.PROJECT_SERVICE;
 
   const resolvedDatadogApiKeyArn =
     datadogApiKeyArn ||
@@ -28,13 +30,13 @@ export function addDatadogLayers(
     DD_ENV: process.env.PROJECT_ENV || "",
     DD_PROFILING_ENABLED: "false",
     DD_SERVERLESS_APPSEC_ENABLED: "false",
-    DD_SERVICE: process.env.PROJECT_SERVICE || "",
+    DD_SERVICE: resolvedService || "",
     DD_SITE: CDK.DATADOG.SITE,
     DD_TAGS: `${CDK.TAG.SPONSOR}:${process.env.PROJECT_SPONSOR || ""}`,
     DD_TRACE_OTEL_ENABLED: "false",
   };
 
-  // Add environment variables only if they don't already exist
+  // Apply Datadog environment variables (overwrites existing keys)
   Object.entries(datadogEnvVars).forEach(([key, value]) => {
     lambdaFunction.addEnvironment(key, value);
   });
@@ -50,7 +52,7 @@ export function addDatadogLayers(
     nodeLayerVersion: CDK.DATADOG.LAYER.NODE,
     extensionLayerVersion: CDK.DATADOG.LAYER.EXTENSION,
     env: process.env.PROJECT_ENV,
-    service: process.env.PROJECT_SERVICE,
+    service: resolvedService,
     version: process.env.PROJECT_VERSION,
   });
   datadogLambda.addLambdaFunctions([lambdaFunction]);

--- a/packages/constructs/src/helpers/jaypieLambdaEnv.ts
+++ b/packages/constructs/src/helpers/jaypieLambdaEnv.ts
@@ -39,10 +39,10 @@ export function jaypieLambdaEnv(options: JaypieLambdaEnvOptions = {}): {
     }
   });
 
-  // Apply serviceTag as PROJECT_SERVICE unless explicitly overridden.
+  // Apply serviceTag as DD_SERVICE unless explicitly overridden.
   // Precedence: explicit environment > serviceTag > process.env.PROJECT_SERVICE
-  if (serviceTag && !environment.PROJECT_SERVICE) {
-    environment.PROJECT_SERVICE = serviceTag;
+  if (serviceTag && !environment.DD_SERVICE) {
+    environment.DD_SERVICE = serviceTag;
   }
 
   // Default environment variables from process.env if present

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.67",
+  "version": "0.8.68",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/constructs/1.2.62.md
+++ b/packages/mcp/release-notes/constructs/1.2.62.md
@@ -1,0 +1,20 @@
+---
+version: 1.2.62
+date: 2026-06-11
+summary: Lambda serviceTag now sets DD_SERVICE instead of PROJECT_SERVICE
+---
+
+## @jaypie/constructs 1.2.62
+
+### Changed
+
+- **`serviceTag` sets `DD_SERVICE` instead of `PROJECT_SERVICE`** (`JaypieLambda`
+  and the `JaypieQueuedLambda`, `JaypieBucketQueuedLambda`,
+  `JaypieExpressLambda`, `JaypieWebSocketLambda` constructs built on it). The
+  `serviceTag` value is now injected as the `DD_SERVICE` environment variable so
+  Datadog attributes traces, logs, and metrics to the service directly.
+  Precedence is explicit `environment.DD_SERVICE` > `serviceTag` >
+  `process.env.PROJECT_SERVICE`. The resolved service is also passed to the
+  Datadog layer configuration, which previously read only
+  `process.env.PROJECT_SERVICE` and could overwrite the Lambda's `DD_SERVICE`.
+  `PROJECT_SERVICE` from the deploy environment still passes through unchanged.


### PR DESCRIPTION
## Summary
- `serviceTag` on `JaypieLambda` (and the queued/express/websocket constructs built on it) now sets the `DD_SERVICE` environment variable instead of `PROJECT_SERVICE`
- `addDatadogLayers` accepts a `serviceTag` option; `JaypieLambda` passes the resolved `DD_SERVICE` through so the Datadog layer config no longer clobbers it with `process.env.PROJECT_SERVICE`
- Precedence: explicit `environment.DD_SERVICE` > `serviceTag` > `process.env.PROJECT_SERVICE`; `PROJECT_SERVICE` process.env passthrough is unchanged
- Bumps `@jaypie/constructs` 1.2.62 and `@jaypie/mcp` 0.8.68 with release notes

## Test plan
- [x] `npm run test -w packages/constructs` (576 tests)
- [x] `npm run test -w packages/mcp` (41 tests)
- [x] typecheck, build, lint clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)