### PR TITLE
fix(llm): MODEL.GPT_MINI/GPT_NANO typo + document model-first constructor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33219,7 +33219,7 @@
       "license": "MIT"
     },
     "packages/jaypie": {
-      "version": "1.2.51",
+      "version": "1.2.52",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "^1.2.9",
@@ -33243,7 +33243,7 @@
         "typescript-eslint": "^8.46.1"
       },
       "peerDependencies": {
-        "@jaypie/llm": "^1.2.38",
+        "@jaypie/llm": "^1.2.39",
         "@jaypie/mongoose": "^1.2.2"
       },
       "peerDependenciesMeta": {
@@ -33353,7 +33353,7 @@
     },
     "packages/llm": {
       "name": "@jaypie/llm",
-      "version": "1.2.38",
+      "version": "1.2.39",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "*",
@@ -33479,7 +33479,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.70",
+      "version": "0.8.71",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.4",

--- a/packages/jaypie/package.json
+++ b/packages/jaypie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jaypie",
-  "version": "1.2.51",
+  "version": "1.2.52",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"
@@ -53,7 +53,7 @@
     "typescript-eslint": "^8.46.1"
   },
   "peerDependencies": {
-    "@jaypie/llm": "^1.2.38",
+    "@jaypie/llm": "^1.2.39",
     "@jaypie/mongoose": "^1.2.2"
   },
   "peerDependenciesMeta": {

--- a/packages/llm/CLAUDE.md
+++ b/packages/llm/CLAUDE.md
@@ -104,6 +104,10 @@ const response = await Llm.operate("Hello", { model: "claude-sonnet-4" });
 // Or specify provider explicitly
 const llm = new Llm("openai", { model: "gpt-4o" });
 const result = await llm.operate("What is 2+2?");
+
+// The constructor's first arg may be a provider name OR a model name —
+// a model name auto-detects the provider and is retained
+const claude = new Llm("claude-sonnet-4-6"); // -> anthropic, claude-sonnet-4-6
 ```
 
 ### Fallback Providers

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/llm",
-  "version": "1.2.38",
+  "version": "1.2.39",
   "description": "Large language model utilities",
   "repository": {
     "type": "git",

--- a/packages/llm/src/constants.ts
+++ b/packages/llm/src/constants.ts
@@ -42,8 +42,8 @@ export const MODEL = {
   GEMINI_PRO: "gemini-3.1-pro-preview",
   // OpenAI
   GPT: "gpt-5.5",
-  GPT_MINI: "gpt-5.5-mini",
-  GPT_NANO: "gpt-5.5-nano",
+  GPT_MINI: "gpt-5.4-mini",
+  GPT_NANO: "gpt-5.4-nano",
   // xAI
   GROK: "grok-latest",
 };

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.70",
+  "version": "0.8.71",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/llm/1.2.39.md
+++ b/packages/mcp/release-notes/llm/1.2.39.md
@@ -1,0 +1,11 @@
+---
+version: 1.2.39
+date: 2026-06-16
+summary: Fix MODEL.GPT_MINI/GPT_NANO typo (gpt-5.5-* → gpt-5.4-*) to match OpenAI provider constants
+---
+
+## @jaypie/llm 1.2.39
+
+### Fixes
+
+- **Model constants**: `MODEL.GPT_MINI` and `MODEL.GPT_NANO` were pinned to nonexistent `gpt-5.5-mini`/`gpt-5.5-nano`; corrected to `gpt-5.4-mini`/`gpt-5.4-nano`, matching `PROVIDER.OPENAI.MODEL.SMALL`/`TINY` and the CI test matrix.

--- a/packages/mcp/release-notes/mcp/0.8.71.md
+++ b/packages/mcp/release-notes/mcp/0.8.71.md
@@ -1,0 +1,9 @@
+---
+version: 0.8.71
+date: 2026-06-16
+summary: Add @jaypie/llm 1.2.39 release notes
+---
+
+## Changes
+
+- Adds release notes for `@jaypie/llm` 1.2.39 (`MODEL.GPT_MINI`/`GPT_NANO` typo fix).

--- a/packages/mcp/release-notes/mcp/0.8.71.md
+++ b/packages/mcp/release-notes/mcp/0.8.71.md
@@ -1,9 +1,10 @@
 ---
 version: 0.8.71
 date: 2026-06-16
-summary: Add @jaypie/llm 1.2.39 release notes
+summary: Add @jaypie/llm 1.2.39 release notes; document model-first Llm constructor
 ---
 
 ## Changes
 
 - Adds release notes for `@jaypie/llm` 1.2.39 (`MODEL.GPT_MINI`/`GPT_NANO` typo fix).
+- Documents that `new Llm(model)` accepts a model name as its first argument (provider auto-detected, model retained) in the `llm` skill.

--- a/packages/mcp/skills/llm.md
+++ b/packages/mcp/skills/llm.md
@@ -315,6 +315,15 @@ const review1 = await llm.operate(code1);
 const review2 = await llm.operate(code2);
 ```
 
+The first constructor argument may be a provider name **or** a model name. When a model name is passed, the provider is auto-detected and the model is retained:
+
+```typescript
+import Llm, { LLM } from "@jaypie/llm";
+
+const llm = new Llm("claude-sonnet-4-6");      // -> anthropic, claude-sonnet-4-6
+const flash = new Llm(LLM.MODEL.GEMINI_FLASH); // -> google, gemini-3.5-flash
+```
+
 ## Environment Variables
 
 ```bash

--- a/workspaces/documentation/docs/guides/llm-integration.md
+++ b/workspaces/documentation/docs/guides/llm-integration.md
@@ -63,6 +63,12 @@ const response2 = await llm.operate("What is my name?");
 // Maintains conversation history
 ```
 
+The first constructor argument may be a provider name **or** a model name. A model name auto-detects the provider and is retained:
+
+```typescript
+const llm = new Llm("claude-sonnet-4-6"); // -> anthropic, claude-sonnet-4-6
+```
+
 ## Model Selection
 
 ### By Model Name

--- a/workspaces/documentation/docs/packages/llm.md
+++ b/workspaces/documentation/docs/packages/llm.md
@@ -133,6 +133,15 @@ await llm.operate("What is my name?");
 console.log(llm.history);
 ```
 
+The first constructor argument may be a provider name **or** a model name. When a model name is passed, the provider is auto-detected and the model is retained:
+
+```typescript
+import Llm, { LLM } from "@jaypie/llm";
+
+const llm = new Llm("claude-sonnet-4-6");      // -> anthropic, claude-sonnet-4-6
+const flash = new Llm(LLM.MODEL.GEMINI_FLASH); // -> google, gemini-3.5-flash
+```
+
 ## Toolkit
 
 Collection of tools for function calling.


### PR DESCRIPTION
## Summary
- 🐛 Fix `MODEL.GPT_MINI`/`GPT_NANO` typo: `gpt-5.5-*` → `gpt-5.4-*` (matches `PROVIDER.OPENAI` and the CI model matrix)
- 📖 Document the model-first `Llm` constructor form (`new Llm("claude-sonnet-4-6")` auto-detects provider, retains model — `#213`)

## Versions
- `@jaypie/llm` 1.2.38 → 1.2.39
- `jaypie` 1.2.51 → 1.2.52 (llm peer range `^1.2.39`)
- `@jaypie/mcp` 0.8.70 → 0.8.71 (release notes + llm skill doc)

## Docs touched
- `packages/mcp/skills/llm.md`, `workspaces/documentation/docs/packages/llm.md`, `.../guides/llm-integration.md`, `packages/llm/CLAUDE.md`

## Test plan
- ✅ llm typecheck + 862 tests
- ✅ mcp build + 41 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)