### PR TITLE
fix(cdk): bump aws-cdk CLI to ^2.1126.0 for schema 54

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14001,7 +14001,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.1112.0",
+      "version": "2.1126.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1126.0.tgz",
+      "integrity": "sha512-uNoocb3vCPiAT3j9+SwL6pn/VVggHWBsgC2XpxyhNvYQYt6cE9BM/149GWwtdcwnLrPjnwW1+CV/5nSSh5dV+w==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -33860,7 +33862,7 @@
       },
       "devDependencies": {
         "@types/node": "^22.13.1",
-        "aws-cdk": "^2.232.1",
+        "aws-cdk": "^2.1126.0",
         "tsx": "^4.20.6",
         "typescript": "^5.3.3",
         "vitest": "^3.0.5"

--- a/workspaces/cdk/package.json
+++ b/workspaces/cdk/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.13.1",
-    "aws-cdk": "^2.232.1",
+    "aws-cdk": "^2.1126.0",
     "tsx": "^4.20.6",
     "typescript": "^5.3.3",
     "vitest": "^3.0.5"


### PR DESCRIPTION
## Problem
Deploy workflows ("Build Stacks to Production/Development") fail with:
> This CDK CLI is not compatible with the CDK library used by your application. (Maximum schema version supported is 53.x.x, but found 54.0.0. You need at least CLI version 2.1126.0)

`aws-cdk-lib` floated to 2.258.1 (cloud-assembly schema **54**), but the `aws-cdk` CLI was pinned `^2.232.1` and resolved to an older 2.11xx build reading only schema 53. The CLI and library are on decoupled version tracks now, so the shared caret stopped keeping them aligned.

## Fix
Bump the `aws-cdk` CLI floor to `^2.1126.0` (latest; reads schema 54) in `workspaces/cdk`. Verified locally: `cdk list` clears the compatibility check and proceeds into synth (failing only on expected no-credentials hosted-zone lookups).

`workspaces/cdk` is private — no version bump.

## Follow-up note
CLI ↔ lib are decoupled; a future `aws-cdk-lib` schema bump could require another CLI bump. Worth watching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)