### PR TITLE
test(datadog): make getLlmObs null test deterministic under dd-trace

### DIFF
--- a/packages/datadog/src/__tests__/llmobs.spec.ts
+++ b/packages/datadog/src/__tests__/llmobs.spec.ts
@@ -44,7 +44,10 @@ describe("llmobs", () => {
       expect(() => flushLlmObs()).not.toThrow();
     });
 
-    it("getLlmObs returns null when dd-trace is absent", () => {
+    it("getLlmObs returns null when the SDK is unavailable", () => {
+      // Inject null rather than relying on dd-trace being absent: the traced
+      // deploy job loads dd-trace, so unmocked resolution returns a real SDK.
+      _setLlmObs(null);
       expect(getLlmObs()).toBeNull();
     });
   });


### PR DESCRIPTION
## Summary

Fixes the red `Unit Test (24.x)` job on NPM Deploy introduced by the LLM Obs feature.

`packages/datadog/src/__tests__/llmobs.spec.ts` asserted `getLlmObs()` returns `null` "when dd-trace is absent". That assumption holds in the non-traced NPM Check job (passed) but not in the traced NPM Deploy job, where Vitest runs under dd-trace instrumentation — so resolution returns a real `LLMObs` and the assertion failed.

The test now injects a null SDK via the existing `_setLlmObs` seam, making it deterministic regardless of runtime dd-trace presence (same pattern as the adjacent "no-ops when SDK is unavailable" test).

Test-only change — no runtime change, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)