### PR TITLE
feat: log.flag() + structured-output array contract & LLM Obs flush

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32462,7 +32462,7 @@
     },
     "packages/datadog": {
       "name": "@jaypie/datadog",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "*",
@@ -32843,7 +32843,7 @@
     },
     "packages/express": {
       "name": "@jaypie/express",
-      "version": "1.2.24",
+      "version": "1.2.25",
       "license": "MIT",
       "dependencies": {
         "@jaypie/datadog": "*",
@@ -33219,17 +33219,17 @@
       "license": "MIT"
     },
     "packages/jaypie": {
-      "version": "1.2.53",
+      "version": "1.2.54",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "^1.2.9",
         "@jaypie/core": "^1.2.2",
-        "@jaypie/datadog": "^1.2.3",
+        "@jaypie/datadog": "^1.2.4",
         "@jaypie/errors": "^1.2.2",
-        "@jaypie/express": "^1.2.24",
+        "@jaypie/express": "^1.2.25",
         "@jaypie/kit": "^1.2.9",
-        "@jaypie/lambda": "^1.2.9",
-        "@jaypie/logger": "^1.2.16"
+        "@jaypie/lambda": "^1.2.10",
+        "@jaypie/logger": "^1.2.17"
       },
       "devDependencies": {
         "@jaypie/types": "^0.1.7",
@@ -33320,7 +33320,7 @@
     },
     "packages/lambda": {
       "name": "@jaypie/lambda",
-      "version": "1.2.9",
+      "version": "1.2.10",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-typescript": "^12.1.2",
@@ -33354,7 +33354,7 @@
     },
     "packages/llm": {
       "name": "@jaypie/llm",
-      "version": "1.2.40",
+      "version": "1.2.41",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "*",
@@ -33480,7 +33480,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.73",
+      "version": "0.8.74",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33417,7 +33417,7 @@
     },
     "packages/logger": {
       "name": "@jaypie/logger",
-      "version": "1.2.16",
+      "version": "1.2.17",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-typescript": "^12.1.2",
@@ -33863,7 +33863,7 @@
     },
     "packages/testkit": {
       "name": "@jaypie/testkit",
-      "version": "1.2.43",
+      "version": "1.2.44",
       "license": "MIT",
       "dependencies": {
         "jest-extended": "^4.0.2",

--- a/packages/datadog/CLAUDE.md
+++ b/packages/datadog/CLAUDE.md
@@ -11,7 +11,10 @@ Provides functions to submit metrics to Datadog from Jaypie applications. Suppor
 | Export | Type | Description |
 |--------|------|-------------|
 | `DATADOG` | Constant | Environment variable names, metric types, and default site |
+| `flushLlmObs` | Function | Flush buffered LLM Observability spans via the runtime `dd-trace` singleton. No-op unless `DD_LLMOBS_ENABLED`; never throws. Bundler-safe |
+| `getLlmObs` | Function | Lazy, bundler-safe accessor for the runtime `tracer.llmobs` SDK, or `null` when `dd-trace` is unavailable |
 | `hasDatadogEnv` | Function | Returns `true` if any Datadog API key env var is set |
+| `isLlmObsEnabled` | Function | Returns `true` when `DD_LLMOBS_ENABLED` is truthy (anything but `false`/`0`) |
 | `loadDatadogApiKey` | Async Function | When LLM Observability is enabled, resolve `DD_API_KEY_SECRET_ARN` into `DD_API_KEY` |
 | `submitDistribution` | Async Function | Submit distribution metrics (percentiles, histograms) |
 | `submitMetric` | Async Function | Submit a single metric |
@@ -24,6 +27,7 @@ src/
   constants.ts              # DATADOG constant with env vars and metric types
   datadog.client.ts         # HTTP client for Datadog v1/v2 APIs
   hasDatadogEnv.function.ts # Check for API key presence
+  llmobs.ts                 # Bundler-safe flushLlmObs / getLlmObs / isLlmObsEnabled
   loadDatadogApiKey.function.ts # Load DD_API_KEY from secret ARN for LLM Observability
   index.ts                  # Public exports
   objectToKeyValueArray.pipeline.ts  # Convert tag objects to Datadog format

--- a/packages/datadog/package.json
+++ b/packages/datadog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/datadog",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"

--- a/packages/datadog/src/__tests__/llmobs.spec.ts
+++ b/packages/datadog/src/__tests__/llmobs.spec.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Subject
+import {
+  _resetLlmObs,
+  _setLlmObs,
+  flushLlmObs,
+  getLlmObs,
+  isLlmObsEnabled,
+} from "../llmobs.js";
+
+//
+//
+// Setup
+//
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  _resetLlmObs();
+  delete process.env.DD_LLMOBS_ENABLED;
+});
+
+afterEach(() => {
+  _resetLlmObs();
+  process.env = { ...ORIGINAL_ENV };
+});
+
+//
+//
+// Run tests
+//
+
+describe("llmobs", () => {
+  describe("Base Cases", () => {
+    it("exports functions", () => {
+      expect(typeof flushLlmObs).toBe("function");
+      expect(typeof getLlmObs).toBe("function");
+      expect(typeof isLlmObsEnabled).toBe("function");
+    });
+
+    it("flushLlmObs is a no-op when dd-trace is absent", () => {
+      process.env.DD_LLMOBS_ENABLED = "true";
+      expect(() => flushLlmObs()).not.toThrow();
+    });
+
+    it("getLlmObs returns null when dd-trace is absent", () => {
+      expect(getLlmObs()).toBeNull();
+    });
+  });
+
+  describe("isLlmObsEnabled", () => {
+    it("is false when unset", () => {
+      expect(isLlmObsEnabled()).toBe(false);
+    });
+
+    it.each(["true", "1", "yes", "on"])("is true for %s", (value) => {
+      process.env.DD_LLMOBS_ENABLED = value;
+      expect(isLlmObsEnabled()).toBe(true);
+    });
+
+    it.each(["false", "0", ""])("is false for %s", (value) => {
+      process.env.DD_LLMOBS_ENABLED = value;
+      expect(isLlmObsEnabled()).toBe(false);
+    });
+  });
+
+  describe("flushLlmObs", () => {
+    it("flushes the SDK when enabled", () => {
+      process.env.DD_LLMOBS_ENABLED = "true";
+      const flush = vi.fn();
+      _setLlmObs({ flush });
+
+      flushLlmObs();
+
+      expect(flush).toHaveBeenCalledOnce();
+    });
+
+    it("does not flush when disabled", () => {
+      const flush = vi.fn();
+      _setLlmObs({ flush });
+
+      flushLlmObs();
+
+      expect(flush).not.toHaveBeenCalled();
+    });
+
+    it("swallows flush errors", () => {
+      process.env.DD_LLMOBS_ENABLED = "true";
+      _setLlmObs({
+        flush: () => {
+          throw new Error("boom");
+        },
+      });
+
+      expect(() => flushLlmObs()).not.toThrow();
+    });
+
+    it("no-ops when SDK is unavailable even if enabled", () => {
+      process.env.DD_LLMOBS_ENABLED = "true";
+      _setLlmObs(null);
+
+      expect(() => flushLlmObs()).not.toThrow();
+    });
+  });
+
+  describe("getLlmObs", () => {
+    it("returns the runtime SDK singleton when available", () => {
+      const sdk = { flush: vi.fn() };
+      _setLlmObs(sdk);
+
+      expect(getLlmObs()).toBe(sdk);
+    });
+
+    it("returns the SDK regardless of the enabled flag", () => {
+      // getLlmObs is a raw accessor; gating belongs to flushLlmObs only
+      const sdk = { flush: vi.fn() };
+      _setLlmObs(sdk);
+
+      expect(getLlmObs()).toBe(sdk);
+    });
+  });
+});

--- a/packages/datadog/src/index.ts
+++ b/packages/datadog/src/index.ts
@@ -5,6 +5,7 @@
 
 export { DATADOG } from "./constants.js";
 export { default as hasDatadogEnv } from "./hasDatadogEnv.function.js";
+export { flushLlmObs, getLlmObs, isLlmObsEnabled } from "./llmobs.js";
 export { default as loadDatadogApiKey } from "./loadDatadogApiKey.function.js";
 export { default as submitDistribution } from "./submitDistribution.adapter.js";
 export { default as submitMetric } from "./submitMetric.adapter.js";

--- a/packages/datadog/src/llmobs.ts
+++ b/packages/datadog/src/llmobs.ts
@@ -1,0 +1,151 @@
+import { createRequire } from "module";
+import { pathToFileURL } from "url";
+
+import { log } from "@jaypie/logger";
+
+import { DATADOG } from "./constants.js";
+
+//
+//
+// Types
+//
+
+/**
+ * Minimal shape of the dd-trace `llmobs` SDK surface. The runtime object
+ * exposes much more (`trace`, `annotate`, `submitEvaluation`, …); we type only
+ * `flush` and allow arbitrary access for manual use cases.
+ */
+export interface LlmObs {
+  flush: () => void;
+  [key: string]: unknown;
+}
+
+//
+//
+// Constants
+//
+
+const MODULE = {
+  // Computed at runtime so bundlers (esbuild/rollup) do not attempt to include
+  // dd-trace. On Lambda, dd-trace is provided by the Datadog layer at runtime;
+  // resolving a bundled copy would be a different module instance whose buffer
+  // never ships (singleton correctness).
+  DD_TRACE: ["dd", "trace"].join("-"),
+};
+
+//
+//
+// Helpers
+//
+
+// CJS/ESM compatible require - handles bundling to CJS where import.meta.url
+// becomes undefined (mirrors packages/llm/src/observability/llmobs.ts).
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore - __filename exists in CJS context when ESM is bundled to CJS
+const requireModule =
+  typeof __filename !== "undefined"
+    ? createRequire(pathToFileURL(__filename).href)
+    : createRequire(import.meta.url);
+
+let resolved = false;
+let cachedLlmObs: LlmObs | null = null;
+let injectedLlmObs: LlmObs | null | undefined;
+
+/**
+ * Lazily resolve the runtime dd-trace `llmobs` SDK singleton. Returns null (and
+ * never throws) when dd-trace is absent or the SDK surface is unexpected.
+ * Cached after the first attempt.
+ */
+function resolveLlmObs(): LlmObs | null {
+  if (resolved) {
+    return cachedLlmObs;
+  }
+  resolved = true;
+  try {
+    const ddTrace = requireModule(MODULE.DD_TRACE);
+    const tracer = ddTrace?.default ?? ddTrace;
+    const llmobs = tracer?.llmobs;
+    if (llmobs && typeof llmobs === "object") {
+      cachedLlmObs = llmobs as LlmObs;
+    }
+  } catch {
+    cachedLlmObs = null;
+  }
+  return cachedLlmObs;
+}
+
+/** The injected (test) SDK when set, otherwise the runtime singleton. */
+function currentLlmObs(): LlmObs | null {
+  return injectedLlmObs !== undefined ? injectedLlmObs : resolveLlmObs();
+}
+
+/** Reset the cached SDK resolution. Exposed for tests. */
+export function _resetLlmObs(): void {
+  resolved = false;
+  cachedLlmObs = null;
+  injectedLlmObs = undefined;
+}
+
+/**
+ * Inject an SDK to bypass dd-trace resolution. Test-only: dd-trace is not a
+ * dependency, so the resolved path cannot otherwise be exercised in unit tests.
+ */
+export function _setLlmObs(sdk: LlmObs | null): void {
+  injectedLlmObs = sdk;
+}
+
+//
+//
+// Main
+//
+
+/**
+ * True when LLM Observability emission is opted in via `DD_LLMOBS_ENABLED`.
+ * Accepts any truthy value except "false"/"0".
+ */
+export function isLlmObsEnabled(): boolean {
+  const value = process.env[DATADOG.ENV.DD_LLMOBS_ENABLED];
+  if (!value) {
+    return false;
+  }
+  const normalized = value.trim().toLowerCase();
+  return normalized !== "" && normalized !== "false" && normalized !== "0";
+}
+
+/**
+ * Bundler-safe accessor for the runtime dd-trace `llmobs` SDK singleton.
+ *
+ * Returns the runtime `tracer.llmobs`, or `null` when dd-trace cannot be
+ * resolved. Use it for the genuine manual cases — opening an enclosing
+ * `workflow`/`agent` span so model/tool spans nest correctly via
+ * AsyncLocalStorage, custom annotations, or `submitEvaluation`. Resolving the
+ * runtime singleton (never a bundled copy) keeps spans on the buffer the layer
+ * actually flushes.
+ */
+export function getLlmObs(): LlmObs | null {
+  return currentLlmObs();
+}
+
+/**
+ * Flush buffered LLM Observability spans through the runtime dd-trace
+ * singleton. On Lambda the runtime freezes the instant the handler resolves, so
+ * buffered spans are dropped unless flushed before return.
+ *
+ * Silent no-op when LLM Obs is disabled (`DD_LLMOBS_ENABLED` falsy) or dd-trace
+ * cannot be resolved. Wrapped so instrumentation never breaks the caller.
+ */
+export function flushLlmObs(): void {
+  if (!isLlmObsEnabled()) {
+    return;
+  }
+  const llmobs = currentLlmObs();
+  if (!llmobs || typeof llmobs.flush !== "function") {
+    return;
+  }
+  try {
+    llmobs.flush();
+  } catch (error) {
+    log.warn("[@jaypie/datadog] LLM Observability flush failed");
+    log.var({ error });
+  }
+}

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/express",
-  "version": "1.2.24",
+  "version": "1.2.25",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"

--- a/packages/express/src/adapter/__tests__/integration.spec.ts
+++ b/packages/express/src/adapter/__tests__/integration.spec.ts
@@ -1,6 +1,17 @@
 import express from "express";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { flushLlmObs } from "@jaypie/datadog";
+
+vi.mock("@jaypie/datadog", async () => {
+  const actual = await vi.importActual("@jaypie/datadog");
+  return {
+    ...actual,
+    flushLlmObs: vi.fn(),
+    loadDatadogApiKey: vi.fn(),
+  };
+});
+
 import type {
   AwsLambdaGlobal,
   FunctionUrlEvent,
@@ -129,6 +140,30 @@ describe("Lambda Adapter Integration", () => {
       expect(result.statusCode).toBe(200);
       expect(result.headers["content-type"]).toBe("application/json");
       expect(JSON.parse(result.body)).toEqual({ message: "Hello World" });
+    });
+
+    it("flushes LLM Observability spans before returning", async () => {
+      const app = express();
+      app.get("/", (_req, res) => {
+        res.json({ message: "Hello World" });
+      });
+
+      const handler = createLambdaHandler(app);
+      await handler(createMockEvent(), mockContext);
+
+      expect(flushLlmObs).toHaveBeenCalledOnce();
+    });
+
+    it("flushes LLM Observability spans even when the app errors", async () => {
+      const app = express();
+      app.get("/", () => {
+        throw new Error("boom");
+      });
+
+      const handler = createLambdaHandler(app);
+      await handler(createMockEvent(), mockContext);
+
+      expect(flushLlmObs).toHaveBeenCalledOnce();
     });
 
     it("handles POST request with JSON body", async () => {

--- a/packages/express/src/adapter/index.ts
+++ b/packages/express/src/adapter/index.ts
@@ -1,5 +1,7 @@
 import type { Application, Request, Response } from "express";
 
+import { flushLlmObs } from "@jaypie/datadog";
+
 import { createLambdaRequest, LambdaRequest } from "./LambdaRequest.js";
 import LambdaResponseBuffered from "./LambdaResponseBuffered.js";
 import LambdaResponseStreaming from "./LambdaResponseStreaming.js";
@@ -155,6 +157,10 @@ export function createLambdaHandler(
     } finally {
       // Clear current invoke context
       clearCurrentInvoke();
+
+      // Flush buffered LLM Observability spans before the Lambda freezes.
+      // No-op unless DD_LLMOBS_ENABLED; never throws.
+      flushLlmObs();
     }
   };
 }
@@ -210,6 +216,10 @@ export function createLambdaStreamHandler(
       } finally {
         // Clear current invoke context
         clearCurrentInvoke();
+
+        // Flush buffered LLM Observability spans before the Lambda freezes.
+        // No-op unless DD_LLMOBS_ENABLED; never throws.
+        flushLlmObs();
       }
     },
   );

--- a/packages/jaypie/package.json
+++ b/packages/jaypie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jaypie",
-  "version": "1.2.53",
+  "version": "1.2.54",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"
@@ -34,12 +34,12 @@
   "dependencies": {
     "@jaypie/aws": "^1.2.9",
     "@jaypie/core": "^1.2.2",
-    "@jaypie/datadog": "^1.2.3",
+    "@jaypie/datadog": "^1.2.4",
     "@jaypie/errors": "^1.2.2",
-    "@jaypie/express": "^1.2.24",
+    "@jaypie/express": "^1.2.25",
     "@jaypie/kit": "^1.2.9",
-    "@jaypie/lambda": "^1.2.9",
-    "@jaypie/logger": "^1.2.16"
+    "@jaypie/lambda": "^1.2.10",
+    "@jaypie/logger": "^1.2.17"
   },
   "devDependencies": {
     "@jaypie/types": "^0.1.7",

--- a/packages/lambda/CLAUDE.md
+++ b/packages/lambda/CLAUDE.md
@@ -177,7 +177,7 @@ const { lambdaHandler } = original.lambda;
 4. **Validate** - Run validation functions
 4. **Setup** - Run setup functions
 5. **Handler** - Execute main handler logic
-6. **Teardown** - Run teardown functions (always runs)
+6. **Teardown** - Run teardown functions, then auto-flush LLM Obs spans via `flushLlmObs()` — runs after user teardown and always (finally), so spans flush before the Lambda freezes even on throw. No-op unless `DD_LLMOBS_ENABLED`
 7. **Response** - Return result or error body
 
 ## Error Handling

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/lambda",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"

--- a/packages/lambda/src/__tests__/lambdaHandler.spec.ts
+++ b/packages/lambda/src/__tests__/lambdaHandler.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ConfigurationError } from "@jaypie/errors";
+import { flushLlmObs } from "@jaypie/datadog";
 import { HTTP, jaypieHandler } from "@jaypie/kit";
 import { log } from "@jaypie/logger";
 import { restoreLog, spyLog } from "@jaypie/testkit";
@@ -34,6 +35,15 @@ vi.mock("@jaypie/kit", async () => {
     ),
   };
   return module;
+});
+
+vi.mock("@jaypie/datadog", async () => {
+  const actual = await vi.importActual("@jaypie/datadog");
+  return {
+    ...actual,
+    flushLlmObs: vi.fn(),
+    loadDatadogApiKey: vi.fn(),
+  };
 });
 
 //
@@ -248,6 +258,43 @@ describe("Lambda Handler Module", () => {
         // Act & Assert
         await expect(handler({}, {})).rejects.toThrow();
         expect(log.debug).toHaveBeenCalled();
+      });
+    });
+    describe("LLM Observability", () => {
+      it("flushes LLM Observability spans during teardown", async () => {
+        // Arrange
+        const handler = lambdaHandler(vi.fn());
+        // Act
+        await handler({}, {});
+        // Assert
+        expect(flushLlmObs).toHaveBeenCalledOnce();
+      });
+      it("flushes after user teardown runs", async () => {
+        // Arrange
+        const order: string[] = [];
+        const userTeardown = vi.fn(() => {
+          order.push("user");
+        });
+        (flushLlmObs as ReturnType<typeof vi.fn>).mockImplementation(() => {
+          order.push("flush");
+        });
+        const handler = lambdaHandler(vi.fn(), { teardown: [userTeardown] });
+        // Act
+        await handler({}, {});
+        // Assert
+        expect(userTeardown).toHaveBeenCalled();
+        expect(order).toEqual(["user", "flush"]);
+      });
+      it("flushes even when the handler throws", async () => {
+        // Arrange
+        const mockFunction = vi.fn(() => {
+          throw new Error("boom");
+        });
+        const handler = lambdaHandler(mockFunction);
+        // Act
+        await handler({}, {});
+        // Assert
+        expect(flushLlmObs).toHaveBeenCalledOnce();
       });
     });
   });

--- a/packages/lambda/src/__tests__/lambdaStreamHandler.spec.ts
+++ b/packages/lambda/src/__tests__/lambdaStreamHandler.spec.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ConfigurationError, BadRequestError } from "@jaypie/errors";
+import { flushLlmObs } from "@jaypie/datadog";
 import { jaypieHandler } from "@jaypie/kit";
 import { log } from "@jaypie/logger";
 import { restoreLog, spyLog } from "@jaypie/testkit";
@@ -32,6 +33,15 @@ vi.mock("@jaypie/kit", async () => {
     ),
   };
   return module;
+});
+
+vi.mock("@jaypie/datadog", async () => {
+  const actual = await vi.importActual("@jaypie/datadog");
+  return {
+    ...actual,
+    flushLlmObs: vi.fn(),
+    loadDatadogApiKey: vi.fn(),
+  };
 });
 
 //
@@ -347,6 +357,28 @@ describe("lambdaStreamHandler", () => {
       expect(responseStream.setContentType).toHaveBeenCalledWith(
         "application/json",
       );
+    });
+  });
+
+  describe("LLM Observability", () => {
+    it("flushes LLM Observability spans during teardown", async () => {
+      const handler = lambdaStreamHandler(async () => {});
+      const responseStream = createMockResponseStream();
+
+      await (handler as unknown as AwsStreamingHandler)({}, responseStream, {});
+
+      expect(flushLlmObs).toHaveBeenCalledOnce();
+    });
+
+    it("flushes even when the handler throws", async () => {
+      const handler = lambdaStreamHandler(async () => {
+        throw new Error("boom");
+      });
+      const responseStream = createMockResponseStream();
+
+      await (handler as unknown as AwsStreamingHandler)({}, responseStream, {});
+
+      expect(flushLlmObs).toHaveBeenCalledOnce();
     });
   });
 });

--- a/packages/lambda/src/lambdaHandler.ts
+++ b/packages/lambda/src/lambdaHandler.ts
@@ -1,5 +1,5 @@
 import { loadEnvSecrets } from "@jaypie/aws";
-import { loadDatadogApiKey } from "@jaypie/datadog";
+import { flushLlmObs, loadDatadogApiKey } from "@jaypie/datadog";
 import { ConfigurationError, UnhandledError } from "@jaypie/errors";
 import { JAYPIE, jaypieHandler } from "@jaypie/kit";
 import { log as publicLogger } from "@jaypie/logger";
@@ -102,6 +102,14 @@ const lambdaHandler = function <TEvent = unknown, TResult = unknown>(
     await loadDatadogApiKey();
   };
   setup = [datadogLlmObsSetup, ...setup];
+
+  // Flush buffered LLM Observability spans before the Lambda freezes. Runs last
+  // (after user teardown) and always — jaypieHandler runs teardown in a finally,
+  // so spans flush even when the handler throws. No-op unless LLM Obs is enabled.
+  const datadogLlmObsTeardown: LifecycleFunction = async () => {
+    flushLlmObs();
+  };
+  teardown = [...(teardown ?? []), datadogLlmObsTeardown];
 
   //
   //

--- a/packages/lambda/src/lambdaStreamHandler.ts
+++ b/packages/lambda/src/lambdaStreamHandler.ts
@@ -4,7 +4,7 @@ import {
   loadEnvSecrets,
 } from "@jaypie/aws";
 import type { StreamFormat } from "@jaypie/aws";
-import { loadDatadogApiKey } from "@jaypie/datadog";
+import { flushLlmObs, loadDatadogApiKey } from "@jaypie/datadog";
 import { ConfigurationError, UnhandledError } from "@jaypie/errors";
 import { JAYPIE, jaypieHandler } from "@jaypie/kit";
 import { log as publicLogger } from "@jaypie/logger";
@@ -205,6 +205,14 @@ const lambdaStreamHandler = function <TEvent = unknown>(
     await loadDatadogApiKey();
   };
   setup = [datadogLlmObsSetup, ...setup];
+
+  // Flush buffered LLM Observability spans before the Lambda freezes. Runs last
+  // (after user teardown) and always — jaypieHandler runs teardown in a finally,
+  // so spans flush even when the handler throws. No-op unless LLM Obs is enabled.
+  const datadogLlmObsTeardown: LifecycleFunction = async () => {
+    flushLlmObs();
+  };
+  teardown = [...(teardown ?? []), datadogLlmObsTeardown];
 
   //
   //

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/llm",
-  "version": "1.2.40",
+  "version": "1.2.41",
   "description": "Large language model utilities",
   "repository": {
     "type": "git",

--- a/packages/llm/src/operate/OperateLoop.ts
+++ b/packages/llm/src/operate/OperateLoop.ts
@@ -19,7 +19,11 @@ import {
   usageToLlmObsMetrics,
   withLlmObsSpan,
 } from "../observability/llmobs.js";
-import { getLogger, maxTurnsFromOptions } from "../util/index.js";
+import {
+  fillFormatArrays,
+  getLogger,
+  maxTurnsFromOptions,
+} from "../util/index.js";
 import { ProviderAdapter } from "./adapters/ProviderAdapter.interface.js";
 import { HookRunner, hookRunner, LlmHooks } from "./hooks/index.js";
 import { InputProcessor, inputProcessor } from "./input/index.js";
@@ -379,7 +383,9 @@ export class OperateLoop {
     if (this.adapter.hasStructuredOutput(response)) {
       const structuredOutput = this.adapter.extractStructuredOutput(response);
       if (structuredOutput) {
-        state.responseBuilder.setContent(structuredOutput);
+        state.responseBuilder.setContent(
+          this.applyFormatArrayDefaults(structuredOutput, options),
+        );
         state.responseBuilder.complete();
         return false; // Stop loop
       }
@@ -541,7 +547,9 @@ export class OperateLoop {
     }
 
     // No tool calls or no toolkit - we're done
-    state.responseBuilder.setContent(parsed.content);
+    state.responseBuilder.setContent(
+      this.applyFormatArrayDefaults(parsed.content, options),
+    );
     state.responseBuilder.complete();
 
     // Add final history items
@@ -551,6 +559,24 @@ export class OperateLoop {
     }
 
     return false; // Stop loop
+  }
+
+  /**
+   * Backfill declared array fields when a `format` is supplied. A declared
+   * `format` is a schema contract: an empty array field should surface as `[]`
+   * rather than be dropped by a provider/model that omits empty lists.
+   */
+  private applyFormatArrayDefaults(
+    content: string | JsonObject | undefined,
+    options: LlmOperateOptions,
+  ): string | JsonObject | undefined {
+    if (!options.format) {
+      return content;
+    }
+    if (typeof content !== "object" || content === null) {
+      return content;
+    }
+    return fillFormatArrays({ content, format: options.format });
   }
 
   /**

--- a/packages/llm/src/operate/__tests__/OperateLoop.spec.ts
+++ b/packages/llm/src/operate/__tests__/OperateLoop.spec.ts
@@ -15,6 +15,7 @@ import {
 } from "../../types/LlmProvider.interface.js";
 import { ErrorCategory, ParsedResponse, StandardToolCall } from "../types.js";
 import { Toolkit } from "../../tools/Toolkit.class.js";
+import { JsonObject } from "@jaypie/types";
 
 //
 //
@@ -586,6 +587,62 @@ describe("OperateLoop", () => {
         });
 
         expect(result.content).toEqual({ name: "John", age: 30 });
+      });
+
+      it("backfills declared array fields omitted from structured output", async () => {
+        mockAdapter.hasStructuredOutput = vi.fn(() => true);
+        mockAdapter.extractStructuredOutput = vi.fn(() => ({
+          "Merchant Request": "refund",
+        }));
+
+        const loop = new OperateLoop({
+          adapter: mockAdapter,
+          client: mockClient,
+        });
+
+        const result = await loop.execute("Get data", {
+          format: {
+            "Merchant Request": String,
+            "Merchant Attachments": [String],
+            "Recommended Actions": [String],
+          },
+        });
+
+        expect(result.content).toEqual({
+          "Merchant Request": "refund",
+          "Merchant Attachments": [],
+          "Recommended Actions": [],
+        });
+      });
+
+      it("backfills declared array fields omitted from parsed content", async () => {
+        mockAdapter.parseResponse = vi.fn(
+          (response): ParsedResponse => ({
+            content: { name: "Jane" } as JsonObject,
+            hasToolCalls: false,
+            stopReason: "end_turn",
+            usage: {
+              input: 10,
+              output: 20,
+              reasoning: 0,
+              total: 30,
+              provider: "mock",
+              model: "mock-model",
+            },
+            raw: response,
+          }),
+        );
+
+        const loop = new OperateLoop({
+          adapter: mockAdapter,
+          client: mockClient,
+        });
+
+        const result = await loop.execute("Get data", {
+          format: { name: String, tags: [String] },
+        });
+
+        expect(result.content).toEqual({ name: "Jane", tags: [] });
       });
     });
   });

--- a/packages/llm/src/util/__tests__/fillFormatArrays.spec.ts
+++ b/packages/llm/src/util/__tests__/fillFormatArrays.spec.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod/v4";
+
+import { fillFormatArrays } from "../fillFormatArrays.js";
+
+describe("fillFormatArrays", () => {
+  describe("Base Cases", () => {
+    it("is a function", () => {
+      expect(typeof fillFormatArrays).toBe("function");
+    });
+
+    it("returns content unchanged when no array fields are declared", () => {
+      const content = { name: "Alice" };
+      const result = fillFormatArrays({
+        content,
+        format: { name: String },
+      });
+      expect(result).toEqual({ name: "Alice" });
+    });
+  });
+
+  describe("NaturalSchema", () => {
+    it("fills a declared array field that the model omitted", () => {
+      const result = fillFormatArrays({
+        content: { "Merchant Request": "refund" },
+        format: {
+          "Merchant Request": String,
+          "Merchant Attachments": [String],
+          "Recommended Actions": [String],
+        },
+      });
+      expect(result).toEqual({
+        "Merchant Request": "refund",
+        "Merchant Attachments": [],
+        "Recommended Actions": [],
+      });
+    });
+
+    it("leaves populated array fields intact", () => {
+      const result = fillFormatArrays({
+        content: { tags: ["a", "b"] },
+        format: { tags: [String] },
+      });
+      expect(result).toEqual({ tags: ["a", "b"] });
+    });
+
+    it("does not mutate the input content", () => {
+      const content = { tags: undefined } as Record<string, unknown>;
+      fillFormatArrays({
+        content: content as never,
+        format: { tags: [String] },
+      });
+      expect(content.tags).toBeUndefined();
+    });
+
+    it("backfills arrays nested inside declared objects", () => {
+      const result = fillFormatArrays({
+        content: { meta: { title: "x" } },
+        format: { meta: { title: String, labels: [String] } },
+      });
+      expect(result).toEqual({ meta: { title: "x", labels: [] } });
+    });
+
+    it("backfills arrays nested inside arrays of objects", () => {
+      const result = fillFormatArrays({
+        content: { items: [{ name: "x" }] },
+        format: { items: [{ name: String, tags: [String] }] },
+      });
+      expect(result).toEqual({ items: [{ name: "x", tags: [] }] });
+    });
+
+    it("does not treat string enums as arrays", () => {
+      const result = fillFormatArrays({
+        content: { color: "red" },
+        format: { color: ["red", "green", "blue"] },
+      });
+      expect(result).toEqual({ color: "red" });
+    });
+  });
+
+  describe("Zod schema", () => {
+    it("fills declared array fields", () => {
+      const format = z.object({
+        name: z.string(),
+        tags: z.array(z.string()),
+      });
+      const result = fillFormatArrays({
+        content: { name: "Alice" },
+        format,
+      });
+      expect(result).toEqual({ name: "Alice", tags: [] });
+    });
+  });
+});

--- a/packages/llm/src/util/fillFormatArrays.ts
+++ b/packages/llm/src/util/fillFormatArrays.ts
@@ -1,0 +1,113 @@
+import { z } from "zod/v4";
+import { JsonObject, NaturalSchema } from "@jaypie/types";
+
+import { naturalZodSchema } from "./naturalZodSchema.js";
+
+//
+//
+// Types
+//
+
+type Format = JsonObject | NaturalSchema | z.ZodType;
+
+//
+//
+// Helpers
+//
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Convert a `format` declaration (Zod schema, NaturalSchema, or a JSON Schema
+ * JsonObject) into a plain JSON Schema we can walk. Mirrors the conversion the
+ * provider adapters perform in `formatOutputSchema`, but without any
+ * provider-specific sanitization.
+ */
+function formatToJsonSchema(format: Format): JsonObject | undefined {
+  if (format instanceof z.ZodType) {
+    return z.toJSONSchema(format) as JsonObject;
+  }
+  if (isPlainObject(format) && (format as JsonObject).type === "json_schema") {
+    const clone = structuredClone(format) as JsonObject;
+    clone.type = "object";
+    return clone;
+  }
+  try {
+    return z.toJSONSchema(
+      naturalZodSchema(format as NaturalSchema),
+    ) as JsonObject;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Walk a JSON Schema alongside a parsed value, filling any declared array field
+ * that is absent (`undefined`/`null`) with `[]`. Recurses into object
+ * properties and array items so nested declared arrays are also backfilled.
+ */
+function fillFromSchema(schema: unknown, value: unknown): unknown {
+  if (!isPlainObject(schema)) {
+    return value;
+  }
+
+  const type = schema.type;
+  const isArray = type === "array" || (type === undefined && "items" in schema);
+  if (isArray) {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    const items = schema.items;
+    if (Array.isArray(value) && isPlainObject(items)) {
+      return value.map((entry) => fillFromSchema(items, entry));
+    }
+    return value;
+  }
+
+  const isObject =
+    type === "object" || (type === undefined && "properties" in schema);
+  if (isObject) {
+    if (!isPlainObject(value)) {
+      return value;
+    }
+    const properties = schema.properties;
+    if (isPlainObject(properties)) {
+      for (const [key, propSchema] of Object.entries(properties)) {
+        value[key] = fillFromSchema(propSchema, value[key]);
+      }
+    }
+    return value;
+  }
+
+  return value;
+}
+
+//
+//
+// Main
+//
+
+/**
+ * Ensure every array field declared in `format` is present in `content` as an
+ * array. A declared `format` is a schema contract: an empty list should surface
+ * as `[]`, not be dropped from the response. Some providers/models omit empty
+ * array fields entirely, leaving consumers to read `.length` on `undefined`.
+ *
+ * Only mutates a (cloned) structured object; strings and non-objects pass
+ * through untouched.
+ */
+export function fillFormatArrays({
+  content,
+  format,
+}: {
+  content: JsonObject;
+  format: Format;
+}): JsonObject {
+  const schema = formatToJsonSchema(format);
+  if (!schema) {
+    return content;
+  }
+  return fillFromSchema(schema, structuredClone(content)) as JsonObject;
+}

--- a/packages/llm/src/util/index.ts
+++ b/packages/llm/src/util/index.ts
@@ -1,5 +1,6 @@
 export * from "./determineModelProvider.js";
 export * from "./extractReasoning.js";
+export * from "./fillFormatArrays.js";
 export * from "./formatOperateInput.js";
 export * from "./formatOperateMessage.js";
 export * from "./jsonSchemaToOpenApi3.js";

--- a/packages/logger/CLAUDE.md
+++ b/packages/logger/CLAUDE.md
@@ -129,6 +129,7 @@ Tags are key-value pairs included in every log output:
 ```typescript
 log.tag({ requestId: "abc-123" });
 log.with({ userId: "456" }).info("User action"); // Creates child logger
+log.flag("beta").info("Behind a flag"); // Child logger tagged { flag: "beta" }; no-op without a string
 ```
 
 ## API Reference
@@ -142,6 +143,7 @@ Factory function returning a `JaypieLogger` instance.
 - `debug/info/warn/error/fatal/trace(...messages)` - Log at level
 - `*.var(keyValue)` - Log variable at level
 - `var(keyValue)` - Log variable at configured var level
+- `flag(flag?)` - Returns a child logger tagged `{ flag }` for a non-empty string; returns the same logger for `undefined`, non-strings, or empty string
 - `init()` - Reset logger state (used between Lambda invocations)
 - `lib({ lib?, level?, tags? })` - Create library logger (silent by default)
 - `tag(tags)` - Add tags to all loggers

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/logger",
-  "version": "1.2.16",
+  "version": "1.2.17",
   "description": "Logger utilities for Jaypie applications",
   "repository": {
     "type": "git",

--- a/packages/logger/src/JaypieLogger.ts
+++ b/packages/logger/src/JaypieLogger.ts
@@ -111,6 +111,13 @@ class JaypieLogger {
       this._logger.var(logVar(messageObject, messageValue));
   }
 
+  public flag(flag?: string): JaypieLogger {
+    if (typeof flag !== "string" || flag === "") {
+      return this;
+    }
+    return this.with({ flag });
+  }
+
   public init(): void {
     _resetDatadogTransport();
     for (const logger of this._loggers) {

--- a/packages/logger/src/__tests__/index.spec.ts
+++ b/packages/logger/src/__tests__/index.spec.ts
@@ -67,6 +67,31 @@ describe("@jaypie/logger", () => {
   });
 
   describe("Features", () => {
+    describe("flag", () => {
+      it("returns a child logger tagged with flag for a string", () => {
+        const logger = createLogger();
+        const flagged = logger.flag("alpha");
+        expect(flagged).toBeDefined();
+        expect(flagged).not.toBe(logger);
+        expect(flagged.debug).toBeDefined();
+      });
+
+      it("returns the same logger for undefined", () => {
+        const logger = createLogger();
+        expect(logger.flag(undefined)).toBe(logger);
+      });
+
+      it("returns the same logger for an empty string", () => {
+        const logger = createLogger();
+        expect(logger.flag("")).toBe(logger);
+      });
+
+      it("returns the same logger for a non-string", () => {
+        const logger = createLogger();
+        expect(logger.flag(42 as unknown as string)).toBe(logger);
+      });
+    });
+
     describe("Multi-param logging", () => {
       afterEach(() => {
         vi.restoreAllMocks();

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.73",
+  "version": "0.8.74",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/datadog/1.2.4.md
+++ b/packages/mcp/release-notes/datadog/1.2.4.md
@@ -1,0 +1,19 @@
+---
+version: 1.2.4
+date: 2026-06-18
+summary: Add bundler-safe flushLlmObs(), getLlmObs(), and isLlmObsEnabled()
+---
+
+## Changes
+
+- `flushLlmObs()` — flush buffered LLM Observability spans via the runtime `dd-trace` singleton. No-op unless `DD_LLMOBS_ENABLED` is truthy or when `dd-trace` is absent; wrapped so it never throws.
+- `getLlmObs()` — lazy, bundler-safe accessor for the runtime `tracer.llmobs` SDK, or `null` when `dd-trace` cannot be resolved. For manual enclosing spans, annotations, and `submitEvaluation`.
+- `isLlmObsEnabled()` — `true` when `DD_LLMOBS_ENABLED` is truthy (anything but `false`/`0`).
+
+## Notes
+
+`dd-trace` is resolved at runtime via a computed module specifier, so bundlers (esbuild/rollup) leave it external and the layer-initialized singleton is used — never a bundled copy whose buffer would never ship.
+
+## Migration
+
+No changes required. New exports are additive.

--- a/packages/mcp/release-notes/express/1.2.25.md
+++ b/packages/mcp/release-notes/express/1.2.25.md
@@ -1,0 +1,18 @@
+---
+version: 1.2.25
+date: 2026-06-18
+summary: Auto-flush LLM Observability spans in the Lambda adapters
+---
+
+## Changes
+
+- `createLambdaHandler` and `createLambdaStreamHandler` call `flushLlmObs()` from `@jaypie/datadog` in their `finally` block.
+- Buffered Datadog LLM Obs spans flush before the Lambda freezes — even when the Express app errors.
+
+## Notes
+
+No-op unless `DD_LLMOBS_ENABLED` is truthy; never affects the response. No per-handler flush code is required.
+
+## Migration
+
+No changes required.

--- a/packages/mcp/release-notes/jaypie/1.2.54.md
+++ b/packages/mcp/release-notes/jaypie/1.2.54.md
@@ -1,0 +1,14 @@
+---
+version: 1.2.54
+date: 2026-06-18
+summary: Pull updated datadog, express, lambda, and logger subpackages
+---
+
+## Changes
+
+- Bumps `@jaypie/datadog` (`^1.2.4`), `@jaypie/express` (`^1.2.25`), `@jaypie/lambda` (`^1.2.10`), and `@jaypie/logger` (`^1.2.17`).
+- Surfaces the new `flushLlmObs`, `getLlmObs`, and `isLlmObsEnabled` exports (re-exported from `@jaypie/datadog`) and LLM Observability auto-flush in the Lambda/Express handlers.
+
+## Migration
+
+No changes required.

--- a/packages/mcp/release-notes/lambda/1.2.10.md
+++ b/packages/mcp/release-notes/lambda/1.2.10.md
@@ -1,0 +1,18 @@
+---
+version: 1.2.10
+date: 2026-06-18
+summary: Auto-flush LLM Observability spans in handler teardown
+---
+
+## Changes
+
+- `lambdaHandler` and `lambdaStreamHandler` append a final teardown step that calls `flushLlmObs()` from `@jaypie/datadog`.
+- Runs after user teardown and always (jaypieHandler runs teardown in a `finally`), so buffered LLM Obs spans flush before the Lambda freezes — even when the handler throws.
+
+## Notes
+
+No-op unless `DD_LLMOBS_ENABLED` is truthy; a flush failure never affects the handler response. No per-handler flush code is required.
+
+## Migration
+
+No changes required.

--- a/packages/mcp/release-notes/llm/1.2.41.md
+++ b/packages/mcp/release-notes/llm/1.2.41.md
@@ -1,0 +1,18 @@
+---
+version: 1.2.41
+date: 2026-06-18
+summary: operate() backfills declared array fields in structured output
+---
+
+## Changes
+
+- A declared `format` is treated as a schema contract: every array field declared in `format` is now present in `content` as an array. An empty list surfaces as `[]` rather than being dropped (`undefined`/absent), so `content.someArray.length` is safe across all providers.
+- New util `fillFormatArrays` walks the schema (NaturalSchema, Zod, or JSON Schema) and recurses into nested objects and arrays of objects.
+
+## Notes
+
+The shipped npm `1.3.0` predates the Datadog LLM Observability emission feature and contains no `dd-trace` code — a `^1.2` range resolves to `1.3.0` and silently loses emission. Pin to a feature-bearing `latest` 1.2.x until a release above `1.3.0` ships.
+
+## Migration
+
+No changes required. Consumers that defensively normalized missing array fields to `[]` can drop that workaround.

--- a/packages/mcp/release-notes/logger/1.2.17.md
+++ b/packages/mcp/release-notes/logger/1.2.17.md
@@ -1,0 +1,18 @@
+---
+version: 1.2.17
+date: 2026-06-18
+summary: Add log.flag() for conditional child loggers tagged with a flag
+---
+
+## Changes
+
+- Added `log.flag(flag?)` to `JaypieLogger`
+  - For a non-empty string, returns a child logger tagged `{ flag }` (via `with`)
+  - For `undefined`, a non-string, or an empty string, returns the same logger unchanged
+
+## Usage
+
+```typescript
+log.flag("beta").info("Behind a flag"); // tags { flag: "beta" }
+log.flag(maybeFlag).info("Always logs"); // no-op tag when maybeFlag is falsy/non-string
+```

--- a/packages/mcp/release-notes/mcp/0.8.74.md
+++ b/packages/mcp/release-notes/mcp/0.8.74.md
@@ -1,0 +1,15 @@
+---
+version: 0.8.74
+date: 2026-06-18
+summary: Document LLM Observability flush primitives and handler auto-flush
+---
+
+## Changes
+
+- `datadog` skill: document `flushLlmObs()`, `getLlmObs()`, and `isLlmObsEnabled()`.
+- `lambda` and `express` skills: document automatic LLM Obs flush in handler teardown.
+- `llm` skill: add an Availability note (npm `1.3.0` predates LLM Obs emission) and Lambda flush guidance.
+
+## Migration
+
+No changes required.

--- a/packages/mcp/release-notes/testkit/1.2.44.md
+++ b/packages/mcp/release-notes/testkit/1.2.44.md
@@ -1,0 +1,18 @@
+---
+version: 1.2.44
+date: 2026-06-18
+summary: Add flag to the log mock surface
+---
+
+## Changes
+
+- Adds `flag` to the log mock (`mockLogFactory`), returning the mock for chaining like `with`/`lib`.
+- Adds `flag` to the spy/restore method list and the `LogMock` type.
+
+## Motivation
+
+Keeps testkit's log mock in sync with the new `log.flag()` method in `@jaypie/logger`.
+
+## Migration
+
+No changes required.

--- a/packages/mcp/skills/datadog.md
+++ b/packages/mcp/skills/datadog.md
@@ -101,6 +101,30 @@ await datadogEvent({
 });
 ```
 
+### LLM Observability primitives
+
+Bundler-safe access to the runtime `dd-trace` LLM Obs singleton. `dd-trace` is resolved at runtime via a computed module specifier (never bundled), so on Lambda these reach the layer-initialized singleton — a bundled copy would be a different instance whose buffer never ships.
+
+```typescript
+import { flushLlmObs, getLlmObs, isLlmObsEnabled } from "@jaypie/datadog";
+
+isLlmObsEnabled(); // true when DD_LLMOBS_ENABLED is truthy (not "false"/"0")
+
+// Manual span / annotation / submitEvaluation against the runtime SDK
+getLlmObs()?.trace({ kind: "workflow", name: "my-job" }, async () => {
+  /* ... */
+});
+
+// Flush before the Lambda freezes — no-op unless enabled; never throws
+flushLlmObs();
+```
+
+| Export | Description |
+|--------|-------------|
+| `flushLlmObs()` | Flush buffered LLM Obs spans. No-op when `DD_LLMOBS_ENABLED` is falsy or `dd-trace` is absent; wrapped so it never throws. Called automatically in `@jaypie/lambda`/`@jaypie/express` handler teardown. |
+| `getLlmObs()` | Lazy accessor for the runtime `tracer.llmobs` SDK, or `null` when `dd-trace` cannot be resolved. For manual enclosing spans, annotations, and `submitEvaluation`. |
+| `isLlmObsEnabled()` | `true` when `DD_LLMOBS_ENABLED` is truthy. |
+
 ## Unified Service Tagging
 
 Use consistent tags across services:

--- a/packages/mcp/skills/express.md
+++ b/packages/mcp/skills/express.md
@@ -104,6 +104,10 @@ import { createLambdaStreamHandler } from "@jaypie/express";
 export const handler = createLambdaStreamHandler(app);
 ```
 
+### LLM Observability auto-flush
+
+`createLambdaHandler` and `createLambdaStreamHandler` call `flushLlmObs()` from `@jaypie/datadog` in their `finally` block, so buffered Datadog LLM Obs spans flush before the Lambda freezes — even when the Express app errors. No-op unless `DD_LLMOBS_ENABLED` is truthy; never affects the response. No per-handler flush code is required.
+
 ## Event Format Support
 
 The adapter supports both API Gateway formats:

--- a/packages/mcp/skills/lambda.md
+++ b/packages/mcp/skills/lambda.md
@@ -93,12 +93,17 @@ lambdaHandler({ name: "test" }, myFunction);
 ## Lifecycle Flow
 
 1. **Logger initialization** - Re-init logger, tag with `invoke` and `handler`
-2. **Secrets loading** - If `secrets` provided, load via `loadEnvSecrets`
-3. **Validate** - Run validation functions
-4. **Setup** - Run setup functions
-5. **Handler** - Execute main handler logic
-6. **Teardown** - Run teardown functions (always runs)
-7. **Response** - Return result or error body
+2. **Datadog LLM Observability** - `loadDatadogApiKey()` resolves `DD_API_KEY` from the secret ARN when LLM Obs is enabled (no-op otherwise)
+3. **Secrets loading** - If `secrets` provided, load via `loadEnvSecrets`
+4. **Validate** - Run validation functions
+5. **Setup** - Run setup functions
+6. **Handler** - Execute main handler logic
+7. **Teardown** - Run teardown functions, then auto-flush LLM Obs spans (always runs)
+8. **Response** - Return result or error body
+
+### LLM Observability auto-flush
+
+`lambdaHandler` and `lambdaStreamHandler` append a final teardown step that calls `flushLlmObs()` from `@jaypie/datadog`. It runs **after** user teardown and **always** (jaypieHandler runs teardown in a `finally`), so buffered LLM Obs spans flush before the Lambda freezes even when the handler throws. No-op unless `DD_LLMOBS_ENABLED` is truthy; never affects the response. No per-handler flush code is required.
 
 ## Error Handling
 

--- a/packages/mcp/skills/llm.md
+++ b/packages/mcp/skills/llm.md
@@ -182,6 +182,22 @@ const result = await Llm.operate("Extract contact info from: John Doe, john@exam
 // result.content = { name: "John Doe", email: "john@example.com", phone: "555-1234" }
 ```
 
+#### Declared arrays always present
+
+A declared `format` is a schema contract. `operate()` guarantees every array field declared in `format` is present in `content` as an array — an empty list surfaces as `[]`, never `undefined` or a dropped key. This holds across providers/models, including those that omit empty array fields, so `content.someArray.length` is always safe without defensive normalization. The backfill recurses into nested objects and arrays of objects.
+
+```typescript
+const res = await Llm.operate(message, {
+  format: {
+    "Merchant Request": String,
+    "Merchant Attachments": [String],
+    "Recommended Actions": [String],
+  },
+});
+// Even when the model returns no recommendations:
+// res.content["Recommended Actions"] === []  (never undefined)
+```
+
 ### Zod Schema
 
 ```typescript
@@ -357,6 +373,28 @@ Behavior:
 - **`stream()`** spans attach to any active enclosing span, but within a single stream the `llm` and `tool` spans are **siblings** — the streamed model span is held open across `yield` boundaries, so it is not the active span when tools run.
 
 For esbuild-bundled Lambda handlers that also want dd-trace auto-instrumentation, wire the `dd-trace/esbuild` plugin with `keepNames: true`; the spans above do not require it.
+
+### Availability
+
+Span emission ships in the **`@jaypie/llm` 1.2.x line** (current `latest`). Note that the `1.3.0` build published to npm predates this feature and contains **no** LLM Obs code — a `^1.2` range resolves to `1.3.0` and silently loses emission. Until a release **above** `1.3.0` ships with the feature, pin to a `latest` 1.2.x that includes it (grep the installed dist for `llmobs` to confirm).
+
+### Flushing on Lambda
+
+On Lambda the runtime freezes the instant the handler resolves, so buffered LLM Obs spans are dropped unless flushed first. Jaypie handler wrappers flush automatically in teardown — no per-handler code:
+
+- `@jaypie/lambda` — `lambdaHandler`, `lambdaStreamHandler`
+- `@jaypie/express` — `createLambdaHandler`, `createLambdaStreamHandler`
+
+Outside those wrappers, flush manually before returning with the bundler-safe `flushLlmObs()` from `@jaypie/datadog`; reach the runtime SDK singleton for manual spans/annotations/`submitEvaluation` via `getLlmObs()`.
+
+```typescript
+import { flushLlmObs, getLlmObs } from "@jaypie/datadog";
+
+getLlmObs()?.trace({ kind: "workflow", name: "my-job" }, async () => {
+  await Llm.operate(input);
+});
+flushLlmObs(); // no-op unless DD_LLMOBS_ENABLED; never throws
+```
 
 ## Error Handling
 

--- a/packages/testkit/package.json
+++ b/packages/testkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/testkit",
-  "version": "1.2.43",
+  "version": "1.2.44",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"

--- a/packages/testkit/src/mock/__tests__/datadog.spec.ts
+++ b/packages/testkit/src/mock/__tests__/datadog.spec.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { submitMetric, submitMetricSet } from "../datadog";
+import {
+  flushLlmObs,
+  getLlmObs,
+  isLlmObsEnabled,
+  submitMetric,
+  submitMetricSet,
+} from "../datadog";
 
 describe("Datadog Mocks", () => {
   beforeEach(() => {
@@ -13,6 +19,21 @@ describe("Datadog Mocks", () => {
 
     it("submitMetricSet is a mock function", () => {
       expect(submitMetricSet).toBeMockFunction();
+    });
+
+    it("flushLlmObs is a mock function returning undefined", () => {
+      expect(flushLlmObs).toBeMockFunction();
+      expect(flushLlmObs()).toBeUndefined();
+    });
+
+    it("getLlmObs is a mock function returning null", () => {
+      expect(getLlmObs).toBeMockFunction();
+      expect(getLlmObs()).toBeNull();
+    });
+
+    it("isLlmObsEnabled is a mock function returning false", () => {
+      expect(isLlmObsEnabled).toBeMockFunction();
+      expect(isLlmObsEnabled()).toBe(false);
     });
   });
 

--- a/packages/testkit/src/mock/datadog.ts
+++ b/packages/testkit/src/mock/datadog.ts
@@ -1,12 +1,19 @@
-import { createMockResolvedFunction, createMockWrappedFunction } from "./utils";
+import {
+  createMockResolvedFunction,
+  createMockReturnedFunction,
+  createMockWrappedFunction,
+} from "./utils";
 
 import * as original from "@jaypie/datadog";
 
 export const DATADOG = original.DATADOG;
+export const flushLlmObs = createMockReturnedFunction(undefined);
+export const getLlmObs = createMockReturnedFunction(null);
 export const hasDatadogEnv = createMockWrappedFunction(
   original.hasDatadogEnv,
   false,
 );
+export const isLlmObsEnabled = createMockReturnedFunction(false);
 export const loadDatadogApiKey = createMockResolvedFunction(false);
 export const submitDistribution = createMockResolvedFunction(true);
 export const submitMetric = createMockResolvedFunction(true);

--- a/packages/testkit/src/mockLog.module.ts
+++ b/packages/testkit/src/mockLog.module.ts
@@ -8,6 +8,7 @@ export function mockLogFactory(): LogMock {
     debug: vi.fn(),
     error: vi.fn(),
     fatal: vi.fn(),
+    flag: vi.fn(),
     info: vi.fn(),
     init: vi.fn(),
     lib: vi.fn(),
@@ -31,6 +32,7 @@ export function mockLogFactory(): LogMock {
   mock.warn.var = mock.var;
 
   // Have modules return correct objects
+  mock.flag.mockReturnValue(mock);
   mock.init.mockReturnValue(null);
   mock.lib.mockReturnValue(mock);
   mock.report.mockReturnValue(null);
@@ -43,6 +45,7 @@ export function mockLogFactory(): LogMock {
     debug: mock.debug,
     error: mock.error,
     fatal: mock.fatal,
+    flag: mock.flag,
     info: mock.info,
     init: mock.init,
     lib: mock.lib,
@@ -64,6 +67,7 @@ const LOG_METHOD_NAMES = [
   "debug",
   "error",
   "fatal",
+  "flag",
   "info",
   "init",
   "lib",

--- a/packages/testkit/src/types/jaypie-testkit.d.ts
+++ b/packages/testkit/src/types/jaypie-testkit.d.ts
@@ -36,6 +36,7 @@ export interface LogMock extends Log {
   debug: MockLogMethod;
   error: MockLogMethod;
   fatal: MockLogMethod;
+  flag: Mock;
   info: MockLogMethod;
   init: Mock;
   lib: Mock;
@@ -43,6 +44,7 @@ export interface LogMock extends Log {
     debug: MockLogMethod;
     error: MockLogMethod;
     fatal: MockLogMethod;
+    flag: Mock;
     info: MockLogMethod;
     init: Mock;
     lib: Mock;


### PR DESCRIPTION
## Summary

Bundles the work folded into this branch:

- **`@jaypie/logger` 1.2.17** — adds `log.flag(flag?)`: returns a child logger tagged `{ flag }` for a non-empty string, otherwise returns the same logger (undefined / non-string / empty string are no-ops).
- **`@jaypie/testkit` 1.2.44** — `flag` added to the log mock surface (factory, spy/restore list, `LogMock` type).
- **`@jaypie/datadog` 1.2.4** — `flushLlmObs` / `getLlmObs` / `isLlmObsEnabled`.
- **`@jaypie/lambda` 1.2.10** — auto-flush LLM Obs in teardown.
- **`@jaypie/express` 1.2.25** — auto-flush LLM Obs in Lambda adapters.
- **`@jaypie/llm` 1.2.41** — `operate()` array-field backfill (structured-output array contract).
- **`@jaypie/mcp` 0.8.74** — skill docs + release notes for the above.
- **`jaypie` 1.2.54** — dependency ranges synced to the updated subpackages.

## Notes

- All bumped packages have matching release notes under `packages/mcp/release-notes/`.
- No double-bumps; `jaypie` dependency ranges updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)