### PR TITLE
feat(constructs): JaypieDistribution serviceTag (#387) + LLM natural-schema docs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32397,7 +32397,7 @@
     },
     "packages/constructs": {
       "name": "@jaypie/constructs",
-      "version": "1.2.66",
+      "version": "1.2.67",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*",
@@ -33480,7 +33480,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.76",
+      "version": "0.8.77",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.4",

--- a/packages/constructs/CLAUDE.md
+++ b/packages/constructs/CLAUDE.md
@@ -168,6 +168,19 @@ new JaypieDistribution(this, "Distribution", {
 });
 ```
 
+#### Service Attribution
+
+`serviceTag` (parallel to `roleTag`, matching `JaypieLambda`) attributes the distribution to a service. When set, the distribution is tagged with `CDK.TAG.SERVICE` (so metrics carry `service:<value>` instead of `service:N/A`) and the created access-log and WAF-log buckets are tagged with the same value, so the Datadog forwarder attributes their forwarded logs to the service instead of the generic `cloudfront`/source default. Omit to preserve current behavior; external/imported log buckets are not tagged.
+
+```typescript
+new JaypieDistribution(this, "Distribution", {
+  handler: api,
+  host: "api.example.com",
+  zone: "example.com",
+  serviceTag: "chat_mcp",
+});
+```
+
 #### Security Headers
 
 `JaypieDistribution` ships with default security response headers (analogous to `helmet` for Express). Headers are applied via a `ResponseHeadersPolicy` attached to the auto-generated default behavior.

--- a/packages/constructs/package.json
+++ b/packages/constructs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/constructs",
-  "version": "1.2.66",
+  "version": "1.2.67",
   "description": "CDK constructs for Jaypie applications",
   "repository": {
     "type": "git",

--- a/packages/constructs/src/JaypieDistribution.ts
+++ b/packages/constructs/src/JaypieDistribution.ts
@@ -253,6 +253,19 @@ export interface JaypieDistributionProps extends Omit<
    */
   roleTag?: string;
   /**
+   * Service tag for attributing this distribution to a service (parallel to
+   * `roleTag`, matching `JaypieLambda`). When set, the distribution is tagged
+   * with `CDK.TAG.SERVICE` (so metrics carry `service:<value>` instead of
+   * `service:N/A`) and the created access-log and WAF-log buckets are tagged
+   * with the same value, so the Datadog forwarder attributes their forwarded
+   * logs to the service instead of the generic `cloudfront`/source default.
+   *
+   * Omit to preserve current behavior (no service tag). Has no effect on
+   * external/imported log buckets, which this construct does not own.
+   * @default undefined (no service tag)
+   */
+  serviceTag?: string;
+  /**
    * WAF WebACL configuration for the CloudFront distribution.
    * - true/undefined: create and attach a WebACL with sensible defaults
    * - false: disable WAF
@@ -299,6 +312,7 @@ export class JaypieDistribution
       responseHeadersPolicy: responseHeadersPolicyProp,
       roleTag = CDK.ROLE.API,
       securityHeaders: securityHeadersProp,
+      serviceTag,
       streaming = false,
       waf: wafProp = true,
       zone: propsZone,
@@ -547,6 +561,9 @@ export class JaypieDistribution
         removalPolicy: RemovalPolicy.DESTROY,
       });
       Tags.of(createdBucket).add(CDK.TAG.ROLE, CDK.ROLE.STORAGE);
+      if (serviceTag) {
+        Tags.of(createdBucket).add(CDK.TAG.SERVICE, serviceTag);
+      }
       logBucket = createdBucket;
     }
 
@@ -589,6 +606,9 @@ export class JaypieDistribution
       },
     );
     Tags.of(this.distribution).add(CDK.TAG.ROLE, roleTag);
+    if (serviceTag) {
+      Tags.of(this.distribution).add(CDK.TAG.SERVICE, serviceTag);
+    }
 
     this.distributionArn = `arn:aws:cloudfront::${Stack.of(this).account}:distribution/${this.distribution.distributionId}`;
     this.distributionDomainName = this.distribution.distributionDomainName;
@@ -826,6 +846,9 @@ export class JaypieDistribution
           removalPolicy: RemovalPolicy.RETAIN,
         });
         Tags.of(createdBucket).add(CDK.TAG.ROLE, CDK.ROLE.MONITORING);
+        if (serviceTag) {
+          Tags.of(createdBucket).add(CDK.TAG.SERVICE, serviceTag);
+        }
 
         // Add Datadog forwarder notification
         if (destinationProp !== false) {

--- a/packages/constructs/src/__tests__/JaypieDistribution.spec.ts
+++ b/packages/constructs/src/__tests__/JaypieDistribution.spec.ts
@@ -302,6 +302,87 @@ describe("JaypieDistribution", () => {
       });
     });
 
+    it("adds service tag to distribution when serviceTag provided", () => {
+      const stack = new Stack();
+      const bucket = new s3.Bucket(stack, "TestBucket");
+      const origin = origins.S3BucketOrigin.withOriginAccessControl(bucket);
+
+      new JaypieDistribution(stack, "TestDistribution", {
+        handler: origin,
+        serviceTag: "chat_mcp",
+      });
+      const template = Template.fromStack(stack);
+
+      const distribution = findDistribution(template);
+      const tags = distribution.Properties.Tags || [];
+      expect(tags).toContainEqual({
+        Key: CDK.TAG.SERVICE,
+        Value: "chat_mcp",
+      });
+    });
+
+    it("adds service tag to the created access-log bucket when serviceTag provided", () => {
+      const stack = new Stack();
+      const bucket = new s3.Bucket(stack, "TestBucket");
+      const origin = origins.S3BucketOrigin.withOriginAccessControl(bucket);
+
+      new JaypieDistribution(stack, "TestDistribution", {
+        handler: origin,
+        serviceTag: "chat_mcp",
+      });
+      const template = Template.fromStack(stack);
+
+      // The log bucket (storage role) carries the service tag so the Datadog
+      // forwarder attributes CloudFront access logs to the service.
+      template.hasResourceProperties("AWS::S3::Bucket", {
+        Tags: Match.arrayWith([
+          Match.objectLike({ Key: CDK.TAG.ROLE, Value: CDK.ROLE.STORAGE }),
+          Match.objectLike({ Key: CDK.TAG.SERVICE, Value: "chat_mcp" }),
+        ]),
+      });
+
+      expect(template).toBeDefined();
+    });
+
+    it("adds service tag to the created WAF log bucket when serviceTag provided", () => {
+      const stack = new Stack();
+      const bucket = new s3.Bucket(stack, "TestBucket");
+      const origin = origins.S3BucketOrigin.withOriginAccessControl(bucket);
+
+      new JaypieDistribution(stack, "TestDistribution", {
+        handler: origin,
+        serviceTag: "chat_mcp",
+        waf: { name: "api" },
+      });
+      const template = Template.fromStack(stack);
+
+      template.hasResourceProperties("AWS::S3::Bucket", {
+        Tags: Match.arrayWith([
+          Match.objectLike({ Key: CDK.TAG.ROLE, Value: CDK.ROLE.MONITORING }),
+          Match.objectLike({ Key: CDK.TAG.SERVICE, Value: "chat_mcp" }),
+        ]),
+      });
+
+      expect(template).toBeDefined();
+    });
+
+    it("does not add a service tag when serviceTag is omitted", () => {
+      const stack = new Stack();
+      const bucket = new s3.Bucket(stack, "TestBucket");
+      const origin = origins.S3BucketOrigin.withOriginAccessControl(bucket);
+
+      new JaypieDistribution(stack, "TestDistribution", {
+        handler: origin,
+      });
+      const template = Template.fromStack(stack);
+
+      const distribution = findDistribution(template);
+      const tags = distribution.Properties.Tags || [];
+      expect(tags).not.toContainEqual(
+        expect.objectContaining({ Key: CDK.TAG.SERVICE }),
+      );
+    });
+
     it("configures streaming for Lambda FunctionUrl", () => {
       const stack = new Stack();
       const fn = new lambda.Function(stack, "TestFunction", {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.76",
+  "version": "0.8.77",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/constructs/1.2.67.md
+++ b/packages/mcp/release-notes/constructs/1.2.67.md
@@ -1,0 +1,19 @@
+---
+version: 1.2.67
+date: 2026-06-20
+summary: Add serviceTag to JaypieDistribution for CloudFront metric and log attribution
+---
+
+## Changes
+
+- `JaypieDistribution` now accepts an optional `serviceTag` prop, parallel to
+  `roleTag` and matching `JaypieLambda`. When set:
+  - The distribution is tagged with `CDK.TAG.SERVICE`, so Datadog metrics carry
+    `service:<value>` instead of `service:N/A`.
+  - The created access-log and WAF-log buckets are tagged with the same value,
+    so the Datadog forwarder attributes their forwarded logs to the service
+    instead of the generic `cloudfront`/source default.
+- Omitting `serviceTag` preserves current behavior. External/imported log
+  buckets are not tagged (the construct does not own them).
+
+Issue: [#387](https://github.com/finlaysonstudio/jaypie/issues/387)

--- a/packages/mcp/release-notes/mcp/0.8.77.md
+++ b/packages/mcp/release-notes/mcp/0.8.77.md
@@ -1,0 +1,13 @@
+---
+version: 0.8.77
+date: 2026-06-20
+summary: Lead LLM structured-output docs with natural schema syntax over Zod
+---
+
+## Changes
+
+- Reordered the `llm` and `models` skills to present Jaypie's natural schema
+  syntax first for structured output, with JSON Schema and Zod as alternatives.
+- Fixed the `llm` skill's `format` type signature to include `NaturalSchema`.
+- Added a natural-schema validation example to the `models` skill so its
+  Validation Patterns section is no longer Zod-only.

--- a/packages/mcp/skills/api.md
+++ b/packages/mcp/skills/api.md
@@ -60,4 +60,4 @@ Every response body is a JSON object with one top-level key:
 3. Single records use an object: `{ data: {} }`
 4. Multiple records use an array: `{ data: [] }`
 5. Errors always use an array: `{ errors: [] }` (responses only)
-6. No other top-level keys (no `status`, `message`, `meta` at the root)
+6. No other top-level keys (no `status`, `message`, `meta` at the root) except `metadata`

--- a/packages/mcp/skills/llm.md
+++ b/packages/mcp/skills/llm.md
@@ -455,7 +455,7 @@ describe("LLM Integration", () => {
 interface LlmOperateOptions {
   data?: Record<string, any>;           // Placeholder substitution data
   fallback?: LlmFallbackConfig[] | false; // Fallback provider chain
-  format?: JsonObject | ZodType;        // Structured output schema
+  format?: NaturalSchema | JsonObject | ZodType; // Structured output schema (natural syntax preferred)
   history?: LlmHistory;                 // Previous conversation
   hooks?: LlmHooks;                     // Lifecycle callbacks
   instructions?: string;                // Additional instructions

--- a/packages/mcp/skills/models.md
+++ b/packages/mcp/skills/models.md
@@ -83,6 +83,27 @@ const createUser = fabricService({
 
 ## Validation Patterns
 
+Prefer Jaypie's natural schema syntax — it validates and types inline without a schema library. Reach for Zod only when you need refinements the natural form can't express.
+
+### Natural Schema
+
+The fabric `input` object is itself a natural schema: each field declares a `type` (a constructor like `String`/`Number`, or a `const` tuple of allowed values), `required`, and `description`. Input is validated and typed before `service` runs.
+
+```typescript
+const createUser = fabricService({
+  alias: "user_create",
+  input: {
+    email: { type: String, required: true, description: "User email address" },
+    name: { type: String, required: true, description: "User display name" },
+    role: { type: ["user", "admin"] as const, required: false },
+  },
+  service: async ({ email, name, role }) => {
+    // email, name, role are validated and typed here
+    return createUserInDatabase({ email, name, role: role || "user" });
+  },
+});
+```
+
 ### Zod Schemas
 
 ```typescript

--- a/workspaces/documentation/docs/guides/llm-integration.md
+++ b/workspaces/documentation/docs/guides/llm-integration.md
@@ -223,32 +223,43 @@ const toolkit = new Toolkit([
 
 ## Structured Output
 
-### JSON Response
+Pass `format` to receive guaranteed-valid JSON. `format` accepts Jaypie's natural schema syntax (preferred), a raw JSON Schema, or a Zod schema.
+
+### Natural Schema
 
 ```typescript
 const response = await Llm.operate(
   "Extract the person's name and age from: 'John is 25 years old'",
   {
-    model: "gpt-4o",
-    responseFormat: {
-      type: "json_schema",
-      json_schema: {
-        name: "person",
-        schema: {
-          type: "object",
-          properties: {
-            name: { type: "string" },
-            age: { type: "number" },
-          },
-        },
-      },
+    model: "gpt-5.1",
+    format: {
+      name: String,
+      age: Number,
     },
   }
 );
 // Returns: { name: "John", age: 25 }
 ```
 
-### Zod Schema Response
+Every array field declared in `format` is guaranteed present in the response as an array — an empty result surfaces as `[]`, never `undefined`.
+
+### JSON Schema
+
+```typescript
+const response = await Llm.operate(prompt, {
+  model: "gpt-5.1",
+  format: {
+    type: "object",
+    properties: {
+      name: { type: "string" },
+      age: { type: "number" },
+    },
+  },
+});
+// Returns: { name: "John", age: 25 }
+```
+
+### Zod Schema
 
 ```typescript
 import { z } from "zod";
@@ -259,8 +270,8 @@ const PersonSchema = z.object({
 });
 
 const response = await Llm.operate(prompt, {
-  model: "gpt-4o",
-  responseSchema: PersonSchema,
+  model: "gpt-5.1",
+  format: PersonSchema,
 });
 // Returns typed object matching PersonSchema
 ```

--- a/workspaces/documentation/docs/packages/llm.md
+++ b/workspaces/documentation/docs/packages/llm.md
@@ -55,9 +55,9 @@ const response = await Llm.operate("What is 2+2?", {
 | Option | Type | Description |
 |--------|------|-------------|
 | `fallback` | `LlmFallbackConfig[] \| false` | Fallback provider chain |
+| `format` | `NaturalSchema \| JSONSchema \| ZodSchema` | Structured output schema |
 | `maxTokens` | `number` | Maximum response tokens |
 | `model` | `string` | Model identifier |
-| `responseFormat` | `object` | Structured output format |
 | `system` | `string` | System prompt |
 | `temperature` | `number` | Response randomness (0-1) |
 | `tools` | `Toolkit` | Available tools |
@@ -224,32 +224,43 @@ When enabled:
 
 ## Structured Output
 
-### JSON Schema
+Pass `format` to receive guaranteed-valid JSON. `format` accepts Jaypie's natural schema syntax (preferred), a raw JSON Schema, or a Zod schema. (`provider.send` uses `response` for the same purpose.)
+
+### Natural Schema
 
 ```typescript
 const response = await Llm.operate(
   "Extract: 'John is 25 years old'",
   {
-    model: "gpt-4o",
-    responseFormat: {
-      type: "json_schema",
-      json_schema: {
-        name: "person",
-        schema: {
-          type: "object",
-          properties: {
-            name: { type: "string" },
-            age: { type: "number" },
-          },
-        },
-      },
+    model: "gpt-5.1",
+    format: {
+      name: String,
+      age: Number,
     },
   }
 );
 // Returns: { name: "John", age: 25 }
 ```
 
-### Zod Response Schema
+Declared array fields are always present in the response as arrays — an empty result surfaces as `[]`, never `undefined`.
+
+### JSON Schema
+
+```typescript
+const response = await Llm.operate(prompt, {
+  model: "gpt-5.1",
+  format: {
+    type: "object",
+    properties: {
+      name: { type: "string" },
+      age: { type: "number" },
+    },
+  },
+});
+// Returns: { name: "John", age: 25 }
+```
+
+### Zod Schema
 
 ```typescript
 import { z } from "zod";
@@ -260,8 +271,8 @@ const PersonSchema = z.object({
 });
 
 const response = await Llm.operate(prompt, {
-  model: "gpt-4o",
-  responseSchema: PersonSchema,
+  model: "gpt-5.1",
+  format: PersonSchema,
 });
 // Returns typed object
 ```


### PR DESCRIPTION
## Summary
- **`@jaypie/constructs` 1.2.67** — Add `serviceTag` to `JaypieDistribution` (#387), parallel to `roleTag` / matching `JaypieLambda`. Tags the distribution with `CDK.TAG.SERVICE` (metrics carry `service:<value>` instead of `service:N/A`) and tags the created access-log and WAF-log buckets so the Datadog forwarder attributes their logs to the service instead of the generic `cloudfront`/source default. Omitting it preserves current behavior; external/imported buckets are untouched.
- **`@jaypie/mcp` 0.8.77** — Lead LLM structured-output docs (`llm`/`models` skills + jaypie.net docs) with Jaypie's natural schema syntax over Zod; fix stale `responseFormat`/`responseSchema` → `format`; add `NaturalSchema` to type signatures.
- Includes a hook-committed `api.md` skill tweak ("except `metadata`").

## Test plan
- New `JaypieDistribution` tests: service tag on distribution, on created access-log bucket, on created WAF-log bucket, and absence when omitted (TDD: written failing first).
- Full constructs suite: 593 pass · typecheck clean · lint clean in changed files · build clean.
- CI NPM Check: green.

Closes #387

🤖 Generated with [Claude Code](https://claude.com/claude-code)