### PR TITLE
fix(types): bundle declarations across packages for node16/nodenext

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32356,7 +32356,7 @@
     },
     "packages/aws": {
       "name": "@jaypie/aws",
-      "version": "1.2.9",
+      "version": "1.2.10",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-apigatewaymanagementapi": "^3.726.0",
@@ -32372,6 +32372,7 @@
         "@rollup/plugin-typescript": "^12.1.2",
         "@types/async-retry": "^1.4.9",
         "@types/node": "^22.13.1",
+        "rollup-plugin-dts": "^6.1.1",
         "typescript": "^5.3.3"
       },
       "peerDependencies": {
@@ -32437,7 +32438,7 @@
     },
     "packages/core": {
       "name": "@jaypie/core",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*",
@@ -32447,6 +32448,7 @@
       "devDependencies": {
         "@rollup/plugin-typescript": "^12.1.2",
         "@types/node": "^22.13.1",
+        "rollup-plugin-dts": "^6.1.1",
         "typescript": "^5.3.3"
       }
     },
@@ -32465,7 +32467,7 @@
     },
     "packages/datadog": {
       "name": "@jaypie/datadog",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "*",
@@ -32474,6 +32476,7 @@
       "devDependencies": {
         "@rollup/plugin-typescript": "^12.1.2",
         "@types/node": "^22.13.1",
+        "rollup-plugin-dts": "^6.1.1",
         "typescript": "^5.3.3"
       },
       "peerDependencies": {
@@ -32496,7 +32499,7 @@
     },
     "packages/dynamodb": {
       "name": "@jaypie/dynamodb",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.726.1",
@@ -32506,6 +32509,7 @@
       "devDependencies": {
         "@rollup/plugin-typescript": "^12.1.2",
         "@types/node": "^22.13.1",
+        "rollup-plugin-dts": "^6.1.1",
         "typescript": "^5.3.3"
       },
       "peerDependencies": {
@@ -32539,7 +32543,7 @@
     },
     "packages/errors": {
       "name": "@jaypie/errors",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "MIT",
       "devDependencies": {
         "@jaypie/types": "*",
@@ -32550,6 +32554,7 @@
         "eslint-config-prettier": "^10.0.1",
         "eslint-plugin-prettier": "^5.2.1",
         "rollup": "^4.12.0",
+        "rollup-plugin-dts": "^6.1.1",
         "typescript": "^5.3.3",
         "typescript-eslint": "^8.18.2",
         "vitest": "^4.1.8"
@@ -32846,7 +32851,7 @@
     },
     "packages/express": {
       "name": "@jaypie/express",
-      "version": "1.2.25",
+      "version": "1.2.26",
       "license": "MIT",
       "dependencies": {
         "@jaypie/datadog": "*",
@@ -32859,6 +32864,7 @@
         "@types/express": "^5.0.0",
         "@types/node": "^22.13.1",
         "express": "^4.21.2",
+        "rollup-plugin-dts": "^6.1.1",
         "typescript": "^5.3.3"
       },
       "peerDependencies": {
@@ -32882,7 +32888,7 @@
     },
     "packages/fabric": {
       "name": "@jaypie/fabric",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*"
@@ -32902,6 +32908,7 @@
         "express": "^5.0.1",
         "jest-extended": "^4.0.2",
         "rollup": "^4.12.0",
+        "rollup-plugin-dts": "^6.1.1",
         "typescript": "^5.3.3",
         "typescript-eslint": "^8.18.2",
         "vitest": "^4.1.8"
@@ -33222,17 +33229,17 @@
       "license": "MIT"
     },
     "packages/jaypie": {
-      "version": "1.2.54",
+      "version": "1.2.55",
       "license": "MIT",
       "dependencies": {
-        "@jaypie/aws": "^1.2.9",
-        "@jaypie/core": "^1.2.2",
-        "@jaypie/datadog": "^1.2.4",
-        "@jaypie/errors": "^1.2.2",
-        "@jaypie/express": "^1.2.25",
-        "@jaypie/kit": "^1.2.9",
-        "@jaypie/lambda": "^1.2.10",
-        "@jaypie/logger": "^1.2.17"
+        "@jaypie/aws": "^1.2.10",
+        "@jaypie/core": "^1.2.3",
+        "@jaypie/datadog": "^1.2.5",
+        "@jaypie/errors": "^1.2.3",
+        "@jaypie/express": "^1.2.26",
+        "@jaypie/kit": "^1.2.10",
+        "@jaypie/lambda": "^1.2.11",
+        "@jaypie/logger": "^1.2.18"
       },
       "devDependencies": {
         "@jaypie/types": "^0.1.7",
@@ -33242,6 +33249,7 @@
         "@typescript-eslint/parser": "^8.46.1",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.4",
+        "rollup-plugin-dts": "^6.1.1",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.46.1"
       },
@@ -33273,7 +33281,7 @@
     },
     "packages/kit": {
       "name": "@jaypie/kit",
-      "version": "1.2.9",
+      "version": "1.2.10",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*",
@@ -33290,6 +33298,7 @@
         "eslint-plugin-prettier": "^5.2.1",
         "jest-extended": "^4.0.2",
         "rollup": "^4.12.0",
+        "rollup-plugin-dts": "^6.1.1",
         "typescript": "^5.3.3",
         "typescript-eslint": "^8.18.2",
         "vitest": "^4.1.8"
@@ -33323,11 +33332,12 @@
     },
     "packages/lambda": {
       "name": "@jaypie/lambda",
-      "version": "1.2.10",
+      "version": "1.2.11",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-typescript": "^12.1.2",
         "@types/node": "^22.13.1",
+        "rollup-plugin-dts": "^6.1.1",
         "typescript": "^5.3.3"
       },
       "peerDependencies": {
@@ -33357,7 +33367,7 @@
     },
     "packages/llm": {
       "name": "@jaypie/llm",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "*",
@@ -33374,7 +33384,8 @@
         "@aws-sdk/client-bedrock-runtime": "^3.1045.0",
         "@google/genai": "^1.30.0",
         "@jaypie/types": "*",
-        "@openrouter/sdk": "^0.1.27"
+        "@openrouter/sdk": "^0.1.27",
+        "rollup-plugin-dts": "^6.1.1"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": "^0.71.0",
@@ -33420,7 +33431,7 @@
     },
     "packages/logger": {
       "name": "@jaypie/logger",
-      "version": "1.2.17",
+      "version": "1.2.18",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-typescript": "^12.1.2",
@@ -33430,6 +33441,7 @@
         "eslint-config-prettier": "^10.0.1",
         "eslint-plugin-prettier": "^5.2.1",
         "rollup": "^4.12.0",
+        "rollup-plugin-dts": "^6.1.1",
         "typescript": "^5.3.3",
         "typescript-eslint": "^8.18.2",
         "vitest": "^4.1.8"
@@ -33483,11 +33495,11 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.79",
+      "version": "0.8.80",
       "license": "MIT",
       "dependencies": {
-        "@jaypie/fabric": "^0.2.4",
-        "@jaypie/tildeskill": "^0.3.1",
+        "@jaypie/fabric": "^0.3.3",
+        "@jaypie/tildeskill": "^0.3.2",
         "@modelcontextprotocol/sdk": "^1.17.0",
         "commander": "^14.0.0",
         "gray-matter": "^4.0.3",
@@ -33505,53 +33517,13 @@
         "express": "^5.1.0",
         "rollup": "^4.53.3",
         "rollup-plugin-copy": "^3.5.0",
+        "rollup-plugin-dts": "^6.1.1",
         "typescript": "^5.9.3"
-      }
-    },
-    "packages/mcp/node_modules/@jaypie/fabric": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@jaypie/fabric/-/fabric-0.2.4.tgz",
-      "integrity": "sha512-a3H4C5anu9aYB97pOgk1NLqzAKiDHK9vefLPR4cEwVAsJmNhzydxEvQrJ6DGSfHAP6xtmEXukgdLwtKb9M+Z0A==",
-      "license": "MIT",
-      "dependencies": {
-        "@jaypie/errors": "*"
-      },
-      "peerDependencies": {
-        "@jaypie/aws": "*",
-        "@jaypie/dynamodb": "*",
-        "@jaypie/lambda": "*",
-        "@modelcontextprotocol/sdk": ">=1.0.0",
-        "commander": ">=12.0.0",
-        "express": ">=4.0.0",
-        "zod": ">=3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@jaypie/aws": {
-          "optional": true
-        },
-        "@jaypie/dynamodb": {
-          "optional": true
-        },
-        "@jaypie/lambda": {
-          "optional": true
-        },
-        "@modelcontextprotocol/sdk": {
-          "optional": true
-        },
-        "commander": {
-          "optional": true
-        },
-        "express": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
       }
     },
     "packages/mcp/node_modules/accepts": {
       "version": "2.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-types": "^3.0.0",
@@ -33563,7 +33535,7 @@
     },
     "packages/mcp/node_modules/body-parser": {
       "version": "2.2.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
@@ -33593,7 +33565,7 @@
     },
     "packages/mcp/node_modules/content-disposition": {
       "version": "1.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -33605,7 +33577,7 @@
     },
     "packages/mcp/node_modules/express": {
       "version": "5.2.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "^2.0.0",
@@ -33647,7 +33619,7 @@
     },
     "packages/mcp/node_modules/finalhandler": {
       "version": "2.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -33667,7 +33639,7 @@
     },
     "packages/mcp/node_modules/fresh": {
       "version": "2.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -33675,7 +33647,7 @@
     },
     "packages/mcp/node_modules/iconv-lite": {
       "version": "0.7.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -33690,7 +33662,7 @@
     },
     "packages/mcp/node_modules/media-typer": {
       "version": "1.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -33698,7 +33670,7 @@
     },
     "packages/mcp/node_modules/merge-descriptors": {
       "version": "2.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -33709,7 +33681,7 @@
     },
     "packages/mcp/node_modules/mime-db": {
       "version": "1.54.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -33717,7 +33689,7 @@
     },
     "packages/mcp/node_modules/mime-types": {
       "version": "3.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
@@ -33732,7 +33704,7 @@
     },
     "packages/mcp/node_modules/negotiator": {
       "version": "1.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -33740,7 +33712,7 @@
     },
     "packages/mcp/node_modules/send": {
       "version": "1.2.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.3",
@@ -33765,7 +33737,7 @@
     },
     "packages/mcp/node_modules/serve-static": {
       "version": "2.2.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "encodeurl": "^2.0.0",
@@ -33783,7 +33755,7 @@
     },
     "packages/mcp/node_modules/type-is": {
       "version": "2.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "content-type": "^1.0.5",
@@ -33796,7 +33768,7 @@
     },
     "packages/mongoose": {
       "name": "@jaypie/mongoose",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "*"
@@ -33805,6 +33777,7 @@
         "@rollup/plugin-typescript": "^12.1.2",
         "@types/node": "^22.13.1",
         "mongoose": "^8.3.0",
+        "rollup-plugin-dts": "^6.1.1",
         "typescript": "^5.3.3"
       },
       "peerDependencies": {
@@ -33954,7 +33927,7 @@
     },
     "packages/tildeskill": {
       "name": "@jaypie/tildeskill",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*",
@@ -33965,6 +33938,7 @@
         "@rollup/plugin-typescript": "^12.1.2",
         "@types/node": "^22.13.1",
         "rollup": "^4.12.0",
+        "rollup-plugin-dts": "^6.1.1",
         "typescript": "^5.3.3",
         "vitest": "^4.1.8"
       }

--- a/packages/aws/package.json
+++ b/packages/aws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/aws",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"
@@ -11,10 +11,14 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/esm/index.d.ts",
-      "require": "./dist/cjs/index.cjs",
-      "import": "./dist/esm/index.js",
-      "default": "./dist/esm/index.js"
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.cts",
+        "default": "./dist/cjs/index.cjs"
+      }
     }
   },
   "main": "./dist/cjs/index.cjs",
@@ -46,6 +50,7 @@
     "@rollup/plugin-typescript": "^12.1.2",
     "@types/async-retry": "^1.4.9",
     "@types/node": "^22.13.1",
+    "rollup-plugin-dts": "^6.1.1",
     "typescript": "^5.3.3"
   },
   "peerDependencies": {

--- a/packages/aws/rollup.config.mjs
+++ b/packages/aws/rollup.config.mjs
@@ -1,4 +1,5 @@
 import typescript from "@rollup/plugin-typescript";
+import { dts } from "rollup-plugin-dts";
 import autoExternal from "rollup-plugin-auto-external";
 
 // Filter out TS2307 warnings for @jaypie/* packages (external workspace dependencies)
@@ -8,6 +9,11 @@ const onwarn = (warning, defaultHandler) => {
   }
   defaultHandler(warning);
 };
+
+// Bundle declarations: keep every bare specifier external so dts() inlines only
+// our own relative files, producing a single self-contained declaration that
+// resolves under node16/nodenext module resolution.
+const dtsExternal = (id) => !/^[./]/.test(id);
 
 export default [
   // ES modules version
@@ -47,5 +53,20 @@ export default [
         outDir: "dist/cjs",
       }),
     ],
+  },
+  // Type definitions (ESM): bundled to a single self-contained declaration file.
+  {
+    input: "src/index.ts",
+    output: { file: "dist/esm/index.d.ts", format: "es" },
+    plugins: [dts()],
+    external: dtsExternal,
+  },
+  // Type definitions (CommonJS): emitted as .d.cts so node16/nodenext flags it
+  // as a CommonJS declaration under the package's "type": "module" setting.
+  {
+    input: "src/index.ts",
+    output: { file: "dist/cjs/index.d.cts", format: "es" },
+    plugins: [dts()],
+    external: dtsExternal,
   },
 ];

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/core",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"
@@ -11,10 +11,14 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/esm/index.d.ts",
-      "require": "./dist/cjs/index.cjs",
-      "import": "./dist/esm/index.js",
-      "default": "./dist/esm/index.js"
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.cts",
+        "default": "./dist/cjs/index.cjs"
+      }
     }
   },
   "main": "./dist/cjs/index.cjs",
@@ -40,6 +44,7 @@
   "devDependencies": {
     "@rollup/plugin-typescript": "^12.1.2",
     "@types/node": "^22.13.1",
+    "rollup-plugin-dts": "^6.1.1",
     "typescript": "^5.3.3"
   },
   "publishConfig": {

--- a/packages/core/rollup.config.mjs
+++ b/packages/core/rollup.config.mjs
@@ -1,4 +1,5 @@
 import typescript from "@rollup/plugin-typescript";
+import { dts } from "rollup-plugin-dts";
 import autoExternal from "rollup-plugin-auto-external";
 
 // Filter out TS2307 warnings for @jaypie/* packages (external workspace dependencies)
@@ -10,6 +11,11 @@ const onwarn = (warning, defaultHandler) => {
 };
 
 const external = ["@jaypie/errors", "@jaypie/kit", "@jaypie/logger"];
+
+// Bundle declarations: keep every bare specifier external so dts() inlines only
+// our own relative files, producing a single self-contained declaration that
+// resolves under node16/nodenext module resolution.
+const dtsExternal = (id) => !/^[./]/.test(id);
 
 export default [
   // ES modules version
@@ -51,5 +57,20 @@ export default [
         outDir: "dist/cjs",
       }),
     ],
+  },
+  // Type definitions (ESM): bundled to a single self-contained declaration file.
+  {
+    input: "src/index.ts",
+    output: { file: "dist/esm/index.d.ts", format: "es" },
+    plugins: [dts()],
+    external: dtsExternal,
+  },
+  // Type definitions (CommonJS): emitted as .d.cts so node16/nodenext flags it
+  // as a CommonJS declaration under the package's "type": "module" setting.
+  {
+    input: "src/index.ts",
+    output: { file: "dist/cjs/index.d.cts", format: "es" },
+    plugins: [dts()],
+    external: dtsExternal,
   },
 ];

--- a/packages/datadog/package.json
+++ b/packages/datadog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/datadog",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"
@@ -11,10 +11,14 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/esm/index.d.ts",
-      "require": "./dist/cjs/index.cjs",
-      "import": "./dist/esm/index.js",
-      "default": "./dist/esm/index.js"
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.cts",
+        "default": "./dist/cjs/index.cjs"
+      }
     }
   },
   "main": "./dist/cjs/index.cjs",
@@ -39,6 +43,7 @@
   "devDependencies": {
     "@rollup/plugin-typescript": "^12.1.2",
     "@types/node": "^22.13.1",
+    "rollup-plugin-dts": "^6.1.1",
     "typescript": "^5.3.3"
   },
   "peerDependencies": {

--- a/packages/datadog/rollup.config.mjs
+++ b/packages/datadog/rollup.config.mjs
@@ -1,4 +1,5 @@
 import typescript from "@rollup/plugin-typescript";
+import { dts } from "rollup-plugin-dts";
 import autoExternal from "rollup-plugin-auto-external";
 
 // Filter out TS2307 warnings for @jaypie/* packages (external workspace dependencies)
@@ -8,6 +9,11 @@ const onwarn = (warning, defaultHandler) => {
   }
   defaultHandler(warning);
 };
+
+// Bundle declarations: keep every bare specifier external so dts() inlines only
+// our own relative files, producing a single self-contained declaration that
+// resolves under node16/nodenext module resolution.
+const dtsExternal = (id) => !/^[./]/.test(id);
 
 export default [
   // ES modules version
@@ -47,5 +53,20 @@ export default [
         outDir: "dist/cjs",
       }),
     ],
+  },
+  // Type definitions (ESM): bundled to a single self-contained declaration file.
+  {
+    input: "src/index.ts",
+    output: { file: "dist/esm/index.d.ts", format: "es" },
+    plugins: [dts()],
+    external: dtsExternal,
+  },
+  // Type definitions (CommonJS): emitted as .d.cts so node16/nodenext flags it
+  // as a CommonJS declaration under the package's "type": "module" setting.
+  {
+    input: "src/index.ts",
+    output: { file: "dist/cjs/index.d.cts", format: "es" },
+    plugins: [dts()],
+    external: dtsExternal,
   },
 ];

--- a/packages/dynamodb/package.json
+++ b/packages/dynamodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/dynamodb",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"
@@ -11,16 +11,24 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/esm/index.d.ts",
-      "require": "./dist/cjs/index.cjs",
-      "import": "./dist/esm/index.js",
-      "default": "./dist/esm/index.js"
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.cts",
+        "default": "./dist/cjs/index.cjs"
+      }
     },
     "./mcp": {
-      "types": "./dist/esm/mcp/index.d.ts",
-      "require": "./dist/cjs/mcp/index.cjs",
-      "import": "./dist/esm/mcp/index.js",
-      "default": "./dist/esm/mcp/index.js"
+      "import": {
+        "types": "./dist/esm/mcp/index.d.ts",
+        "default": "./dist/esm/mcp/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/mcp/index.d.cts",
+        "default": "./dist/cjs/mcp/index.cjs"
+      }
     }
   },
   "main": "./dist/cjs/index.cjs",
@@ -46,6 +54,7 @@
   "devDependencies": {
     "@rollup/plugin-typescript": "^12.1.2",
     "@types/node": "^22.13.1",
+    "rollup-plugin-dts": "^6.1.1",
     "typescript": "^5.3.3"
   },
   "peerDependencies": {

--- a/packages/dynamodb/rollup.config.mjs
+++ b/packages/dynamodb/rollup.config.mjs
@@ -1,5 +1,6 @@
 import typescript from "@rollup/plugin-typescript";
 import autoExternal from "rollup-plugin-auto-external";
+import { dts } from "rollup-plugin-dts";
 
 // Filter out TS2307 warnings for @jaypie/* packages (external workspace dependencies)
 const onwarn = (warning, defaultHandler) => {
@@ -8,6 +9,11 @@ const onwarn = (warning, defaultHandler) => {
   }
   defaultHandler(warning);
 };
+
+// Bundle declarations: keep every bare specifier external so dts() inlines only
+// our own relative files, producing a single self-contained declaration that
+// resolves under node16/nodenext module resolution.
+const dtsExternal = (id) => !/^[./]/.test(id);
 
 export default [
   // ES modules version - main
@@ -89,5 +95,33 @@ export default [
       }),
     ],
     external: ["@jaypie/fabric/mcp"],
+  },
+  // Type definitions (ESM): bundled to a single self-contained declaration file.
+  {
+    input: "src/index.ts",
+    output: { file: "dist/esm/index.d.ts", format: "es" },
+    plugins: [dts()],
+    external: dtsExternal,
+  },
+  // Type definitions (CommonJS): emitted as .d.cts so node16/nodenext flags it
+  // as a CommonJS declaration under the package's "type": "module" setting.
+  {
+    input: "src/index.ts",
+    output: { file: "dist/cjs/index.d.cts", format: "es" },
+    plugins: [dts()],
+    external: dtsExternal,
+  },
+  // Type definitions for the ./mcp subpath
+  {
+    input: "src/mcp/index.ts",
+    output: { file: "dist/esm/mcp/index.d.ts", format: "es" },
+    plugins: [dts()],
+    external: dtsExternal,
+  },
+  {
+    input: "src/mcp/index.ts",
+    output: { file: "dist/cjs/mcp/index.d.cts", format: "es" },
+    plugins: [dts()],
+    external: dtsExternal,
   },
 ];

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/errors",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Error utilities for Jaypie applications",
   "repository": {
     "type": "git",
@@ -11,10 +11,14 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/esm/index.d.ts",
-      "require": "./dist/cjs/index.cjs",
-      "import": "./dist/esm/index.js",
-      "default": "./dist/esm/index.js"
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.cts",
+        "default": "./dist/cjs/index.cjs"
+      }
     }
   },
   "main": "./dist/cjs/index.cjs",
@@ -40,6 +44,7 @@
     "eslint-config-prettier": "^10.0.1",
     "eslint-plugin-prettier": "^5.2.1",
     "rollup": "^4.12.0",
+    "rollup-plugin-dts": "^6.1.1",
     "typescript": "^5.3.3",
     "typescript-eslint": "^8.18.2",
     "vitest": "^4.1.8"

--- a/packages/errors/rollup.config.js
+++ b/packages/errors/rollup.config.js
@@ -1,4 +1,10 @@
 import typescript from "@rollup/plugin-typescript";
+import { dts } from "rollup-plugin-dts";
+
+// Bundle declarations: keep every bare specifier external so dts() inlines only
+// our own relative files, producing a single self-contained declaration that
+// resolves under node16/nodenext module resolution.
+const dtsExternal = (id) => !/^[./]/.test(id);
 
 export default [
   // ES modules version
@@ -36,5 +42,20 @@ export default [
       }),
     ],
     external: [],
+  },
+  // Type definitions (ESM): bundled to a single self-contained declaration file.
+  {
+    input: "src/index.ts",
+    output: { file: "dist/esm/index.d.ts", format: "es" },
+    plugins: [dts()],
+    external: dtsExternal,
+  },
+  // Type definitions (CommonJS): emitted as .d.cts so node16/nodenext flags it
+  // as a CommonJS declaration under the package's "type": "module" setting.
+  {
+    input: "src/index.ts",
+    output: { file: "dist/cjs/index.d.cts", format: "es" },
+    plugins: [dts()],
+    external: dtsExternal,
   },
 ];

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/express",
-  "version": "1.2.25",
+  "version": "1.2.26",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"
@@ -11,9 +11,14 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/esm/index.d.ts",
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.cjs"
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.cts",
+        "default": "./dist/cjs/index.cjs"
+      }
     }
   },
   "main": "./dist/cjs/index.cjs",
@@ -53,6 +58,7 @@
     "@types/express": "^5.0.0",
     "@types/node": "^22.13.1",
     "express": "^4.21.2",
+    "rollup-plugin-dts": "^6.1.1",
     "typescript": "^5.3.3"
   },
   "peerDependencies": {

--- a/packages/express/rollup.config.mjs
+++ b/packages/express/rollup.config.mjs
@@ -1,4 +1,5 @@
 import autoExternal from "rollup-plugin-auto-external";
+import { dts } from "rollup-plugin-dts";
 import typescript from "@rollup/plugin-typescript";
 
 // Externals not caught by auto-external (peer deps + node: prefixed builtins)
@@ -11,6 +12,11 @@ const onwarn = (warning, defaultHandler) => {
   }
   defaultHandler(warning);
 };
+
+// Bundle declarations: keep every bare specifier external so dts() inlines only
+// our own relative files, producing a single self-contained declaration that
+// resolves under node16/nodenext module resolution.
+const dtsExternal = (id) => !/^[./]/.test(id);
 
 export default [
   // ES modules version
@@ -52,5 +58,20 @@ export default [
         outDir: "dist/cjs",
       }),
     ],
+  },
+  // Type definitions (ESM): bundled to a single self-contained declaration file.
+  {
+    input: "src/index.ts",
+    output: { file: "dist/esm/index.d.ts", format: "es" },
+    plugins: [dts()],
+    external: dtsExternal,
+  },
+  // Type definitions (CommonJS): emitted as .d.cts so node16/nodenext flags it
+  // as a CommonJS declaration under the package's "type": "module" setting.
+  {
+    input: "src/index.ts",
+    output: { file: "dist/cjs/index.d.cts", format: "es" },
+    plugins: [dts()],
+    external: dtsExternal,
   },
 ];

--- a/packages/fabric/package.json
+++ b/packages/fabric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/fabric",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Jaypie modeling framework with type conversion, service handlers, and adapters",
   "repository": {
     "type": "git",
@@ -12,49 +12,94 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/esm/index.d.ts",
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.cjs"
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.cts",
+        "default": "./dist/cjs/index.cjs"
+      }
     },
     "./commander": {
-      "types": "./dist/esm/commander/index.d.ts",
-      "import": "./dist/esm/commander/index.js",
-      "require": "./dist/cjs/commander/index.cjs"
+      "import": {
+        "types": "./dist/esm/commander/index.d.ts",
+        "default": "./dist/esm/commander/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/commander/index.d.cts",
+        "default": "./dist/cjs/commander/index.cjs"
+      }
     },
     "./http": {
-      "types": "./dist/esm/http/index.d.ts",
-      "import": "./dist/esm/http/index.js",
-      "require": "./dist/cjs/http/index.cjs"
+      "import": {
+        "types": "./dist/esm/http/index.d.ts",
+        "default": "./dist/esm/http/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/http/index.d.cts",
+        "default": "./dist/cjs/http/index.cjs"
+      }
     },
     "./lambda": {
-      "types": "./dist/esm/lambda/index.d.ts",
-      "import": "./dist/esm/lambda/index.js",
-      "require": "./dist/cjs/lambda/index.cjs"
+      "import": {
+        "types": "./dist/esm/lambda/index.d.ts",
+        "default": "./dist/esm/lambda/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/lambda/index.d.cts",
+        "default": "./dist/cjs/lambda/index.cjs"
+      }
     },
     "./llm": {
-      "types": "./dist/esm/llm/index.d.ts",
-      "import": "./dist/esm/llm/index.js",
-      "require": "./dist/cjs/llm/index.cjs"
+      "import": {
+        "types": "./dist/esm/llm/index.d.ts",
+        "default": "./dist/esm/llm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/llm/index.d.cts",
+        "default": "./dist/cjs/llm/index.cjs"
+      }
     },
     "./mcp": {
-      "types": "./dist/esm/mcp/index.d.ts",
-      "import": "./dist/esm/mcp/index.js",
-      "require": "./dist/cjs/mcp/index.cjs"
+      "import": {
+        "types": "./dist/esm/mcp/index.d.ts",
+        "default": "./dist/esm/mcp/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/mcp/index.d.cts",
+        "default": "./dist/cjs/mcp/index.cjs"
+      }
     },
     "./express": {
-      "types": "./dist/esm/express/index.d.ts",
-      "import": "./dist/esm/express/index.js",
-      "require": "./dist/cjs/express/index.cjs"
+      "import": {
+        "types": "./dist/esm/express/index.d.ts",
+        "default": "./dist/esm/express/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/express/index.d.cts",
+        "default": "./dist/cjs/express/index.cjs"
+      }
     },
     "./data": {
-      "types": "./dist/esm/data/index.d.ts",
-      "import": "./dist/esm/data/index.js",
-      "require": "./dist/cjs/data/index.cjs"
+      "import": {
+        "types": "./dist/esm/data/index.d.ts",
+        "default": "./dist/esm/data/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/data/index.d.cts",
+        "default": "./dist/cjs/data/index.cjs"
+      }
     },
     "./websocket": {
-      "types": "./dist/esm/websocket/index.d.ts",
-      "import": "./dist/esm/websocket/index.js",
-      "require": "./dist/cjs/websocket/index.cjs"
+      "import": {
+        "types": "./dist/esm/websocket/index.d.ts",
+        "default": "./dist/esm/websocket/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/websocket/index.d.cts",
+        "default": "./dist/cjs/websocket/index.cjs"
+      }
     }
   },
   "main": "./dist/cjs/index.cjs",
@@ -89,6 +134,7 @@
     "express": "^5.0.1",
     "jest-extended": "^4.0.2",
     "rollup": "^4.12.0",
+    "rollup-plugin-dts": "^6.1.1",
     "typescript": "^5.3.3",
     "typescript-eslint": "^8.18.2",
     "vitest": "^4.1.8"

--- a/packages/fabric/rollup.config.js
+++ b/packages/fabric/rollup.config.js
@@ -1,4 +1,43 @@
 import typescript from "@rollup/plugin-typescript";
+import { dts } from "rollup-plugin-dts";
+
+// Bundle declarations: keep every bare specifier external so dts() inlines only
+// our own relative files, producing a single self-contained declaration per
+// entry point that resolves under node16/nodenext module resolution.
+const dtsExternal = (id) => !/^[./]/.test(id);
+
+// Subpath entry points ("" is the package root). Each gets a bundled ESM
+// `index.d.ts` and a CommonJS `index.d.cts`.
+const dtsEntries = [
+  "",
+  "commander",
+  "data",
+  "express",
+  "http",
+  "lambda",
+  "llm",
+  "mcp",
+  "websocket",
+];
+
+const dtsConfigs = dtsEntries.flatMap((sub) => {
+  const dir = sub ? `${sub}/` : "";
+  const input = `src/${dir}index.ts`;
+  return [
+    {
+      input,
+      output: { file: `dist/esm/${dir}index.d.ts`, format: "es" },
+      plugins: [dts()],
+      external: dtsExternal,
+    },
+    {
+      input,
+      output: { file: `dist/cjs/${dir}index.d.cts`, format: "es" },
+      plugins: [dts()],
+      external: dtsExternal,
+    },
+  ];
+});
 
 // Filter out expected warnings:
 // - TS2307: Cannot find module '@jaypie/*' (external workspace dependencies)
@@ -345,4 +384,6 @@ export default [
     ],
     external,
   },
+  // Type definitions: one self-contained bundle per entry point and format.
+  ...dtsConfigs,
 ];

--- a/packages/jaypie/package.json
+++ b/packages/jaypie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jaypie",
-  "version": "1.2.54",
+  "version": "1.2.55",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"
@@ -11,9 +11,14 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/esm/index.d.ts",
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.cjs"
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.cts",
+        "default": "./dist/cjs/index.cjs"
+      }
     }
   },
   "main": "./dist/cjs/index.cjs",
@@ -32,14 +37,14 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@jaypie/aws": "^1.2.9",
-    "@jaypie/core": "^1.2.2",
-    "@jaypie/datadog": "^1.2.4",
-    "@jaypie/errors": "^1.2.2",
-    "@jaypie/express": "^1.2.25",
-    "@jaypie/kit": "^1.2.9",
-    "@jaypie/lambda": "^1.2.10",
-    "@jaypie/logger": "^1.2.17"
+    "@jaypie/aws": "^1.2.10",
+    "@jaypie/core": "^1.2.3",
+    "@jaypie/datadog": "^1.2.5",
+    "@jaypie/errors": "^1.2.3",
+    "@jaypie/express": "^1.2.26",
+    "@jaypie/kit": "^1.2.10",
+    "@jaypie/lambda": "^1.2.11",
+    "@jaypie/logger": "^1.2.18"
   },
   "devDependencies": {
     "@jaypie/types": "^0.1.7",
@@ -49,6 +54,7 @@
     "@typescript-eslint/parser": "^8.46.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.4",
+    "rollup-plugin-dts": "^6.1.1",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.46.1"
   },

--- a/packages/jaypie/rollup.config.mjs
+++ b/packages/jaypie/rollup.config.mjs
@@ -1,4 +1,10 @@
 import typescript from "@rollup/plugin-typescript";
+import { dts } from "rollup-plugin-dts";
+
+// Bundle declarations: keep every bare specifier external so dts() inlines only
+// our own relative files, producing a single self-contained declaration that
+// resolves under node16/nodenext module resolution.
+const dtsExternal = (id) => !/^[./]/.test(id);
 
 // Filter out TS2307 warnings for @jaypie/* packages (external workspace dependencies)
 const onwarn = (warning, defaultHandler) => {
@@ -58,5 +64,20 @@ export default [
       }),
     ],
     external,
+  },
+  // Type definitions (ESM): bundled to a single self-contained declaration file.
+  {
+    input: "src/index.ts",
+    output: { file: "dist/esm/index.d.ts", format: "es" },
+    plugins: [dts()],
+    external: dtsExternal,
+  },
+  // Type definitions (CommonJS): emitted as .d.cts so node16/nodenext flags it
+  // as a CommonJS declaration under the package's "type": "module" setting.
+  {
+    input: "src/index.ts",
+    output: { file: "dist/cjs/index.d.cts", format: "es" },
+    plugins: [dts()],
+    external: dtsExternal,
   },
 ];

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/kit",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "Utility functions for Jaypie applications",
   "repository": {
     "type": "git",
@@ -12,9 +12,14 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/esm/index.d.ts",
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.cjs"
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.cts",
+        "default": "./dist/cjs/index.cjs"
+      }
     }
   },
   "main": "./dist/cjs/index.cjs",
@@ -46,6 +51,7 @@
     "eslint-plugin-prettier": "^5.2.1",
     "jest-extended": "^4.0.2",
     "rollup": "^4.12.0",
+    "rollup-plugin-dts": "^6.1.1",
     "typescript": "^5.3.3",
     "typescript-eslint": "^8.18.2",
     "vitest": "^4.1.8"

--- a/packages/kit/rollup.config.js
+++ b/packages/kit/rollup.config.js
@@ -1,4 +1,5 @@
 import typescript from "@rollup/plugin-typescript";
+import { dts } from "rollup-plugin-dts";
 
 // Filter out TS2307 warnings for @jaypie/* packages (external workspace dependencies)
 const onwarn = (warning, defaultHandler) => {
@@ -7,6 +8,11 @@ const onwarn = (warning, defaultHandler) => {
   }
   defaultHandler(warning);
 };
+
+// Bundle declarations: keep every bare specifier external so dts() inlines only
+// our own relative files, producing a single self-contained declaration that
+// resolves under node16/nodenext module resolution.
+const dtsExternal = (id) => !/^[./]/.test(id);
 
 export default [
   // ES modules version
@@ -46,5 +52,20 @@ export default [
       }),
     ],
     external: ["@jaypie/errors", "@jaypie/logger", "node:crypto", "uuid"],
+  },
+  // Type definitions (ESM): bundled to a single self-contained declaration file.
+  {
+    input: "src/index.ts",
+    output: { file: "dist/esm/index.d.ts", format: "es" },
+    plugins: [dts()],
+    external: dtsExternal,
+  },
+  // Type definitions (CommonJS): emitted as .d.cts so node16/nodenext flags it
+  // as a CommonJS declaration under the package's "type": "module" setting.
+  {
+    input: "src/index.ts",
+    output: { file: "dist/cjs/index.d.cts", format: "es" },
+    plugins: [dts()],
+    external: dtsExternal,
   },
 ];

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/lambda",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"
@@ -11,10 +11,14 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/esm/index.d.ts",
-      "require": "./dist/cjs/index.cjs",
-      "import": "./dist/esm/index.js",
-      "default": "./dist/esm/index.js"
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.cts",
+        "default": "./dist/cjs/index.cjs"
+      }
     }
   },
   "main": "./dist/cjs/index.cjs",
@@ -35,6 +39,7 @@
   "devDependencies": {
     "@rollup/plugin-typescript": "^12.1.2",
     "@types/node": "^22.13.1",
+    "rollup-plugin-dts": "^6.1.1",
     "typescript": "^5.3.3"
   },
   "peerDependencies": {

--- a/packages/lambda/rollup.config.mjs
+++ b/packages/lambda/rollup.config.mjs
@@ -1,4 +1,5 @@
 import typescript from "@rollup/plugin-typescript";
+import { dts } from "rollup-plugin-dts";
 import autoExternal from "rollup-plugin-auto-external";
 
 // Filter out TS2307 warnings for @jaypie/* packages (external workspace dependencies)
@@ -8,6 +9,11 @@ const onwarn = (warning, defaultHandler) => {
   }
   defaultHandler(warning);
 };
+
+// Bundle declarations: keep every bare specifier external so dts() inlines only
+// our own relative files, producing a single self-contained declaration that
+// resolves under node16/nodenext module resolution.
+const dtsExternal = (id) => !/^[./]/.test(id);
 
 export default [
   // ES modules version
@@ -47,5 +53,20 @@ export default [
         outDir: "dist/cjs",
       }),
     ],
+  },
+  // Type definitions (ESM): bundled to a single self-contained declaration file.
+  {
+    input: "src/index.ts",
+    output: { file: "dist/esm/index.d.ts", format: "es" },
+    plugins: [dts()],
+    external: dtsExternal,
+  },
+  // Type definitions (CommonJS): emitted as .d.cts so node16/nodenext flags it
+  // as a CommonJS declaration under the package's "type": "module" setting.
+  {
+    input: "src/index.ts",
+    output: { file: "dist/cjs/index.d.cts", format: "es" },
+    plugins: [dts()],
+    external: dtsExternal,
   },
 ];

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/llm",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Large language model utilities",
   "repository": {
     "type": "git",
@@ -12,9 +12,14 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/esm/index.d.ts",
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.cjs"
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.cts",
+        "default": "./dist/cjs/index.cjs"
+      }
     }
   },
   "main": "./dist/cjs/index.cjs",
@@ -48,7 +53,8 @@
     "@aws-sdk/client-bedrock-runtime": "^3.1045.0",
     "@google/genai": "^1.30.0",
     "@jaypie/types": "*",
-    "@openrouter/sdk": "^0.1.27"
+    "@openrouter/sdk": "^0.1.27",
+    "rollup-plugin-dts": "^6.1.1"
   },
   "peerDependencies": {
     "@anthropic-ai/sdk": "^0.71.0",

--- a/packages/llm/rollup.config.js
+++ b/packages/llm/rollup.config.js
@@ -1,4 +1,5 @@
 import typescript from "@rollup/plugin-typescript";
+import { dts } from "rollup-plugin-dts";
 
 // Filter out TS2307 warnings for @jaypie/* packages (external workspace dependencies)
 const onwarn = (warning, defaultHandler) => {
@@ -7,6 +8,11 @@ const onwarn = (warning, defaultHandler) => {
   }
   defaultHandler(warning);
 };
+
+// Bundle declarations: keep every bare specifier external so dts() inlines only
+// our own relative files, producing a single self-contained declaration that
+// resolves under node16/nodenext module resolution.
+const dtsExternal = (id) => !/^[./]/.test(id);
 
 export default [
   // ES modules version
@@ -88,5 +94,20 @@ export default [
       "zod",
       "zod/v4",
     ],
+  },
+  // Type definitions (ESM): bundled to a single self-contained declaration file.
+  {
+    input: "src/index.ts",
+    output: { file: "dist/esm/index.d.ts", format: "es" },
+    plugins: [dts()],
+    external: dtsExternal,
+  },
+  // Type definitions (CommonJS): emitted as .d.cts so node16/nodenext flags it
+  // as a CommonJS declaration under the package's "type": "module" setting.
+  {
+    input: "src/index.ts",
+    output: { file: "dist/cjs/index.d.cts", format: "es" },
+    plugins: [dts()],
+    external: dtsExternal,
   },
 ];

--- a/packages/llm/src/providers/anthropic/utils.ts
+++ b/packages/llm/src/providers/anthropic/utils.ts
@@ -1,7 +1,7 @@
 import { getEnvSecret } from "@jaypie/aws";
 import { ConfigurationError } from "@jaypie/errors";
 import { JAYPIE, placeholders as replacePlaceholders } from "@jaypie/kit";
-import { log as defaultLog, log } from "@jaypie/logger";
+import { createLogger, log as defaultLog, log } from "@jaypie/logger";
 import type Anthropic from "@anthropic-ai/sdk";
 import { PROVIDER } from "../../constants.js";
 import { LlmMessageOptions } from "../../types/LlmProvider.interface.js";
@@ -25,7 +25,8 @@ export async function loadSdk(): Promise<typeof import("@anthropic-ai/sdk")> {
 }
 
 // Logger
-export const getLogger = () => defaultLog.lib({ lib: JAYPIE.LIB.LLM });
+export const getLogger = (): ReturnType<typeof createLogger> =>
+  defaultLog.lib({ lib: JAYPIE.LIB.LLM });
 
 // Client initialization
 export async function initializeClient({

--- a/packages/llm/src/providers/bedrock/utils.ts
+++ b/packages/llm/src/providers/bedrock/utils.ts
@@ -1,5 +1,5 @@
 import { JAYPIE } from "@jaypie/kit";
-import { log as defaultLog } from "@jaypie/logger";
+import { createLogger, log as defaultLog } from "@jaypie/logger";
 import { ConfigurationError } from "@jaypie/errors";
 import type { BedrockRuntimeClient } from "@aws-sdk/client-bedrock-runtime";
 
@@ -19,7 +19,8 @@ export async function loadSdk(): Promise<
   }
 }
 
-export const getLogger = () => defaultLog.lib({ lib: JAYPIE.LIB.LLM });
+export const getLogger = (): ReturnType<typeof createLogger> =>
+  defaultLog.lib({ lib: JAYPIE.LIB.LLM });
 
 export async function initializeClient({
   region,

--- a/packages/llm/src/providers/google/utils.ts
+++ b/packages/llm/src/providers/google/utils.ts
@@ -1,7 +1,7 @@
 import { getEnvSecret } from "@jaypie/aws";
 import { ConfigurationError } from "@jaypie/errors";
 import { JAYPIE, placeholders as replacePlaceholders } from "@jaypie/kit";
-import { log as defaultLog } from "@jaypie/logger";
+import { createLogger, log as defaultLog } from "@jaypie/logger";
 import type { GoogleGenAI } from "@google/genai";
 import { LlmMessageOptions } from "../../types/LlmProvider.interface.js";
 
@@ -21,7 +21,8 @@ export async function loadSdk(): Promise<typeof import("@google/genai")> {
 }
 
 // Logger
-export const getLogger = () => defaultLog.lib({ lib: JAYPIE.LIB.LLM });
+export const getLogger = (): ReturnType<typeof createLogger> =>
+  defaultLog.lib({ lib: JAYPIE.LIB.LLM });
 
 // Client initialization
 export async function initializeClient({

--- a/packages/llm/src/providers/openai/utils.ts
+++ b/packages/llm/src/providers/openai/utils.ts
@@ -1,7 +1,7 @@
 import { getEnvSecret } from "@jaypie/aws";
 import { ConfigurationError } from "@jaypie/errors";
 import { JAYPIE, placeholders as replacePlaceholders } from "@jaypie/kit";
-import { log as defaultLog } from "@jaypie/logger";
+import { createLogger, log as defaultLog } from "@jaypie/logger";
 import { JsonObject, NaturalSchema } from "@jaypie/types";
 import { OpenAI } from "openai";
 import { zodResponseFormat } from "openai/helpers/zod";
@@ -10,7 +10,8 @@ import { LlmMessageOptions } from "../../types/LlmProvider.interface.js";
 import { naturalZodSchema } from "../../util";
 
 // Logger
-export const getLogger = () => defaultLog.lib({ lib: JAYPIE.LIB.LLM });
+export const getLogger = (): ReturnType<typeof createLogger> =>
+  defaultLog.lib({ lib: JAYPIE.LIB.LLM });
 
 // Client initialization
 export async function initializeClient({

--- a/packages/llm/src/providers/openrouter/utils.ts
+++ b/packages/llm/src/providers/openrouter/utils.ts
@@ -1,7 +1,7 @@
 import { getEnvSecret } from "@jaypie/aws";
 import { ConfigurationError } from "@jaypie/errors";
 import { JAYPIE, placeholders as replacePlaceholders } from "@jaypie/kit";
-import { log as defaultLog } from "@jaypie/logger";
+import { createLogger, log as defaultLog } from "@jaypie/logger";
 import type { OpenRouter } from "@openrouter/sdk";
 import { LlmMessageOptions } from "../../types/LlmProvider.interface.js";
 import { PROVIDER } from "../../constants.js";
@@ -22,7 +22,8 @@ export async function loadSdk(): Promise<typeof import("@openrouter/sdk")> {
 }
 
 // Logger
-export const getLogger = () => defaultLog.lib({ lib: JAYPIE.LIB.LLM });
+export const getLogger = (): ReturnType<typeof createLogger> =>
+  defaultLog.lib({ lib: JAYPIE.LIB.LLM });
 
 // Client initialization
 export async function initializeClient({

--- a/packages/llm/src/providers/xai/utils.ts
+++ b/packages/llm/src/providers/xai/utils.ts
@@ -1,13 +1,14 @@
 import { getEnvSecret } from "@jaypie/aws";
 import { ConfigurationError } from "@jaypie/errors";
 import { JAYPIE } from "@jaypie/kit";
-import { log as defaultLog } from "@jaypie/logger";
+import { createLogger, log as defaultLog } from "@jaypie/logger";
 import { OpenAI } from "openai";
 
 import { PROVIDER } from "../../constants.js";
 
 // Logger
-export const getLogger = () => defaultLog.lib({ lib: JAYPIE.LIB.LLM });
+export const getLogger = (): ReturnType<typeof createLogger> =>
+  defaultLog.lib({ lib: JAYPIE.LIB.LLM });
 
 // Client initialization
 export async function initializeClient({

--- a/packages/llm/src/util/logger.ts
+++ b/packages/llm/src/util/logger.ts
@@ -1,4 +1,5 @@
 import { JAYPIE } from "@jaypie/kit";
-import { log as defaultLog } from "@jaypie/logger";
+import { createLogger, log as defaultLog } from "@jaypie/logger";
 
-export const getLogger = () => defaultLog.lib({ lib: JAYPIE.LIB.LLM });
+export const getLogger = (): ReturnType<typeof createLogger> =>
+  defaultLog.lib({ lib: JAYPIE.LIB.LLM });

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/logger",
-  "version": "1.2.17",
+  "version": "1.2.18",
   "description": "Logger utilities for Jaypie applications",
   "repository": {
     "type": "git",
@@ -12,9 +12,14 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/esm/index.d.ts",
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.cjs"
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.cts",
+        "default": "./dist/cjs/index.cjs"
+      }
     }
   },
   "main": "./dist/cjs/index.cjs",
@@ -39,6 +44,7 @@
     "eslint-config-prettier": "^10.0.1",
     "eslint-plugin-prettier": "^5.2.1",
     "rollup": "^4.12.0",
+    "rollup-plugin-dts": "^6.1.1",
     "typescript": "^5.3.3",
     "typescript-eslint": "^8.18.2",
     "vitest": "^4.1.8"

--- a/packages/logger/rollup.config.js
+++ b/packages/logger/rollup.config.js
@@ -1,4 +1,10 @@
 import typescript from "@rollup/plugin-typescript";
+import { dts } from "rollup-plugin-dts";
+
+// Bundle declarations: keep every bare specifier external so dts() inlines only
+// our own relative files, producing a single self-contained declaration that
+// resolves under node16/nodenext module resolution.
+const dtsExternal = (id) => !/^[./]/.test(id);
 
 export default [
   // ES modules version
@@ -36,5 +42,20 @@ export default [
       }),
     ],
     external: ["node:crypto", "node:https", "node:os"],
+  },
+  // Type definitions (ESM): bundled to a single self-contained declaration file.
+  {
+    input: "src/index.ts",
+    output: { file: "dist/esm/index.d.ts", format: "es" },
+    plugins: [dts()],
+    external: dtsExternal,
+  },
+  // Type definitions (CommonJS): emitted as .d.cts so node16/nodenext flags it
+  // as a CommonJS declaration under the package's "type": "module" setting.
+  {
+    input: "src/index.ts",
+    output: { file: "dist/cjs/index.d.cts", format: "es" },
+    plugins: [dts()],
+    external: dtsExternal,
   },
 ];

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.79",
+  "version": "0.8.80",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",
@@ -11,12 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     },
     "./suite": {
-      "types": "./dist/suite.d.ts",
-      "import": "./dist/suite.js"
+      "import": {
+        "types": "./dist/suite.d.ts",
+        "default": "./dist/suite.js"
+      }
     }
   },
   "main": "dist/index.js",
@@ -39,8 +43,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@jaypie/fabric": "^0.2.4",
-    "@jaypie/tildeskill": "^0.3.1",
+    "@jaypie/fabric": "^0.3.3",
+    "@jaypie/tildeskill": "^0.3.2",
     "@modelcontextprotocol/sdk": "^1.17.0",
     "commander": "^14.0.0",
     "gray-matter": "^4.0.3",
@@ -55,6 +59,7 @@
     "express": "^5.1.0",
     "rollup": "^4.53.3",
     "rollup-plugin-copy": "^3.5.0",
+    "rollup-plugin-dts": "^6.1.1",
     "typescript": "^5.9.3"
   },
   "publishConfig": {

--- a/packages/mcp/release-notes/aws/1.2.10.md
+++ b/packages/mcp/release-notes/aws/1.2.10.md
@@ -1,0 +1,17 @@
+---
+version: 1.2.10
+date: 2026-06-21
+summary: Bundle declarations so types resolve under node16/nodenext
+---
+
+## Fixes
+
+- Bundle the public TypeScript declarations into a single self-contained
+  `index.d.ts` (and `index.d.cts` for the CommonJS entry) instead of a per-file
+  `.d.ts` tree with extensionless relative re-exports.
+- Under `node16`/`nodenext` module resolution the old extensionless re-exports
+  did not resolve in ESM mode, so named re-exports degraded to `any` and
+  `export *` members vanished (`TS2305`). The flat declaration resolves
+  correctly under `bundler`, `node16`, and `nodenext`.
+
+No runtime behavior changes.

--- a/packages/mcp/release-notes/core/1.2.3.md
+++ b/packages/mcp/release-notes/core/1.2.3.md
@@ -1,0 +1,17 @@
+---
+version: 1.2.3
+date: 2026-06-21
+summary: Bundle declarations so types resolve under node16/nodenext
+---
+
+## Fixes
+
+- Bundle the public TypeScript declarations into a single self-contained
+  `index.d.ts` (and `index.d.cts` for the CommonJS entry) instead of a per-file
+  `.d.ts` tree with extensionless relative re-exports.
+- Under `node16`/`nodenext` module resolution the old extensionless re-exports
+  did not resolve in ESM mode, so named re-exports degraded to `any` and
+  `export *` members vanished (`TS2305`). The flat declaration resolves
+  correctly under `bundler`, `node16`, and `nodenext`.
+
+No runtime behavior changes.

--- a/packages/mcp/release-notes/datadog/1.2.5.md
+++ b/packages/mcp/release-notes/datadog/1.2.5.md
@@ -1,0 +1,17 @@
+---
+version: 1.2.5
+date: 2026-06-21
+summary: Bundle declarations so types resolve under node16/nodenext
+---
+
+## Fixes
+
+- Bundle the public TypeScript declarations into a single self-contained
+  `index.d.ts` (and `index.d.cts` for the CommonJS entry) instead of a per-file
+  `.d.ts` tree with extensionless relative re-exports.
+- Under `node16`/`nodenext` module resolution the old extensionless re-exports
+  did not resolve in ESM mode, so named re-exports degraded to `any` and
+  `export *` members vanished (`TS2305`). The flat declaration resolves
+  correctly under `bundler`, `node16`, and `nodenext`.
+
+No runtime behavior changes.

--- a/packages/mcp/release-notes/dynamodb/0.6.4.md
+++ b/packages/mcp/release-notes/dynamodb/0.6.4.md
@@ -1,0 +1,18 @@
+---
+version: 0.6.4
+date: 2026-06-21
+summary: Bundle declarations so types resolve under node16/nodenext
+---
+
+## Fixes
+
+- Bundle the public TypeScript declarations into a single self-contained
+  `index.d.ts` (and `index.d.cts` for the CommonJS entry) instead of a per-file
+  `.d.ts` tree with extensionless relative re-exports.
+- Under `node16`/`nodenext` module resolution the old extensionless re-exports
+  did not resolve in ESM mode, so named re-exports degraded to `any` and
+  `export *` members vanished (`TS2305`). The flat declaration resolves
+  correctly under `bundler`, `node16`, and `nodenext`.
+- Applies to both the `.` and `./mcp` subpath exports.
+
+No runtime behavior changes.

--- a/packages/mcp/release-notes/errors/1.2.3.md
+++ b/packages/mcp/release-notes/errors/1.2.3.md
@@ -1,0 +1,17 @@
+---
+version: 1.2.3
+date: 2026-06-21
+summary: Bundle declarations so types resolve under node16/nodenext
+---
+
+## Fixes
+
+- Bundle the public TypeScript declarations into a single self-contained
+  `index.d.ts` (and `index.d.cts` for the CommonJS entry) instead of a per-file
+  `.d.ts` tree with extensionless relative re-exports.
+- Under `node16`/`nodenext` module resolution the old extensionless re-exports
+  did not resolve in ESM mode, so named re-exports degraded to `any` and
+  `export *` members vanished (`TS2305`). The flat declaration resolves
+  correctly under `bundler`, `node16`, and `nodenext`.
+
+No runtime behavior changes.

--- a/packages/mcp/release-notes/express/1.2.26.md
+++ b/packages/mcp/release-notes/express/1.2.26.md
@@ -1,0 +1,17 @@
+---
+version: 1.2.26
+date: 2026-06-21
+summary: Bundle declarations so types resolve under node16/nodenext
+---
+
+## Fixes
+
+- Bundle the public TypeScript declarations into a single self-contained
+  `index.d.ts` (and `index.d.cts` for the CommonJS entry) instead of a per-file
+  `.d.ts` tree with extensionless relative re-exports.
+- Under `node16`/`nodenext` module resolution the old extensionless re-exports
+  did not resolve in ESM mode, so named re-exports degraded to `any` and
+  `export *` members vanished (`TS2305`). The flat declaration resolves
+  correctly under `bundler`, `node16`, and `nodenext`.
+
+No runtime behavior changes.

--- a/packages/mcp/release-notes/fabric/0.3.3.md
+++ b/packages/mcp/release-notes/fabric/0.3.3.md
@@ -1,0 +1,18 @@
+---
+version: 0.3.3
+date: 2026-06-21
+summary: Bundle declarations so types resolve under node16/nodenext
+---
+
+## Fixes
+
+- Bundle the public TypeScript declarations into a single self-contained
+  `index.d.ts` (and `index.d.cts` for the CommonJS entry) instead of a per-file
+  `.d.ts` tree with extensionless relative re-exports.
+- Under `node16`/`nodenext` module resolution the old extensionless re-exports
+  did not resolve in ESM mode, so named re-exports degraded to `any` and
+  `export *` members vanished (`TS2305`). The flat declaration resolves
+  correctly under `bundler`, `node16`, and `nodenext`.
+- Applies to every subpath export (`.`, `./commander`, `./data`, `./express`, `./http`, `./lambda`, `./llm`, `./mcp`, `./websocket`).
+
+No runtime behavior changes.

--- a/packages/mcp/release-notes/jaypie/1.2.55.md
+++ b/packages/mcp/release-notes/jaypie/1.2.55.md
@@ -1,0 +1,18 @@
+---
+version: 1.2.55
+date: 2026-06-21
+summary: Bundle declarations so types resolve under node16/nodenext
+---
+
+## Fixes
+
+- Bundle the public TypeScript declarations into a single self-contained
+  `index.d.ts` (and `index.d.cts` for the CommonJS entry) instead of a per-file
+  `.d.ts` tree with extensionless relative re-exports.
+- Under `node16`/`nodenext` module resolution the old extensionless re-exports
+  did not resolve in ESM mode, so named re-exports degraded to `any` and
+  `export *` members vanished (`TS2305`). The flat declaration resolves
+  correctly under `bundler`, `node16`, and `nodenext`.
+- The umbrella package now ships a single self-contained `index.d.ts`/`index.d.cts`; re-exports of `@jaypie/*` subpackages remain external and resolvable.
+
+No runtime behavior changes.

--- a/packages/mcp/release-notes/kit/1.2.10.md
+++ b/packages/mcp/release-notes/kit/1.2.10.md
@@ -1,0 +1,17 @@
+---
+version: 1.2.10
+date: 2026-06-21
+summary: Bundle declarations so types resolve under node16/nodenext
+---
+
+## Fixes
+
+- Bundle the public TypeScript declarations into a single self-contained
+  `index.d.ts` (and `index.d.cts` for the CommonJS entry) instead of a per-file
+  `.d.ts` tree with extensionless relative re-exports.
+- Under `node16`/`nodenext` module resolution the old extensionless re-exports
+  did not resolve in ESM mode, so named re-exports degraded to `any` and
+  `export *` members vanished (`TS2305`). The flat declaration resolves
+  correctly under `bundler`, `node16`, and `nodenext`.
+
+No runtime behavior changes.

--- a/packages/mcp/release-notes/lambda/1.2.11.md
+++ b/packages/mcp/release-notes/lambda/1.2.11.md
@@ -1,0 +1,17 @@
+---
+version: 1.2.11
+date: 2026-06-21
+summary: Bundle declarations so types resolve under node16/nodenext
+---
+
+## Fixes
+
+- Bundle the public TypeScript declarations into a single self-contained
+  `index.d.ts` (and `index.d.cts` for the CommonJS entry) instead of a per-file
+  `.d.ts` tree with extensionless relative re-exports.
+- Under `node16`/`nodenext` module resolution the old extensionless re-exports
+  did not resolve in ESM mode, so named re-exports degraded to `any` and
+  `export *` members vanished (`TS2305`). The flat declaration resolves
+  correctly under `bundler`, `node16`, and `nodenext`.
+
+No runtime behavior changes.

--- a/packages/mcp/release-notes/llm/1.3.2.md
+++ b/packages/mcp/release-notes/llm/1.3.2.md
@@ -1,0 +1,18 @@
+---
+version: 1.3.2
+date: 2026-06-21
+summary: Bundle declarations so types resolve under node16/nodenext
+---
+
+## Fixes
+
+- Bundle the public TypeScript declarations into a single self-contained
+  `index.d.ts` (and `index.d.cts` for the CommonJS entry) instead of a per-file
+  `.d.ts` tree with extensionless relative re-exports.
+- Under `node16`/`nodenext` module resolution the old extensionless re-exports
+  did not resolve in ESM mode, so named re-exports degraded to `any` and
+  `export *` members vanished (`TS2305`). The flat declaration resolves
+  correctly under `bundler`, `node16`, and `nodenext`.
+- Added explicit return-type annotations to the internal `getLogger` helpers so the bundled declaration references `@jaypie/logger` instead of inlining a private class (`TS4094`).
+
+No runtime behavior changes.

--- a/packages/mcp/release-notes/logger/1.2.18.md
+++ b/packages/mcp/release-notes/logger/1.2.18.md
@@ -1,0 +1,17 @@
+---
+version: 1.2.18
+date: 2026-06-21
+summary: Bundle declarations so types resolve under node16/nodenext
+---
+
+## Fixes
+
+- Bundle the public TypeScript declarations into a single self-contained
+  `index.d.ts` (and `index.d.cts` for the CommonJS entry) instead of a per-file
+  `.d.ts` tree with extensionless relative re-exports.
+- Under `node16`/`nodenext` module resolution the old extensionless re-exports
+  did not resolve in ESM mode, so named re-exports degraded to `any` and
+  `export *` members vanished (`TS2305`). The flat declaration resolves
+  correctly under `bundler`, `node16`, and `nodenext`.
+
+No runtime behavior changes.

--- a/packages/mcp/release-notes/mcp/0.8.80.md
+++ b/packages/mcp/release-notes/mcp/0.8.80.md
@@ -1,0 +1,19 @@
+---
+version: 0.8.80
+date: 2026-06-21
+summary: Bundle declarations so types resolve under node16/nodenext
+---
+
+## Fixes
+
+- Bundle the public TypeScript declarations into a single self-contained
+  `index.d.ts` (and `index.d.cts` for the CommonJS entry) instead of a per-file
+  `.d.ts` tree with extensionless relative re-exports.
+- Under `node16`/`nodenext` module resolution the old extensionless re-exports
+  did not resolve in ESM mode, so named re-exports degraded to `any` and
+  `export *` members vanished (`TS2305`). The flat declaration resolves
+  correctly under `bundler`, `node16`, and `nodenext`.
+- Applies to both the `.` and `./suite` exports (ESM-only).
+- Corrected the `@jaypie/fabric` dependency range (`^0.2.4` → `^0.3.3`); the old range could not resolve the current fabric 0.3.x line.
+
+No runtime behavior changes.

--- a/packages/mcp/release-notes/mongoose/1.2.3.md
+++ b/packages/mcp/release-notes/mongoose/1.2.3.md
@@ -1,0 +1,17 @@
+---
+version: 1.2.3
+date: 2026-06-21
+summary: Bundle declarations so types resolve under node16/nodenext
+---
+
+## Fixes
+
+- Bundle the public TypeScript declarations into a single self-contained
+  `index.d.ts` (and `index.d.cts` for the CommonJS entry) instead of a per-file
+  `.d.ts` tree with extensionless relative re-exports.
+- Under `node16`/`nodenext` module resolution the old extensionless re-exports
+  did not resolve in ESM mode, so named re-exports degraded to `any` and
+  `export *` members vanished (`TS2305`). The flat declaration resolves
+  correctly under `bundler`, `node16`, and `nodenext`.
+
+No runtime behavior changes.

--- a/packages/mcp/release-notes/tildeskill/0.3.2.md
+++ b/packages/mcp/release-notes/tildeskill/0.3.2.md
@@ -1,0 +1,17 @@
+---
+version: 0.3.2
+date: 2026-06-21
+summary: Bundle declarations so types resolve under node16/nodenext
+---
+
+## Fixes
+
+- Bundle the public TypeScript declarations into a single self-contained
+  `index.d.ts` (and `index.d.cts` for the CommonJS entry) instead of a per-file
+  `.d.ts` tree with extensionless relative re-exports.
+- Under `node16`/`nodenext` module resolution the old extensionless re-exports
+  did not resolve in ESM mode, so named re-exports degraded to `any` and
+  `export *` members vanished (`TS2305`). The flat declaration resolves
+  correctly under `bundler`, `node16`, and `nodenext`.
+
+No runtime behavior changes.

--- a/packages/mcp/rollup.config.js
+++ b/packages/mcp/rollup.config.js
@@ -2,6 +2,12 @@ import { readFileSync } from "node:fs";
 import copy from "rollup-plugin-copy";
 import replace from "@rollup/plugin-replace";
 import typescript from "@rollup/plugin-typescript";
+import { dts } from "rollup-plugin-dts";
+
+// Bundle declarations: keep every bare specifier external so dts() inlines only
+// our own relative files, producing a single self-contained declaration per
+// entry point that resolves under node16/nodenext module resolution.
+const dtsExternal = (id) => !/^[./]/.test(id);
 
 const pkg = JSON.parse(readFileSync("./package.json", "utf-8"));
 const version = pkg.version;
@@ -16,62 +22,77 @@ const onwarn = (warning, defaultHandler) => {
   defaultHandler(warning);
 };
 
-export default {
-  input: [
-    "src/index.ts",
-    "src/suite.ts",
-    "src/suites/datadog/index.ts",
-    "src/suites/docs/index.ts",
-  ],
-  onwarn,
-  output: {
-    dir: "dist",
-    format: "es",
-    preserveModules: true,
-    preserveModulesRoot: "src",
-    sourcemap: true,
-  },
-  plugins: [
-    replace({
-      preventAssignment: true,
-      values: {
-        __BUILD_VERSION__: JSON.stringify(version),
-        __BUILD_COMMIT__: JSON.stringify(commitHash),
-        __BUILD_VERSION_STRING__: JSON.stringify(versionString),
-      },
-    }),
-    typescript({
-      exclude: ["**/__tests__/**/*", "**/*.test.ts"],
-    }),
-    copy({
-      targets: [
-        { src: "src/suites/datadog/help.md", dest: "dist/suites/datadog" },
-        {
-          src: "src/suites/docs/release-notes/help.md",
-          dest: "dist/suites/docs/release-notes",
+export default [
+  {
+    input: [
+      "src/index.ts",
+      "src/suite.ts",
+      "src/suites/datadog/index.ts",
+      "src/suites/docs/index.ts",
+    ],
+    onwarn,
+    output: {
+      dir: "dist",
+      format: "es",
+      preserveModules: true,
+      preserveModulesRoot: "src",
+      sourcemap: true,
+    },
+    plugins: [
+      replace({
+        preventAssignment: true,
+        values: {
+          __BUILD_VERSION__: JSON.stringify(version),
+          __BUILD_COMMIT__: JSON.stringify(commitHash),
+          __BUILD_VERSION_STRING__: JSON.stringify(versionString),
         },
-      ],
-    }),
-  ],
-  external: [
-    "@jaypie/errors",
-    "@jaypie/fabric",
-    "@jaypie/fabric/mcp",
-    "@jaypie/tildeskill",
-    "@modelcontextprotocol/sdk/server/mcp.js",
-    "@modelcontextprotocol/sdk/server/stdio.js",
-    "@modelcontextprotocol/sdk/server/streamableHttp.js",
-    "commander",
-    "gray-matter",
-    "node:child_process",
-    "node:crypto",
-    "node:fs",
-    "node:fs/promises",
-    "node:https",
-    "node:os",
-    "node:path",
-    "node:url",
-    "semver",
-    "zod",
-  ],
-};
+      }),
+      typescript({
+        exclude: ["**/__tests__/**/*", "**/*.test.ts"],
+      }),
+      copy({
+        targets: [
+          { src: "src/suites/datadog/help.md", dest: "dist/suites/datadog" },
+          {
+            src: "src/suites/docs/release-notes/help.md",
+            dest: "dist/suites/docs/release-notes",
+          },
+        ],
+      }),
+    ],
+    external: [
+      "@jaypie/errors",
+      "@jaypie/fabric",
+      "@jaypie/fabric/mcp",
+      "@jaypie/tildeskill",
+      "@modelcontextprotocol/sdk/server/mcp.js",
+      "@modelcontextprotocol/sdk/server/stdio.js",
+      "@modelcontextprotocol/sdk/server/streamableHttp.js",
+      "commander",
+      "gray-matter",
+      "node:child_process",
+      "node:crypto",
+      "node:fs",
+      "node:fs/promises",
+      "node:https",
+      "node:os",
+      "node:path",
+      "node:url",
+      "semver",
+      "zod",
+    ],
+  },
+  // Type definitions (ESM-only package): one self-contained bundle per entry.
+  {
+    input: "src/index.ts",
+    output: { file: "dist/index.d.ts", format: "es" },
+    plugins: [dts()],
+    external: dtsExternal,
+  },
+  {
+    input: "src/suite.ts",
+    output: { file: "dist/suite.d.ts", format: "es" },
+    plugins: [dts()],
+    external: dtsExternal,
+  },
+];

--- a/packages/mongoose/package.json
+++ b/packages/mongoose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mongoose",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"
@@ -11,10 +11,14 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/esm/index.d.ts",
-      "require": "./dist/cjs/index.cjs",
-      "import": "./dist/esm/index.js",
-      "default": "./dist/esm/index.js"
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.cts",
+        "default": "./dist/cjs/index.cjs"
+      }
     }
   },
   "main": "./dist/cjs/index.cjs",
@@ -39,6 +43,7 @@
     "@rollup/plugin-typescript": "^12.1.2",
     "@types/node": "^22.13.1",
     "mongoose": "^8.3.0",
+    "rollup-plugin-dts": "^6.1.1",
     "typescript": "^5.3.3"
   },
   "peerDependencies": {

--- a/packages/mongoose/rollup.config.mjs
+++ b/packages/mongoose/rollup.config.mjs
@@ -1,4 +1,5 @@
 import typescript from "@rollup/plugin-typescript";
+import { dts } from "rollup-plugin-dts";
 import autoExternal from "rollup-plugin-auto-external";
 
 // Filter out TS2307 warnings for @jaypie/* packages (external workspace dependencies)
@@ -8,6 +9,11 @@ const onwarn = (warning, defaultHandler) => {
   }
   defaultHandler(warning);
 };
+
+// Bundle declarations: keep every bare specifier external so dts() inlines only
+// our own relative files, producing a single self-contained declaration that
+// resolves under node16/nodenext module resolution.
+const dtsExternal = (id) => !/^[./]/.test(id);
 
 export default [
   // ES modules version
@@ -47,5 +53,20 @@ export default [
         outDir: "dist/cjs",
       }),
     ],
+  },
+  // Type definitions (ESM): bundled to a single self-contained declaration file.
+  {
+    input: "src/index.ts",
+    output: { file: "dist/esm/index.d.ts", format: "es" },
+    plugins: [dts()],
+    external: dtsExternal,
+  },
+  // Type definitions (CommonJS): emitted as .d.cts so node16/nodenext flags it
+  // as a CommonJS declaration under the package's "type": "module" setting.
+  {
+    input: "src/index.ts",
+    output: { file: "dist/cjs/index.d.cts", format: "es" },
+    plugins: [dts()],
+    external: dtsExternal,
   },
 ];

--- a/packages/tildeskill/package.json
+++ b/packages/tildeskill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/tildeskill",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Skill/vocabulary management with pluggable storage backends",
   "repository": {
     "type": "git",
@@ -12,9 +12,14 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/esm/index.d.ts",
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.cjs"
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.cts",
+        "default": "./dist/cjs/index.cjs"
+      }
     }
   },
   "main": "./dist/cjs/index.cjs",
@@ -40,6 +45,7 @@
     "@rollup/plugin-typescript": "^12.1.2",
     "@types/node": "^22.13.1",
     "rollup": "^4.12.0",
+    "rollup-plugin-dts": "^6.1.1",
     "typescript": "^5.3.3",
     "vitest": "^4.1.8"
   },

--- a/packages/tildeskill/rollup.config.js
+++ b/packages/tildeskill/rollup.config.js
@@ -1,4 +1,10 @@
 import typescript from "@rollup/plugin-typescript";
+import { dts } from "rollup-plugin-dts";
+
+// Bundle declarations: keep every bare specifier external so dts() inlines only
+// our own relative files, producing a single self-contained declaration that
+// resolves under node16/nodenext module resolution.
+const dtsExternal = (id) => !/^[./]/.test(id);
 
 // Filter out TS2307 warnings for @jaypie/* packages (external workspace dependencies)
 const onwarn = (warning, defaultHandler) => {
@@ -56,5 +62,20 @@ export default [
       "node:fs/promises",
       "node:path",
     ],
+  },
+  // Type definitions (ESM): bundled to a single self-contained declaration file.
+  {
+    input: "src/index.ts",
+    output: { file: "dist/esm/index.d.ts", format: "es" },
+    plugins: [dts()],
+    external: dtsExternal,
+  },
+  // Type definitions (CommonJS): emitted as .d.cts so node16/nodenext flags it
+  // as a CommonJS declaration under the package's "type": "module" setting.
+  {
+    input: "src/index.ts",
+    output: { file: "dist/cjs/index.d.cts", format: "es" },
+    plugins: [dts()],
+    external: dtsExternal,
   },
 ];


### PR DESCRIPTION
Follow-up to #391 (constructs). Every Jaypie package shipped a per-file `.d.ts` tree with **extensionless relative re-exports**, which ESM-mode (`node16`/`nodenext`) module resolution cannot follow:
- `export { Name } from "./File"` → name appears but **degrades to `any`**
- `export * from "./dir"` → unresolved path yields **zero names** → `TS2305`

So the type surface of these packages was silently broken under modern module resolution. This bundles each public entry into a single self-contained `index.d.ts` / `index.d.cts` via `rollup-plugin-dts` (matching `constructs`/`testkit`/`types`), with per-condition `types` in `exports`.

## Packages fixed (15)
`aws`, `core`, `datadog`, `dynamodb` (+`./mcp`), `errors`, `express`, `fabric` (all 9 subpaths), `jaypie`, `kit`, `lambda`, `llm`, `logger`, `mongoose`, `tildeskill`, `mcp` (+`./suite`).

Skipped (already nodenext-safe): `textract` (uses `.js` import extensions), `magpie`/`repokit`/`fabricator` (self-contained indexes), `constructs`/`testkit`/`types` (already bundled).

## Notable
- `llm`: added explicit `getLogger` return annotations so dts references `@jaypie/logger` instead of inlining a private class (`TS4094`).
- `mcp`: corrected `@jaypie/fabric` range `^0.2.4 → ^0.3.3` (old range could not resolve fabric's 0.3.x line).
- All 15 packages patch-bumped; `jaypie` dependency ranges updated; 15 release notes added.

## Verification
- Reproduced the bug + fix under a real nodenext consumer (real types, no `TS2305`).
- All published declaration files: **0 relative re-exports**; `.d.cts` present for every CJS entry.
- Full monorepo build ✅ · **3517 tests** ✅ · typecheck clean ✅ · lint 0 errors.

No runtime behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)