### PR TITLE
feat(constructs): pass Datadog LLM Observability env vars to Lambdas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32397,7 +32397,7 @@
     },
     "packages/constructs": {
       "name": "@jaypie/constructs",
-      "version": "1.2.63",
+      "version": "1.2.64",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*",
@@ -33479,7 +33479,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.72",
+      "version": "0.8.73",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.4",

--- a/packages/constructs/package.json
+++ b/packages/constructs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/constructs",
-  "version": "1.2.63",
+  "version": "1.2.64",
   "description": "CDK constructs for Jaypie applications",
   "repository": {
     "type": "git",

--- a/packages/constructs/src/constants.ts
+++ b/packages/constructs/src/constants.ts
@@ -35,8 +35,8 @@ export const CDK = {
     SITE: "datadoghq.com",
     LAYER: {
       // https://docs.datadoghq.com/meta/latest-lambda-layer-version.json
-      NODE: 131, // 127 on 9/12/2025
-      EXTENSION: 86, // 86 on 9/12/2025
+      NODE: 139, // 139 on 6/17/2026
+      EXTENSION: 97, // 97 on 6/17/2026
     },
   },
   DEFAULT: {

--- a/packages/constructs/src/helpers/__tests__/jaypieLambdaEnv.spec.ts
+++ b/packages/constructs/src/helpers/__tests__/jaypieLambdaEnv.spec.ts
@@ -20,6 +20,8 @@ describe("jaypieLambdaEnv", () => {
     delete process.env.NOT_IN_LIST;
     delete process.env.RANDOM_VAR;
     delete process.env.ANOTHER_VAR;
+    delete process.env.DD_LLMOBS_ENABLED;
+    delete process.env.DD_LLMOBS_ML_APP;
   });
 
   afterEach(() => {
@@ -181,6 +183,88 @@ describe("jaypieLambdaEnv", () => {
 
       expect(result.PROJECT_SERVICE).toBe("env-service");
       expect(result.DD_SERVICE).toBe("my-service");
+    });
+  });
+
+  describe("Datadog LLM Observability", () => {
+    it("should pass through DD_LLMOBS_ENABLED when set", () => {
+      process.env.DD_LLMOBS_ENABLED = "true";
+
+      const result = jaypieLambdaEnv();
+
+      expect(result.DD_LLMOBS_ENABLED).toBe("true");
+    });
+
+    it("should not set DD_LLMOBS_ENABLED when unset", () => {
+      const result = jaypieLambdaEnv();
+
+      expect(result.DD_LLMOBS_ENABLED).toBeUndefined();
+    });
+
+    it("should bring over DD_LLMOBS_ML_APP when set", () => {
+      process.env.DD_LLMOBS_ENABLED = "true";
+      process.env.DD_LLMOBS_ML_APP = "my-app";
+
+      const result = jaypieLambdaEnv();
+
+      expect(result.DD_LLMOBS_ML_APP).toBe("my-app");
+    });
+
+    it("should bring over DD_LLMOBS_ML_APP even when DD_LLMOBS_ENABLED is unset", () => {
+      process.env.DD_LLMOBS_ML_APP = "my-app";
+
+      const result = jaypieLambdaEnv();
+
+      expect(result.DD_LLMOBS_ML_APP).toBe("my-app");
+    });
+
+    it("should not bring over DD_LLMOBS_ML_APP when DD_LLMOBS_ENABLED is 'false'", () => {
+      process.env.DD_LLMOBS_ENABLED = "false";
+      process.env.DD_LLMOBS_ML_APP = "my-app";
+
+      const result = jaypieLambdaEnv();
+
+      expect(result.DD_LLMOBS_ENABLED).toBe("false");
+      expect(result.DD_LLMOBS_ML_APP).toBeUndefined();
+    });
+
+    it("should not bring over DD_LLMOBS_ML_APP when DD_LLMOBS_ENABLED is '0'", () => {
+      process.env.DD_LLMOBS_ENABLED = "0";
+      process.env.DD_LLMOBS_ML_APP = "my-app";
+
+      const result = jaypieLambdaEnv();
+
+      expect(result.DD_LLMOBS_ENABLED).toBe("0");
+      expect(result.DD_LLMOBS_ML_APP).toBeUndefined();
+    });
+
+    it("should suppress process.env DD_LLMOBS_ML_APP when initialEnvironment disables observability", () => {
+      process.env.DD_LLMOBS_ENABLED = "true";
+      process.env.DD_LLMOBS_ML_APP = "env-app";
+
+      const result = jaypieLambdaEnv({
+        initialEnvironment: {
+          DD_LLMOBS_ENABLED: "false",
+        },
+      });
+
+      expect(result.DD_LLMOBS_ENABLED).toBe("false");
+      expect(result.DD_LLMOBS_ML_APP).toBeUndefined();
+    });
+
+    it("should let explicit initialEnvironment win over process.env", () => {
+      process.env.DD_LLMOBS_ENABLED = "true";
+      process.env.DD_LLMOBS_ML_APP = "env-app";
+
+      const result = jaypieLambdaEnv({
+        initialEnvironment: {
+          DD_LLMOBS_ENABLED: "false",
+          DD_LLMOBS_ML_APP: "explicit-app",
+        },
+      });
+
+      expect(result.DD_LLMOBS_ENABLED).toBe("false");
+      expect(result.DD_LLMOBS_ML_APP).toBe("explicit-app");
     });
   });
 

--- a/packages/constructs/src/helpers/jaypieLambdaEnv.ts
+++ b/packages/constructs/src/helpers/jaypieLambdaEnv.ts
@@ -68,5 +68,22 @@ export function jaypieLambdaEnv(options: JaypieLambdaEnvOptions = {}): {
     }
   });
 
+  // Datadog LLM Observability: pass through DD_LLMOBS_ENABLED if set, and
+  // DD_LLMOBS_ML_APP unless observability is explicitly disabled. Explicit
+  // initialEnvironment values win over process.env, including for the gate.
+  if (process.env.DD_LLMOBS_ENABLED && !environment.DD_LLMOBS_ENABLED) {
+    environment.DD_LLMOBS_ENABLED = process.env.DD_LLMOBS_ENABLED;
+  }
+  const llmObsDisabled =
+    environment.DD_LLMOBS_ENABLED === "false" ||
+    environment.DD_LLMOBS_ENABLED === "0";
+  if (
+    process.env.DD_LLMOBS_ML_APP &&
+    !llmObsDisabled &&
+    !environment.DD_LLMOBS_ML_APP
+  ) {
+    environment.DD_LLMOBS_ML_APP = process.env.DD_LLMOBS_ML_APP;
+  }
+
   return environment;
 }

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.72",
+  "version": "0.8.73",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/constructs/1.2.64.md
+++ b/packages/mcp/release-notes/constructs/1.2.64.md
@@ -1,0 +1,13 @@
+---
+version: 1.2.64
+date: 2026-06-17
+summary: Pass Datadog LLM Observability env vars to Lambdas; bump Datadog layer versions
+---
+
+## Changes
+
+- `jaypieLambdaEnv` (and therefore every `JaypieLambda` derivative) now passes Datadog LLM Observability environment variables through to the Lambda at synth time:
+  - `DD_LLMOBS_ENABLED` is forwarded from `process.env` when set.
+  - `DD_LLMOBS_ML_APP` is forwarded when set, **unless** observability is disabled (`DD_LLMOBS_ENABLED` resolves to `"false"` or `"0"`).
+  - Explicit `environment` props win over `process.env`, including for the disable gate — `environment: { DD_LLMOBS_ENABLED: "false" }` suppresses the `DD_LLMOBS_ML_APP` passthrough.
+- Bumps Datadog Lambda layers to `NODE: 139` and `EXTENSION: 97`.

--- a/packages/mcp/release-notes/mcp/0.8.73.md
+++ b/packages/mcp/release-notes/mcp/0.8.73.md
@@ -1,0 +1,10 @@
+---
+version: 0.8.73
+date: 2026-06-17
+summary: Add @jaypie/constructs 1.2.64 release notes; document LLM Observability env passthrough in the cdk skill
+---
+
+## Changes
+
+- Adds release notes for `@jaypie/constructs` 1.2.64 (Datadog LLM Observability env passthrough; Datadog layer bumps).
+- Documents the `DD_LLMOBS_ENABLED` / `DD_LLMOBS_ML_APP` synth-time passthrough behavior in the `cdk` skill.

--- a/packages/mcp/skills/cdk.md
+++ b/packages/mcp/skills/cdk.md
@@ -292,6 +292,10 @@ const handler = new JaypieLambda(this, "Handler", {
 });
 ```
 
+### LLM Observability passthrough
+
+If `DD_LLMOBS_ENABLED` is set at synth time, `JaypieLambda` (and every derivative) forwards it to the Lambda environment. `DD_LLMOBS_ML_APP` is forwarded too — **unless** observability is disabled (`DD_LLMOBS_ENABLED` resolves to `"false"` or `"0"`). Explicit `environment` props win over `process.env`, including the disable gate, so `environment: { DD_LLMOBS_ENABLED: "false" }` suppresses the `DD_LLMOBS_ML_APP` passthrough. This is the deploy-time half of the runtime opt-in documented in `skill("llm")`.
+
 ## JaypieNextJs
 
 Deploy Next.js applications:


### PR DESCRIPTION
## Summary

`jaypieLambdaEnv` — and therefore every `JaypieLambda` derivative (`JaypieExpressLambda`, `JaypieQueuedLambda`, `JaypieWebSocketLambda`, etc.) — now forwards Datadog LLM Observability environment variables to the Lambda at synth time:

- `DD_LLMOBS_ENABLED` is forwarded from `process.env` when set.
- `DD_LLMOBS_ML_APP` is forwarded when set, **unless** observability is disabled (`DD_LLMOBS_ENABLED` resolves to `"false"` or `"0"`).
- Explicit `environment` props win over `process.env`, including the disable gate — `environment: { DD_LLMOBS_ENABLED: "false" }` suppresses the `DD_LLMOBS_ML_APP` passthrough.

This is the deploy-time half of the runtime opt-in already documented in the `llm` skill.

Also folds in an operator Datadog Lambda layer bump (`NODE: 139`, `EXTENSION: 97`).

## Versions

- `@jaypie/constructs` 1.2.63 → 1.2.64
- `@jaypie/mcp` 0.8.72 → 0.8.73 (release notes + `cdk` skill doc)

## Test plan

- 25 `jaypieLambdaEnv` unit tests (8 new for LLM Observability passthrough)
- Full constructs suite: 584 passing
- mcp suite: 41 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)