### PR TITLE
feat(constructs): grant Datadog role trustedadvisor:ListRecommendations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32397,7 +32397,7 @@
     },
     "packages/constructs": {
       "name": "@jaypie/constructs",
-      "version": "1.2.67",
+      "version": "1.2.68",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*",
@@ -33480,7 +33480,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.77",
+      "version": "0.8.78",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.4",

--- a/packages/constructs/package.json
+++ b/packages/constructs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/constructs",
-  "version": "1.2.67",
+  "version": "1.2.68",
   "description": "CDK constructs for Jaypie applications",
   "repository": {
     "type": "git",

--- a/packages/constructs/src/helpers/__tests__/extendDatadogRole.spec.ts
+++ b/packages/constructs/src/helpers/__tests__/extendDatadogRole.spec.ts
@@ -1,0 +1,72 @@
+import * as cdk from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { extendDatadogRole } from "../extendDatadogRole.js";
+
+const DATADOG_ROLE_ARN =
+  "arn:aws:iam::123456789012:role/DatadogIntegrationRole";
+
+describe("extendDatadogRole", () => {
+  let originalRoleArn: string | undefined;
+
+  beforeEach(() => {
+    originalRoleArn = process.env.CDK_ENV_DATADOG_ROLE_ARN;
+  });
+
+  afterEach(() => {
+    if (originalRoleArn === undefined) {
+      delete process.env.CDK_ENV_DATADOG_ROLE_ARN;
+    } else {
+      process.env.CDK_ENV_DATADOG_ROLE_ARN = originalRoleArn;
+    }
+  });
+
+  describe("Base Cases", () => {
+    it("returns undefined when CDK_ENV_DATADOG_ROLE_ARN is not set", () => {
+      delete process.env.CDK_ENV_DATADOG_ROLE_ARN;
+      const app = new cdk.App();
+      const stack = new cdk.Stack(app, "TestStack");
+
+      expect(extendDatadogRole(stack)).toBeUndefined();
+    });
+
+    it("creates a policy when CDK_ENV_DATADOG_ROLE_ARN is set", () => {
+      process.env.CDK_ENV_DATADOG_ROLE_ARN = DATADOG_ROLE_ARN;
+      const app = new cdk.App();
+      const stack = new cdk.Stack(app, "TestStack");
+
+      expect(extendDatadogRole(stack)).toBeDefined();
+    });
+  });
+
+  describe("Happy Paths", () => {
+    it("grants the expected Datadog read permissions", () => {
+      process.env.CDK_ENV_DATADOG_ROLE_ARN = DATADOG_ROLE_ARN;
+      const app = new cdk.App();
+      const stack = new cdk.Stack(app, "TestStack");
+
+      extendDatadogRole(stack);
+
+      const template = Template.fromStack(stack);
+      expect(() =>
+        template.hasResourceProperties("AWS::IAM::Policy", {
+          PolicyDocument: {
+            Statement: [
+              { Action: "budgets:ViewBudget", Effect: "Allow", Resource: "*" },
+              {
+                Action: "logs:DescribeLogGroups",
+                Effect: "Allow",
+                Resource: "*",
+              },
+              {
+                Action: "trustedadvisor:ListRecommendations",
+                Effect: "Allow",
+                Resource: "*",
+              },
+            ],
+          },
+        }),
+      ).not.toThrow();
+    });
+  });
+});

--- a/packages/constructs/src/helpers/extendDatadogRole.ts
+++ b/packages/constructs/src/helpers/extendDatadogRole.ts
@@ -29,6 +29,7 @@ export interface ExtendDatadogRoleOptions {
  * If found, creates a custom policy with:
  * - budgets:ViewBudget
  * - logs:DescribeLogGroups
+ * - trustedadvisor:ListRecommendations
  *
  * @param scope - The construct scope
  * @param options - Configuration options
@@ -64,6 +65,11 @@ export function extendDatadogRole(
     // Allow describe log groups
     new PolicyStatement({
       actions: ["logs:DescribeLogGroups"],
+      resources: ["*"],
+    }),
+    // Allow list trusted advisor recommendations
+    new PolicyStatement({
+      actions: ["trustedadvisor:ListRecommendations"],
       resources: ["*"],
     }),
   ];

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.77",
+  "version": "0.8.78",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/constructs/1.2.68.md
+++ b/packages/mcp/release-notes/constructs/1.2.68.md
@@ -1,0 +1,14 @@
+---
+version: 1.2.68
+date: 2026-06-21
+summary: Grant Datadog role trustedadvisor:ListRecommendations
+---
+
+## Changes
+
+- `extendDatadogRole` now adds `trustedadvisor:ListRecommendations` (Resource
+  `*`) to the custom Datadog policy, alongside the existing
+  `budgets:ViewBudget` and `logs:DescribeLogGroups` grants. This lets the
+  Datadog AWS integration role surface Trusted Advisor recommendations.
+- Applies wherever `extendDatadogRole` runs (e.g. `JaypieDatadogForwarder` with
+  role extension enabled and `CDK_ENV_DATADOG_ROLE_ARN` set).

--- a/packages/mcp/release-notes/mcp/0.8.78.md
+++ b/packages/mcp/release-notes/mcp/0.8.78.md
@@ -1,0 +1,10 @@
+---
+version: 0.8.78
+date: 2026-06-21
+summary: Add constructs 1.2.68 release notes
+---
+
+## Changes
+
+- Added release notes for `@jaypie/constructs` 1.2.68 (Datadog role gains
+  `trustedadvisor:ListRecommendations`).


### PR DESCRIPTION
## Summary
- Add `trustedadvisor:ListRecommendations` (Resource `*`) to `extendDatadogRole`, alongside the existing `budgets:ViewBudget` and `logs:DescribeLogGroups` grants on the Datadog AWS integration role.
- Applies wherever `extendDatadogRole` runs (e.g. `JaypieDatadogForwarder` with role extension enabled and `CDK_ENV_DATADOG_ROLE_ARN` set).

## Changes
- `packages/constructs/src/helpers/extendDatadogRole.ts` — new policy statement + JSDoc
- New test `extendDatadogRole.spec.ts` asserting all three statements
- Versions: `@jaypie/constructs` 1.2.68, `@jaypie/mcp` 0.8.78
- Release notes for both

🤖 Generated with [Claude Code](https://claude.com/claude-code)