### PR TITLE
fix(constructs): stabilize JaypieEnvSecret cross-stack export name (#365)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32397,7 +32397,7 @@
     },
     "packages/constructs": {
       "name": "@jaypie/constructs",
-      "version": "1.2.64",
+      "version": "1.2.65",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*",
@@ -33480,7 +33480,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.74",
+      "version": "0.8.75",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33354,7 +33354,7 @@
     },
     "packages/llm": {
       "name": "@jaypie/llm",
-      "version": "1.2.41",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "*",

--- a/packages/constructs/package.json
+++ b/packages/constructs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/constructs",
-  "version": "1.2.64",
+  "version": "1.2.65",
   "description": "CDK constructs for Jaypie applications",
   "repository": {
     "type": "git",

--- a/packages/constructs/src/JaypieEnvSecret.ts
+++ b/packages/constructs/src/JaypieEnvSecret.ts
@@ -72,7 +72,7 @@ export class JaypieEnvSecret extends JaypieSecret {
   }
 
   protected buildSecret(context: BuildSecretContext): secretsmanager.ISecret {
-    const { envKey, id, treatAsEnvKey } = context;
+    const { envKey, id } = context;
     const props = context.props as JaypieEnvSecretProps;
     const {
       consumer = checkEnvIsConsumer(),
@@ -88,11 +88,13 @@ export class JaypieEnvSecret extends JaypieSecret {
     let exportName;
 
     if (!exportParam) {
-      // When shorthand detection is active, use the full construct id (which
-      // includes the "EnvSecret_" prefix) so the export name matches what was
-      // produced by earlier versions of this construct. Using the raw envKey
-      // here produces a shorter name that breaks existing cross-stack imports.
-      const exportSource = treatAsEnvKey ? id : envKey || id;
+      // Always derive the export name from the construct id so the name is
+      // stable across both call forms. For shorthand detection the id carries
+      // the "EnvSecret_" prefix; for the explicit (id, { envKey }) form the id
+      // is the caller's construct id. Deriving from envKey instead would change
+      // the export name for an unchanged explicit-form call site across a
+      // version bump and break existing cross-stack imports (issues #347, #365).
+      const exportSource = id;
       exportName = exportEnvName(exportSource, process.env, consumer);
     } else {
       exportName = cleanName(exportParam);

--- a/packages/constructs/src/__tests__/JaypieEnvSecret.spec.ts
+++ b/packages/constructs/src/__tests__/JaypieEnvSecret.spec.ts
@@ -231,6 +231,65 @@ describe("JaypieSecret", () => {
     });
   });
 
+  describe("Issue #365: Explicit (id, { envKey }) export name regression", () => {
+    const originalEnv = { ...process.env };
+
+    afterEach(() => {
+      process.env = { ...originalEnv };
+    });
+
+    it("provider explicit form derives export name from construct id, not envKey", () => {
+      process.env.AGENTS_INTERNAL_KEY = "agents-value";
+      process.env.PROJECT_ENV = CDK.ENV.SANDBOX;
+      process.env.PROJECT_KEY = "agents";
+
+      const stack = new Stack();
+      new JaypieEnvSecret(stack, "AgentsInternalKey", {
+        envKey: "AGENTS_INTERNAL_KEY",
+      });
+      const template = Template.fromStack(stack);
+
+      const outputs = template.findOutputs("*");
+      const exportNames = Object.values(outputs)
+        .filter((o: any) => o.Export?.Name)
+        .map((o: any) => o.Export.Name as string);
+
+      expect(exportNames.length).toBe(1);
+      expect(exportNames[0]).toBe("env-sandbox-agents-AgentsInternalKey");
+      expect(exportNames[0]).not.toContain("AGENTSINTERNALKEY");
+    });
+
+    it("explicit-form provider and consumer produce matching export names", () => {
+      process.env.AGENTS_INTERNAL_KEY = "agents-value";
+      process.env.PROJECT_KEY = "agents";
+
+      const providerStack = new Stack();
+      process.env.PROJECT_ENV = CDK.ENV.SANDBOX;
+      new JaypieEnvSecret(providerStack, "AgentsInternalKey", {
+        envKey: "AGENTS_INTERNAL_KEY",
+      });
+      const providerTemplate = Template.fromStack(providerStack);
+
+      const outputs = providerTemplate.findOutputs("*");
+      const exportNames = Object.values(outputs)
+        .filter((o: any) => o.Export?.Name)
+        .map((o: any) => o.Export.Name as string);
+      expect(exportNames.length).toBe(1);
+      const providerExportName = exportNames[0];
+
+      const consumerStack = new Stack();
+      delete process.env.PROJECT_ENV;
+      new JaypieEnvSecret(consumerStack, "AgentsInternalKey", {
+        envKey: "AGENTS_INTERNAL_KEY",
+        consumer: true,
+      });
+      const consumerTemplate = Template.fromStack(consumerStack);
+
+      const consumerStr = JSON.stringify(consumerTemplate.toJSON());
+      expect(consumerStr).toContain(providerExportName);
+    });
+  });
+
   describe("Error Cases", () => {
     it("throws ConfigurationError when envKey is set but env var is missing and no value or generateSecretString", () => {
       delete process.env.MISSING_SECRET;

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/llm",
-  "version": "1.2.41",
+  "version": "1.3.1",
   "description": "Large language model utilities",
   "repository": {
     "type": "git",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.74",
+  "version": "0.8.75",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/constructs/1.2.65.md
+++ b/packages/mcp/release-notes/constructs/1.2.65.md
@@ -1,0 +1,14 @@
+---
+version: 1.2.65
+date: 2026-06-18
+summary: Stabilize JaypieEnvSecret cross-stack export name across both call forms
+---
+
+## Changes
+
+- `JaypieEnvSecret` now always derives its CloudFormation cross-stack export name from the construct id, for both the shorthand and explicit `(id, { envKey })` call forms.
+- Previously the explicit form derived the export name from `envKey`, silently renaming the export across a version bump and breaking existing `Fn::ImportValue` consumers (e.g. `env-sandbox-agents-AgentsInternalKey` became `env-sandbox-agents-AGENTSINTERNALKEY`).
+
+## Migration
+
+No changes required. Unchanged explicit-form call sites now keep their original id-based export name, restoring compatibility with previously published exports (issues #347, #365).

--- a/packages/mcp/release-notes/llm/1.3.1.md
+++ b/packages/mcp/release-notes/llm/1.3.1.md
@@ -1,0 +1,13 @@
+---
+version: 1.3.1
+date: 2026-06-18
+summary: Version step to 1.3.1 to avoid conflict with an accidental 1.3.0
+---
+
+## Changes
+
+- No functional changes. Version advances directly from `1.2.41` to `1.3.1` to step over an accidental `1.3.0` and prevent ongoing version conflicts.
+
+## Migration
+
+No changes required.

--- a/packages/mcp/release-notes/mcp/0.8.75.md
+++ b/packages/mcp/release-notes/mcp/0.8.75.md
@@ -1,0 +1,13 @@
+---
+version: 0.8.75
+date: 2026-06-18
+summary: Document JaypieMigration in the cdk skill
+---
+
+## Changes
+
+- `cdk` skill: add a Database Migrations section covering `JaypieMigration` and link to `skill("migrations")`.
+
+## Migration
+
+No changes required.

--- a/packages/mcp/skills/cdk.md
+++ b/packages/mcp/skills/cdk.md
@@ -237,6 +237,27 @@ new JaypieLambda(this, "Handler", {
 
 See `skill("dynamodb")` for table key conventions and query patterns.
 
+## Database Migrations
+
+`JaypieMigration` runs DynamoDB migrations as a CloudFormation custom resource on every `cdk deploy`. It wraps a `JaypieLambda` in a `cr.Provider` and re-fires on the deploy nonce, so newly added migrations run on code-only deploys instead of being skipped:
+
+```typescript
+import { JaypieDynamoDb, JaypieMigration } from "@jaypie/constructs";
+
+const table = new JaypieDynamoDb(this, "myApp");
+
+new JaypieMigration(this, "SeedData", {
+  code: "dist/migrations/seed",
+  handler: "index.handler",
+  tables: [table],
+  dependencies: [table], // Ensures the table exists first
+});
+```
+
+Use `migrationHandler` from `jaypie` in the migration Lambda so errors propagate as CloudFormation failures. Prefer this construct over a hand-rolled `cr.Provider` + `cdk.CustomResource`, which is easy to key on the table name alone and thereby skip the deploy-nonce re-fire.
+
+See `skill("migrations")` for the full props table, behavior, and handler pattern.
+
 ## Lambda with Secrets
 
 Pass secrets as strings (auto-creates `JaypieEnvSecret`) or as construct instances:
@@ -390,6 +411,7 @@ new JaypieOrganizationTrail(this, "OrgTrail", {
 - **`skill("dynamodb")`** - DynamoDB key design and query patterns
 - **`skill("express")`** - Express handler and Lambda adapter
 - **`skill("lambda")`** - Lambda handler wrappers and lifecycle
+- **`skill("migrations")`** - JaypieMigration DynamoDB migration custom resources
 - **`skill("secrets")`** - Secret management with JaypieEnvSecret
 - **`skill("streaming")`** - JaypieDistribution and JaypieNextJs streaming configuration
 - **`skill("variables")`** - Environment variables reference


### PR DESCRIPTION
## Summary

- Fix #365: `JaypieEnvSecret` now always derives its CloudFormation cross-stack export name from the construct id, for both the shorthand and explicit `(id, { envKey })` call forms. Previously the explicit form derived the name from `envKey`, silently renaming the export across a version bump and breaking existing `Fn::ImportValue` consumers.
- Document `JaypieMigration` in the cdk skill (`packages/mcp/skills/cdk.md`).
- Version bumps: `@jaypie/constructs` 1.2.65, `@jaypie/mcp` 0.8.75, `@jaypie/llm` 1.3.1 (steps over an accidental 1.3.0; no functional change).

## Test plan

- `JaypieEnvSecret.spec.ts` — 24/24 pass, including a new `Issue #365` block asserting the explicit form derives the export name from the id and that provider/consumer names match.
- Lint + typecheck clean on `packages/constructs`.

Closes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)