### PR TITLE
fix(constructs): bundle declarations so types resolve under node16/nodenext (#390)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28599,7 +28599,9 @@
       }
     },
     "node_modules/rollup-plugin-dts": {
-      "version": "6.4.0",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-6.4.1.tgz",
+      "integrity": "sha512-l//F3Zf7ID5GoOfLfD8kroBjQKEKpy1qfhtAdnpibFZMffPaylrg1CoDC2vGkPeTeyxUe4bVFCln2EFuL7IGGg==",
       "dev": true,
       "license": "LGPL-3.0-only",
       "dependencies": {
@@ -28609,7 +28611,7 @@
         "magic-string": "^0.30.21"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/Swatinem"
@@ -32397,7 +32399,7 @@
     },
     "packages/constructs": {
       "name": "@jaypie/constructs",
-      "version": "1.2.68",
+      "version": "1.2.69",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*",
@@ -32414,6 +32416,7 @@
         "eslint-config-prettier": "^10.0.1",
         "eslint-plugin-prettier": "^5.2.1",
         "rollup": "^4.12.0",
+        "rollup-plugin-dts": "^6.4.1",
         "typescript": "^5.3.3",
         "typescript-eslint": "^8.18.2",
         "vitest": "^4.1.8"
@@ -33480,7 +33483,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.78",
+      "version": "0.8.79",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.2.4",

--- a/packages/constructs/package.json
+++ b/packages/constructs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/constructs",
-  "version": "1.2.68",
+  "version": "1.2.69",
   "description": "CDK constructs for Jaypie applications",
   "repository": {
     "type": "git",
@@ -11,9 +11,14 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/esm/index.d.ts",
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.cjs"
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.cts",
+        "default": "./dist/cjs/index.cjs"
+      }
     }
   },
   "main": "./dist/cjs/index.cjs",
@@ -45,6 +50,7 @@
     "eslint-config-prettier": "^10.0.1",
     "eslint-plugin-prettier": "^5.2.1",
     "rollup": "^4.12.0",
+    "rollup-plugin-dts": "^6.4.1",
     "typescript": "^5.3.3",
     "typescript-eslint": "^8.18.2",
     "vitest": "^4.1.8"

--- a/packages/constructs/rollup.config.js
+++ b/packages/constructs/rollup.config.js
@@ -1,4 +1,5 @@
 import typescript from "@rollup/plugin-typescript";
+import { dts } from "rollup-plugin-dts";
 
 // Filter out TS2307 warnings for @jaypie/* packages (external workspace dependencies)
 const onwarn = (warning, defaultHandler) => {
@@ -7,6 +8,47 @@ const onwarn = (warning, defaultHandler) => {
   }
   defaultHandler(warning);
 };
+
+// Shared external list: the runtime is bundled to a single index file and the
+// declarations are bundled to a single index.d.ts, so every dependency must be
+// kept external in both the JS and the .d.ts passes.
+const external = [
+  "@jaypie/errors",
+  "aws-cdk-lib",
+  "aws-cdk-lib/aws-accessanalyzer",
+  "aws-cdk-lib/aws-apigateway",
+  "aws-cdk-lib/aws-apigatewayv2",
+  "aws-cdk-lib/aws-apigatewayv2-integrations",
+  "aws-cdk-lib/aws-certificatemanager",
+  "aws-cdk-lib/aws-cloudfront",
+  "aws-cdk-lib/aws-cloudfront-origins",
+  "aws-cdk-lib/aws-cloudtrail",
+  "aws-cdk-lib/aws-cloudwatch",
+  "aws-cdk-lib/aws-dynamodb",
+  "aws-cdk-lib/aws-events",
+  "aws-cdk-lib/aws-events-targets",
+  "aws-cdk-lib/aws-iam",
+  "aws-cdk-lib/aws-kms",
+  "aws-cdk-lib/aws-lambda",
+  "aws-cdk-lib/aws-lambda-event-sources",
+  "aws-cdk-lib/aws-logs",
+  "aws-cdk-lib/aws-logs-destinations",
+  "aws-cdk-lib/aws-route53",
+  "aws-cdk-lib/aws-route53-targets",
+  "aws-cdk-lib/aws-s3",
+  "aws-cdk-lib/aws-s3-notifications",
+  "aws-cdk-lib/aws-sam",
+  "aws-cdk-lib/aws-secretsmanager",
+  "aws-cdk-lib/aws-sns",
+  "aws-cdk-lib/aws-sqs",
+  "aws-cdk-lib/aws-sso",
+  "aws-cdk-lib/aws-wafv2",
+  "aws-cdk-lib/custom-resources",
+  "cdk-nextjs-standalone",
+  "constructs",
+  "datadog-cdk-constructs-v2",
+  "path",
+];
 
 export default [
   // ES modules version
@@ -25,43 +67,7 @@ export default [
         outDir: "dist/esm",
       }),
     ],
-    external: [
-      "@jaypie/errors",
-      "aws-cdk-lib",
-      "aws-cdk-lib/aws-accessanalyzer",
-      "aws-cdk-lib/aws-apigateway",
-      "aws-cdk-lib/aws-apigatewayv2",
-      "aws-cdk-lib/aws-apigatewayv2-integrations",
-      "aws-cdk-lib/aws-certificatemanager",
-      "aws-cdk-lib/aws-cloudfront",
-      "aws-cdk-lib/aws-cloudfront-origins",
-      "aws-cdk-lib/aws-cloudtrail",
-      "aws-cdk-lib/aws-cloudwatch",
-      "aws-cdk-lib/aws-dynamodb",
-      "aws-cdk-lib/aws-events",
-      "aws-cdk-lib/aws-events-targets",
-      "aws-cdk-lib/aws-iam",
-      "aws-cdk-lib/aws-kms",
-      "aws-cdk-lib/aws-lambda",
-      "aws-cdk-lib/aws-lambda-event-sources",
-      "aws-cdk-lib/aws-logs",
-      "aws-cdk-lib/aws-logs-destinations",
-      "aws-cdk-lib/aws-route53",
-      "aws-cdk-lib/aws-route53-targets",
-      "aws-cdk-lib/aws-s3",
-      "aws-cdk-lib/aws-s3-notifications",
-      "aws-cdk-lib/aws-sam",
-      "aws-cdk-lib/aws-secretsmanager",
-      "aws-cdk-lib/aws-sns",
-      "aws-cdk-lib/aws-sqs",
-      "aws-cdk-lib/aws-sso",
-      "aws-cdk-lib/aws-wafv2",
-      "aws-cdk-lib/custom-resources",
-      "cdk-nextjs-standalone",
-      "constructs",
-      "datadog-cdk-constructs-v2",
-      "path",
-    ],
+    external,
   },
   // CommonJS version
   {
@@ -81,42 +87,30 @@ export default [
         outDir: "dist/cjs",
       }),
     ],
-    external: [
-      "@jaypie/errors",
-      "aws-cdk-lib",
-      "aws-cdk-lib/aws-accessanalyzer",
-      "aws-cdk-lib/aws-apigateway",
-      "aws-cdk-lib/aws-apigatewayv2",
-      "aws-cdk-lib/aws-apigatewayv2-integrations",
-      "aws-cdk-lib/aws-certificatemanager",
-      "aws-cdk-lib/aws-cloudfront",
-      "aws-cdk-lib/aws-cloudfront-origins",
-      "aws-cdk-lib/aws-cloudtrail",
-      "aws-cdk-lib/aws-cloudwatch",
-      "aws-cdk-lib/aws-dynamodb",
-      "aws-cdk-lib/aws-events",
-      "aws-cdk-lib/aws-events-targets",
-      "aws-cdk-lib/aws-iam",
-      "aws-cdk-lib/aws-kms",
-      "aws-cdk-lib/aws-lambda",
-      "aws-cdk-lib/aws-lambda-event-sources",
-      "aws-cdk-lib/aws-logs",
-      "aws-cdk-lib/aws-logs-destinations",
-      "aws-cdk-lib/aws-route53",
-      "aws-cdk-lib/aws-route53-targets",
-      "aws-cdk-lib/aws-s3",
-      "aws-cdk-lib/aws-s3-notifications",
-      "aws-cdk-lib/aws-sam",
-      "aws-cdk-lib/aws-secretsmanager",
-      "aws-cdk-lib/aws-sns",
-      "aws-cdk-lib/aws-sqs",
-      "aws-cdk-lib/aws-sso",
-      "aws-cdk-lib/aws-wafv2",
-      "aws-cdk-lib/custom-resources",
-      "cdk-nextjs-standalone",
-      "constructs",
-      "datadog-cdk-constructs-v2",
-      "path",
-    ],
+    external,
+  },
+  // Type definitions (ESM): bundled to a single declaration file so every
+  // re-export resolves under node16/nodenext module resolution. A per-file
+  // .d.ts tree with extensionless relative specifiers does not resolve in ESM
+  // mode, which silently dropped `export * from "./helpers"` members (#390).
+  {
+    input: "src/index.ts",
+    output: {
+      file: "dist/esm/index.d.ts",
+      format: "es",
+    },
+    plugins: [dts()],
+    external,
+  },
+  // Type definitions (CommonJS): emitted as .d.cts so node16/nodenext flags it
+  // as a CommonJS declaration under the package's "type": "module" setting.
+  {
+    input: "src/index.ts",
+    output: {
+      file: "dist/cjs/index.d.cts",
+      format: "es",
+    },
+    plugins: [dts()],
+    external,
   },
 ];

--- a/packages/constructs/src/__tests__/issue-390-declaration-types.spec.ts
+++ b/packages/constructs/src/__tests__/issue-390-declaration-types.spec.ts
@@ -1,0 +1,51 @@
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import { extendDatadogRole } from "..";
+
+// https://github.com/finlaysonstudio/jaypie/issues/390
+//
+// `extendDatadogRole` was present in the runtime bundle but vanished from the
+// public `.d.ts` under node16/nodenext module resolution. The per-file
+// declaration tree used extensionless relative specifiers (`from "./helpers"`),
+// which ESM-mode resolution cannot follow, so `export * from "./helpers"`
+// resolved to zero members (TS2305) and every named re-export silently
+// degraded to `any`. The build now bundles the declarations into a single,
+// self-contained `index.d.ts` so every export resolves under all resolution
+// modes.
+
+const distFile = (relative: string): string =>
+  fileURLToPath(new URL(`../../${relative}`, import.meta.url));
+
+describe("issue-390 declaration types", () => {
+  describe("Runtime", () => {
+    it("exports extendDatadogRole", () => {
+      expect(typeof extendDatadogRole).toBe("function");
+    });
+  });
+
+  describe.each([["dist/esm/index.d.ts"], ["dist/cjs/index.d.cts"]])(
+    "Bundled declarations: %s",
+    (relative) => {
+      const path = distFile(relative);
+
+      it("is built (run `npm run build -w packages/constructs` first)", () => {
+        expect(existsSync(path)).toBe(true);
+      });
+
+      it("is self-contained with no relative re-exports", () => {
+        const source = readFileSync(path, "utf8");
+        // A relative specifier in the public declaration file means a consumer
+        // under node16/nodenext would fail to resolve it (the cause of #390).
+        expect(source).not.toMatch(/from\s+["']\.\.?\//);
+      });
+
+      it("re-exports extendDatadogRole and ExtendDatadogRoleOptions", () => {
+        const source = readFileSync(path, "utf8");
+        expect(source).toContain("extendDatadogRole");
+        expect(source).toContain("ExtendDatadogRoleOptions");
+      });
+    },
+  );
+});

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.78",
+  "version": "0.8.79",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/constructs/1.2.69.md
+++ b/packages/mcp/release-notes/constructs/1.2.69.md
@@ -1,0 +1,20 @@
+---
+version: 1.2.69
+date: 2026-06-21
+summary: Bundle declarations so types resolve under node16/nodenext
+---
+
+## Fixes
+
+- Bundle the public TypeScript declarations into a single, self-contained
+  `index.d.ts` (and `index.d.cts` for the CommonJS entry) instead of shipping a
+  per-file `.d.ts` tree with extensionless relative specifiers (#390).
+- Under `node16`/`nodenext` module resolution the old extensionless re-exports
+  (`export * from "./helpers"`) did not resolve in ESM mode: `extendDatadogRole`
+  and `ExtendDatadogRoleOptions` vanished from the type surface (`TS2305`), and
+  every other named export silently degraded to `any`. The flat declaration
+  file resolves correctly under `bundler`, `node16`, and `nodenext`.
+- `package.json` `exports` now declares per-condition `types` (`import` →
+  `dist/esm/index.d.ts`, `require` → `dist/cjs/index.d.cts`).
+
+No runtime behavior changes.


### PR DESCRIPTION
Fixes #390.

## Problem
`extendDatadogRole` (added in `@jaypie/constructs@1.2.68`) was present at runtime but missing from the public `.d.ts`, so `import { extendDatadogRole } from "@jaypie/constructs"` failed type-checking with `TS2305`.

## Root cause (deeper than reported)
The runtime is bundled to a single `index.js`, but declarations were emitted as a **per-file `.d.ts` tree with extensionless relative specifiers** (`export * from "./helpers"`). Under `node16`/`nodenext` (ESM mode) those specifiers don't resolve:
- `export { Name } from "./File"` → name appears but **degrades to `any`**
- `export * from "./helpers"` → unresolved path yields **zero names** → `extendDatadogRole` vanishes → `TS2305`

So the entire `@jaypie/constructs` type surface was silently `any` under node16/nodenext; `extendDatadogRole` was just the loud casualty (confirmed by reproducing against the published `1.2.68` tarball).

## Fix
- Bundle declarations into a single self-contained `dist/esm/index.d.ts` and `dist/cjs/index.d.cts` via `rollup-plugin-dts` (matching `@jaypie/testkit`/`@jaypie/types`).
- Declare per-condition `types` in `package.json` `exports` (`import`→ESM, `require`→`.d.cts`).
- Regression test asserting the runtime export plus both bundled declaration files are self-contained (no relative re-exports) and export `extendDatadogRole`/`ExtendDatadogRoleOptions`.

## Verification
- Repro consumer now passes under **ESM nodenext**, **CJS Node16 (require→.d.cts)**, and **bundler**.
- `JaypieDatadogSecret` now carries **real types** (no longer `any`) — whole-surface fix.
- typecheck clean; **603 tests pass** (incl. 7 new); lint 0 errors on changed files.

Versions: constructs `1.2.69`, mcp `0.8.79` (release note). No runtime behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)