### PR TITLE
feat(llm): fetch-based provider clients; remove provider SDKs (Bedrock excepted)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -266,11 +266,14 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.71.2",
+      "version": "0.105.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.105.0.tgz",
+      "integrity": "sha512-sDyu+aM9cE6uZE+HgRjjHRb+qqb87GHZOx+8bE0YlWetdL1YcVLxn8h9ltxGOflyChTe6PMEo50kMQV4cw0hfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
       },
       "bin": {
         "anthropic-ai-sdk": "bin/cli"
@@ -5886,9 +5889,9 @@
       }
     },
     "node_modules/@google/genai": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
-      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.10.0.tgz",
+      "integrity": "sha512-e4cFxj3tiuMtsgOT4G9c1hXyGJhg7/Buj7VVeBacRY3fRtkRZZ59Q3nuVp2xbq8BGQXLXCDB253qMhklMOeUDg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -7635,8 +7638,11 @@
       }
     },
     "node_modules/@openrouter/sdk": {
-      "version": "0.1.27",
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/@openrouter/sdk/-/sdk-0.13.7.tgz",
+      "integrity": "sha512-/QGoYdbFC2lqnVoCwtBX1+3Z5v6SF5hS1/dQisY0so3DzNAIQLHShA0OQVeAg20X0RG3CSKSCK0Ijnkt2rHDXA==",
       "dev": true,
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.25.0 || ^4.0.0"
@@ -9006,6 +9012,13 @@
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -15439,6 +15452,13 @@
       "version": "2.1.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "dev": true,
+      "license": "Unlicense"
     },
     "node_modules/fast-uri": {
       "version": "3.1.2",
@@ -26275,6 +26295,17 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "license": "MIT",
@@ -29527,11 +29558,11 @@
         "zod": "^4.1.13"
       },
       "devDependencies": {
-        "@anthropic-ai/sdk": "^0.71.0",
+        "@anthropic-ai/sdk": "^0.105.0",
         "@aws-sdk/client-bedrock-runtime": "^3.1045.0",
-        "@google/genai": "^1.30.0",
+        "@google/genai": "^2.10.0",
         "@jaypie/types": "*",
-        "@openrouter/sdk": "^0.1.27",
+        "@openrouter/sdk": "^0.13.7",
         "rollup-plugin-dts": "^6.1.1"
       },
       "peerDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7637,17 +7637,6 @@
         "node": ">=12.0"
       }
     },
-    "node_modules/@openrouter/sdk": {
-      "version": "0.13.7",
-      "resolved": "https://registry.npmjs.org/@openrouter/sdk/-/sdk-0.13.7.tgz",
-      "integrity": "sha512-/QGoYdbFC2lqnVoCwtBX1+3Z5v6SF5hS1/dQisY0so3DzNAIQLHShA0OQVeAg20X0RG3CSKSCK0Ijnkt2rHDXA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      }
-    },
     "node_modules/@oxc-project/types": {
       "version": "0.133.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
@@ -29562,16 +29551,14 @@
         "@aws-sdk/client-bedrock-runtime": "^3.1045.0",
         "@google/genai": "^2.10.0",
         "@jaypie/types": "*",
-        "@openrouter/sdk": "^0.13.7",
         "rollup-plugin-dts": "^6.1.1"
       },
       "peerDependencies": {
-        "@anthropic-ai/sdk": "^0.71.0",
+        "@anthropic-ai/sdk": "^0.105.0",
         "@aws-sdk/client-bedrock-runtime": "^3.1045.0",
-        "@google/genai": "^1.30.0",
+        "@google/genai": "^2.10.0",
         "@jaypie/kit": "*",
-        "@jaypie/logger": "*",
-        "@openrouter/sdk": "^0.1.27"
+        "@jaypie/logger": "*"
       },
       "peerDependenciesMeta": {
         "@anthropic-ai/sdk": {
@@ -29581,9 +29568,6 @@
           "optional": true
         },
         "@google/genai": {
-          "optional": true
-        },
-        "@openrouter/sdk": {
           "optional": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -265,28 +265,6 @@
         "node": ">= 14.0.0"
       }
     },
-    "node_modules/@anthropic-ai/sdk": {
-      "version": "0.105.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.105.0.tgz",
-      "integrity": "sha512-sDyu+aM9cE6uZE+HgRjjHRb+qqb87GHZOx+8bE0YlWetdL1YcVLxn8h9ltxGOflyChTe6PMEo50kMQV4cw0hfg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1",
-        "standardwebhooks": "^1.0.0"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@auth0/nextjs-auth0": {
       "version": "4.22.0",
       "resolved": "https://registry.npmjs.org/@auth0/nextjs-auth0/-/nextjs-auth0-4.22.0.tgz",
@@ -8912,13 +8890,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@stablelib/base64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
-      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -15296,13 +15267,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-sha256": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
-      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
-      "dev": true,
-      "license": "Unlicense"
-    },
     "node_modules/fast-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
@@ -18289,18 +18253,6 @@
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "license": "MIT"
-    },
-    "node_modules/json-schema-to-ts": {
-      "version": "3.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "ts-algebra": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -25934,17 +25886,6 @@
       "devOptional": true,
       "license": "MIT"
     },
-    "node_modules/standardwebhooks": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
-      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@stablelib/base64": "^1.0.0",
-        "fast-sha256": "^1.3.0"
-      }
-    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "license": "MIT",
@@ -26590,11 +26531,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/ts-algebra": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
@@ -29189,21 +29125,16 @@
         "zod": "^4.1.13"
       },
       "devDependencies": {
-        "@anthropic-ai/sdk": "^0.105.0",
         "@aws-sdk/client-bedrock-runtime": "^3.1045.0",
         "@jaypie/types": "*",
         "rollup-plugin-dts": "^6.1.1"
       },
       "peerDependencies": {
-        "@anthropic-ai/sdk": "^0.105.0",
         "@aws-sdk/client-bedrock-runtime": "^3.1045.0",
         "@jaypie/kit": "*",
         "@jaypie/logger": "*"
       },
       "peerDependenciesMeta": {
-        "@anthropic-ai/sdk": {
-          "optional": true
-        },
         "@aws-sdk/client-bedrock-runtime": {
           "optional": true
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21625,24 +21625,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/openai": {
-      "version": "6.44.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.44.0.tgz",
-      "integrity": "sha512-09/gH+8jH0RgUwsgWHAaxsKGRT5zVZ95IaJUnqAWj6XejIBmnFRwq2WUIF37VtDEsmGrtPmvCs5+yBSeZGWvkA==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/opener": {
       "version": "1.5.2",
       "license": "(WTFPL OR MIT)",
@@ -29117,7 +29099,6 @@
       "dependencies": {
         "@jaypie/aws": "*",
         "@jaypie/errors": "*",
-        "openai": "^6.9.1",
         "openmeteo": "^1.2.1",
         "pdf-lib": "^1.17.1",
         "random": "^5.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5888,31 +5888,6 @@
         "npm": ">=9.0.0"
       }
     },
-    "node_modules/@google/genai": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.10.0.tgz",
-      "integrity": "sha512-e4cFxj3tiuMtsgOT4G9c1hXyGJhg7/Buj7VVeBacRY3fRtkRZZ59Q3nuVp2xbq8BGQXLXCDB253qMhklMOeUDg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "google-auth-library": "^10.3.0",
-        "p-retry": "^4.6.2",
-        "protobufjs": "^7.5.4",
-        "ws": "^8.18.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "@modelcontextprotocol/sdk": "^1.25.2"
-      },
-      "peerDependenciesMeta": {
-        "@modelcontextprotocol/sdk": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
       "license": "BSD-3-Clause"
@@ -7850,71 +7825,6 @@
     "node_modules/@polka/url": {
       "version": "1.0.0-next.29",
       "license": "MIT"
-    },
-    "node_modules/@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/base64": {
-      "version": "1.1.2",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/codegen": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
-      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
-      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/fetch": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
-      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1"
-      }
-    },
-    "node_modules/@protobufjs/float": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/path": {
-      "version": "1.1.2",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/pool": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/utf8": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
-      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.3",
@@ -10695,14 +10605,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/agent-base": {
-      "version": "7.1.4",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
       "license": "MIT",
@@ -11861,25 +11763,6 @@
       "version": "1.0.2",
       "license": "MIT"
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.35",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.35.tgz",
@@ -11900,14 +11783,6 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/bignumber.js": {
-      "version": "9.3.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -12160,11 +12035,6 @@
       "dependencies": {
         "node-int64": "^0.4.0"
       }
-    },
-    "node_modules/buffer-equal-constant-time": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -13481,14 +13351,6 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "dev": true,
@@ -14000,14 +13862,6 @@
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "license": "MIT"
-    },
-    "node_modules/ecdsa-sig-formatter": {
-      "version": "1.0.11",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -15530,28 +15384,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "license": "MIT",
@@ -15855,17 +15687,6 @@
         "node": ">=0.4.x"
       }
     },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      }
-    },
     "node_modules/formidable": {
       "version": "3.5.4",
       "dev": true,
@@ -15969,32 +15790,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/gaxios": {
-      "version": "7.1.4",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^7.0.1",
-        "node-fetch": "^3.3.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/gcp-metadata": {
-      "version": "8.1.2",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "gaxios": "^7.0.0",
-        "google-logging-utils": "^1.0.0",
-        "json-bigint": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/generator-function": {
@@ -16221,30 +16016,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/google-auth-library": {
-      "version": "10.6.2",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "ecdsa-sig-formatter": "^1.0.11",
-        "gaxios": "^7.1.4",
-        "gcp-metadata": "8.1.2",
-        "google-logging-utils": "1.1.3",
-        "jws": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/google-logging-utils": {
-      "version": "1.1.3",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/gopd": {
@@ -16898,18 +16669,6 @@
       },
       "engines": {
         "node": ">=10.19.0"
-      }
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/human-signals": {
@@ -18518,14 +18277,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/json-bigint": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bignumber.js": "^9.0.0"
-      }
-    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "license": "MIT"
@@ -18595,25 +18346,6 @@
       },
       "engines": {
         "node": ">=4.0"
-      }
-    },
-    "node_modules/jwa": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-equal-constant-time": "^1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/jws": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "jwa": "^2.0.1",
-        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/keyv": {
@@ -19100,11 +18832,6 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
       "license": "MIT"
-    },
-    "node_modules/long": {
-      "version": "5.3.2",
-      "dev": true,
-      "license": "Apache-2.0"
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -21603,24 +21330,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
     "node_modules/node-emoji": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.2.0.tgz",
@@ -21663,23 +21372,6 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.3.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-int64": {
@@ -22129,23 +21821,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/p-retry": {
-      "version": "4.6.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/retry": "0.12.0",
-        "retry": "^0.13.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/p-retry/node_modules/@types/retry": {
-      "version": "0.12.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/p-timeout": {
       "version": "3.2.0",
@@ -24132,31 +23807,6 @@
     "node_modules/proto-list": {
       "version": "1.2.4",
       "license": "ISC"
-    },
-    "node_modules/protobufjs": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.3.tgz",
-      "integrity": "sha512-+k0vdJKNdW+Vu+dYe8tZA/VvQb6XKNWexC6URwBFXxNnjLJz9nQJCemGyNgRAWD+B7+nGNc9qMPGwcD7s4nzUw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.1",
-        "@protobufjs/fetch": "^1.1.1",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.2",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.1",
-        "@types/node": ">=13.7.0",
-        "long": "^5.3.2"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -27986,14 +27636,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/webpack": {
       "version": "5.105.4",
       "license": "MIT",
@@ -29549,14 +29191,12 @@
       "devDependencies": {
         "@anthropic-ai/sdk": "^0.105.0",
         "@aws-sdk/client-bedrock-runtime": "^3.1045.0",
-        "@google/genai": "^2.10.0",
         "@jaypie/types": "*",
         "rollup-plugin-dts": "^6.1.1"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": "^0.105.0",
         "@aws-sdk/client-bedrock-runtime": "^3.1045.0",
-        "@google/genai": "^2.10.0",
         "@jaypie/kit": "*",
         "@jaypie/logger": "*"
       },
@@ -29565,9 +29205,6 @@
           "optional": true
         },
         "@aws-sdk/client-bedrock-runtime": {
-          "optional": true
-        },
-        "@google/genai": {
           "optional": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -29094,7 +29094,7 @@
     },
     "packages/llm": {
       "name": "@jaypie/llm",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "*",
@@ -29191,7 +29191,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.83",
+      "version": "0.8.84",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.3.3",

--- a/packages/llm/CLAUDE.md
+++ b/packages/llm/CLAUDE.md
@@ -271,14 +271,28 @@ for await (const chunk of Llm.stream("Tell me a story")) {
 }
 ```
 
-## Provider SDKs
+## Provider Clients
 
-Provider SDKs are peer dependencies (optional except for the provider you use):
+The first-class providers talk to their APIs over `fetch` — no provider SDK is
+installed. Each has a minimal client under `src/providers/<provider>/client.ts`
+that mirrors only the surface the adapters use (request, streaming via SSE, and
+HTTP errors shaped to drive `classifyError`):
 
-- `openai` - OpenAI and xAI (required dependency; xAI uses the OpenAI SDK with a custom base URL)
-- `@anthropic-ai/sdk` - Anthropic (peer)
-- `@google/genai` - Google (peer)
-- `@openrouter/sdk` - OpenRouter (peer)
+- OpenAI — `OpenAIClient` (Responses API for `operate`/`stream`, Chat
+  Completions for `send`)
+- xAI — reuses `OpenAIClient` with `PROVIDER.XAI.BASE_URL` (OpenAI-compatible)
+- Anthropic — `AnthropicClient` (Messages API)
+- Google — `GoogleClient` (Gemini REST)
+- OpenRouter — `OpenRouterClient` (OpenAI-compatible Chat Completions)
+
+Bedrock is the one provider that keeps an SDK: `@aws-sdk/client-bedrock-runtime`
+is an **optional peer dependency**, loaded lazily via dynamic `import()` only
+when the Bedrock provider runs (SigV4 auth + binary eventstream make a hand-
+rolled client impractical). Non-Bedrock consumers never need it installed.
+
+Each provider has env-gated live "hot" tests at
+`src/providers/<provider>/__tests__/client.hot.spec.ts` — they run automatically
+when the matching `*_API_KEY` is set and skip otherwise.
 
 ## Environment Variables
 

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -53,7 +53,6 @@
     "@aws-sdk/client-bedrock-runtime": "^3.1045.0",
     "@google/genai": "^2.10.0",
     "@jaypie/types": "*",
-    "@openrouter/sdk": "^0.13.7",
     "rollup-plugin-dts": "^6.1.1"
   },
   "peerDependencies": {
@@ -61,8 +60,7 @@
     "@aws-sdk/client-bedrock-runtime": "^3.1045.0",
     "@google/genai": "^2.10.0",
     "@jaypie/kit": "*",
-    "@jaypie/logger": "*",
-    "@openrouter/sdk": "^0.13.7"
+    "@jaypie/logger": "*"
   },
   "peerDependenciesMeta": {
     "@anthropic-ai/sdk": {
@@ -72,9 +70,6 @@
       "optional": true
     },
     "@google/genai": {
-      "optional": true
-    },
-    "@openrouter/sdk": {
       "optional": true
     }
   },

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -51,14 +51,12 @@
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.105.0",
     "@aws-sdk/client-bedrock-runtime": "^3.1045.0",
-    "@google/genai": "^2.10.0",
     "@jaypie/types": "*",
     "rollup-plugin-dts": "^6.1.1"
   },
   "peerDependencies": {
     "@anthropic-ai/sdk": "^0.105.0",
     "@aws-sdk/client-bedrock-runtime": "^3.1045.0",
-    "@google/genai": "^2.10.0",
     "@jaypie/kit": "*",
     "@jaypie/logger": "*"
   },
@@ -67,9 +65,6 @@
       "optional": true
     },
     "@aws-sdk/client-bedrock-runtime": {
-      "optional": true
-    },
-    "@google/genai": {
       "optional": true
     }
   },

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -41,7 +41,6 @@
   "dependencies": {
     "@jaypie/aws": "*",
     "@jaypie/errors": "*",
-    "openai": "^6.9.1",
     "openmeteo": "^1.2.1",
     "pdf-lib": "^1.17.1",
     "random": "^5.3.0",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/llm",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Large language model utilities",
   "repository": {
     "type": "git",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -49,21 +49,16 @@
     "zod": "^4.1.13"
   },
   "devDependencies": {
-    "@anthropic-ai/sdk": "^0.105.0",
     "@aws-sdk/client-bedrock-runtime": "^3.1045.0",
     "@jaypie/types": "*",
     "rollup-plugin-dts": "^6.1.1"
   },
   "peerDependencies": {
-    "@anthropic-ai/sdk": "^0.105.0",
     "@aws-sdk/client-bedrock-runtime": "^3.1045.0",
     "@jaypie/kit": "*",
     "@jaypie/logger": "*"
   },
   "peerDependenciesMeta": {
-    "@anthropic-ai/sdk": {
-      "optional": true
-    },
     "@aws-sdk/client-bedrock-runtime": {
       "optional": true
     }

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -49,20 +49,20 @@
     "zod": "^4.1.13"
   },
   "devDependencies": {
-    "@anthropic-ai/sdk": "^0.71.0",
+    "@anthropic-ai/sdk": "^0.105.0",
     "@aws-sdk/client-bedrock-runtime": "^3.1045.0",
-    "@google/genai": "^1.30.0",
+    "@google/genai": "^2.10.0",
     "@jaypie/types": "*",
-    "@openrouter/sdk": "^0.1.27",
+    "@openrouter/sdk": "^0.13.7",
     "rollup-plugin-dts": "^6.1.1"
   },
   "peerDependencies": {
-    "@anthropic-ai/sdk": "^0.71.0",
+    "@anthropic-ai/sdk": "^0.105.0",
     "@aws-sdk/client-bedrock-runtime": "^3.1045.0",
-    "@google/genai": "^1.30.0",
+    "@google/genai": "^2.10.0",
     "@jaypie/kit": "*",
     "@jaypie/logger": "*",
-    "@openrouter/sdk": "^0.1.27"
+    "@openrouter/sdk": "^0.13.7"
   },
   "peerDependenciesMeta": {
     "@anthropic-ai/sdk": {

--- a/packages/llm/src/operate/adapters/AnthropicAdapter.ts
+++ b/packages/llm/src/operate/adapters/AnthropicAdapter.ts
@@ -1,5 +1,4 @@
-import type { Anthropic } from "@anthropic-ai/sdk";
-import log from "@jaypie/logger";
+import { log } from "@jaypie/logger";
 import { JsonObject, NaturalSchema } from "@jaypie/types";
 import { z } from "zod/v4";
 
@@ -28,6 +27,8 @@ import {
   StandardToolResult,
 } from "../types.js";
 import { isTransientNetworkError } from "../retry/isTransientNetworkError.js";
+import { AnthropicClient } from "../../providers/anthropic/client.js";
+import { Anthropic } from "../../providers/anthropic/types.js";
 import { BaseProviderAdapter } from "./ProviderAdapter.interface.js";
 
 //
@@ -625,7 +626,7 @@ export class AnthropicAdapter extends BaseProviderAdapter {
     request: unknown,
     signal?: AbortSignal,
   ): Promise<Anthropic.Message> {
-    const anthropic = client as Anthropic;
+    const anthropic = client as AnthropicClient;
     const anthropicRequest = request as AnthropicRequestParams;
     const wantsStructuredOutput = Boolean(anthropicRequest.output_config);
     try {
@@ -710,7 +711,7 @@ export class AnthropicAdapter extends BaseProviderAdapter {
     request: unknown,
     signal?: AbortSignal,
   ): AsyncIterable<LlmStreamChunk> {
-    const anthropic = client as Anthropic;
+    const anthropic = client as AnthropicClient;
     // Preserve `output_config` when passing through to the SDK by typing
     // through the local extension instead of the upstream
     // MessageCreateParams shape.

--- a/packages/llm/src/operate/adapters/GoogleAdapter.ts
+++ b/packages/llm/src/operate/adapters/GoogleAdapter.ts
@@ -1,5 +1,4 @@
-import type { GoogleGenAI } from "@google/genai";
-import log from "@jaypie/logger";
+import { log } from "@jaypie/logger";
 import { JsonObject, NaturalSchema } from "@jaypie/types";
 import { z } from "zod/v4";
 
@@ -28,6 +27,7 @@ import {
   StandardToolResult,
 } from "../types.js";
 import { isTransientNetworkError } from "../retry/isTransientNetworkError.js";
+import { GoogleClient } from "../../providers/google/client.js";
 import { BaseProviderAdapter } from "./ProviderAdapter.interface.js";
 import {
   GeminiContent,
@@ -318,7 +318,7 @@ export class GoogleAdapter extends BaseProviderAdapter {
     request: unknown,
     signal?: AbortSignal,
   ): Promise<GeminiRawResponse> {
-    const genAI = client as GoogleGenAI;
+    const genAI = client as GoogleClient;
     const geminiRequest = request as GeminiRequest;
     const wantsNativeCombo =
       !!geminiRequest.config?.responseJsonSchema &&
@@ -407,7 +407,7 @@ export class GoogleAdapter extends BaseProviderAdapter {
   ): AsyncIterable<LlmStreamChunk> {
     // signal is accepted for interface conformance; Gemini SDK does not natively support it
     void signal;
-    const genAI = client as GoogleGenAI;
+    const genAI = client as GoogleClient;
     const geminiRequest = request as GeminiRequest;
 
     // Use generateContentStream for streaming

--- a/packages/llm/src/operate/adapters/OpenAiAdapter.ts
+++ b/packages/llm/src/operate/adapters/OpenAiAdapter.ts
@@ -1,4 +1,7 @@
 import { JsonObject, NaturalSchema } from "@jaypie/types";
+import { z } from "zod/v4";
+
+import { PROVIDER } from "../../constants.js";
 import {
   APIConnectionError,
   APIConnectionTimeoutError,
@@ -8,15 +11,12 @@ import {
   ConflictError,
   InternalServerError,
   NotFoundError,
-  OpenAI,
+  OpenAIClient,
   PermissionDeniedError,
   RateLimitError,
   UnprocessableEntityError,
-} from "openai";
-import { zodResponseFormat } from "openai/helpers/zod";
-import { z } from "zod/v4";
-
-import { PROVIDER } from "../../constants.js";
+} from "../../providers/openai/client.js";
+import { zodResponseFormat } from "../../providers/openai/responseFormat.js";
 
 // Patterns for OpenAI reasoning models that support extended thinking
 const REASONING_MODEL_PATTERNS = [
@@ -269,12 +269,11 @@ export class OpenAiAdapter extends BaseProviderAdapter {
     request: unknown,
     signal?: AbortSignal,
   ): Promise<unknown> {
-    const openai = client as OpenAI;
+    const openai = client as OpenAIClient;
     const openaiRequest = request as Record<string, unknown>;
-    type CreateParams = Parameters<typeof openai.responses.create>[0];
     try {
       return await openai.responses.create(
-        openaiRequest as CreateParams,
+        openaiRequest,
         signal ? { signal } : undefined,
       );
     } catch (error) {
@@ -289,7 +288,7 @@ export class OpenAiAdapter extends BaseProviderAdapter {
         const retryRequest = { ...openaiRequest };
         delete retryRequest.temperature;
         return await openai.responses.create(
-          retryRequest as CreateParams,
+          retryRequest,
           signal ? { signal } : undefined,
         );
       }
@@ -303,15 +302,15 @@ export class OpenAiAdapter extends BaseProviderAdapter {
     request: unknown,
     signal?: AbortSignal,
   ): AsyncIterable<LlmStreamChunk> {
-    const openai = client as OpenAI;
+    const openai = client as OpenAIClient;
     const baseRequest = request as Record<string, unknown>;
     const streamRequest = {
       ...baseRequest,
-      stream: true,
+      stream: true as const,
     };
 
     const stream = await openai.responses.create(
-      streamRequest as Parameters<typeof openai.responses.create>[0],
+      streamRequest,
       signal ? { signal } : undefined,
     );
 

--- a/packages/llm/src/operate/adapters/OpenRouterAdapter.ts
+++ b/packages/llm/src/operate/adapters/OpenRouterAdapter.ts
@@ -1,6 +1,5 @@
 import { log } from "@jaypie/logger";
 import { JsonObject, NaturalSchema } from "@jaypie/types";
-import type { OpenRouter } from "@openrouter/sdk";
 import { z } from "zod/v4";
 
 import { PROVIDER } from "../../constants.js";
@@ -29,6 +28,7 @@ import {
   StandardToolResult,
 } from "../types.js";
 import { isTransientNetworkError } from "../retry/isTransientNetworkError.js";
+import { OpenRouterClient } from "../../providers/openrouter/client.js";
 import { BaseProviderAdapter } from "./ProviderAdapter.interface.js";
 
 //
@@ -268,7 +268,55 @@ function convertContentToOpenRouter(
   return parts;
 }
 
-// OpenRouter SDK error types based on HTTP status codes
+/**
+ * Convert internal content parts to the OpenAI-compatible wire shape. The
+ * internal representation uses camelCase keys (`imageUrl`, `fileData`) that the
+ * SDK accepted; the REST API wants snake_case (`image_url`, `file_data`).
+ */
+function contentToWire(
+  content: string | OpenRouterContentPart[] | null | undefined,
+): unknown {
+  if (
+    content === null ||
+    content === undefined ||
+    typeof content === "string"
+  ) {
+    return content;
+  }
+  return content.map((part) => {
+    if (part.type === "image_url") {
+      return { type: "image_url", image_url: part.imageUrl };
+    }
+    if (part.type === "file") {
+      return {
+        type: "file",
+        file: { filename: part.file.filename, file_data: part.file.fileData },
+      };
+    }
+    return part;
+  });
+}
+
+/**
+ * Serialize an internal message to the OpenAI-compatible wire shape, mapping
+ * camelCase tool fields (`toolCalls`, `toolCallId`) to snake_case. Tool-call
+ * objects are already wire-shaped (`{ id, type, function: { name, arguments } }`).
+ */
+function messageToWire(message: OpenRouterMessage): Record<string, unknown> {
+  const wire: Record<string, unknown> = { role: message.role };
+  if (message.content !== undefined) {
+    wire.content = contentToWire(message.content);
+  }
+  if (message.toolCalls) {
+    wire.tool_calls = message.toolCalls;
+  }
+  if (message.toolCallId) {
+    wire.tool_call_id = message.toolCallId;
+  }
+  return wire;
+}
+
+// OpenRouter error types based on HTTP status codes
 const RETRYABLE_STATUS_CODES = [408, 500, 502, 503, 524, 529];
 const RATE_LIMIT_STATUS_CODE = 429;
 
@@ -517,17 +565,15 @@ export class OpenRouterAdapter extends BaseProviderAdapter {
     request: unknown,
     signal?: AbortSignal,
   ): Promise<OpenRouterResponse> {
-    const openRouter = client as OpenRouter;
+    const openRouter = client as OpenRouterClient;
     const openRouterRequest = request as OpenRouterRequest;
     const wantsStructuredOutput = Boolean(openRouterRequest.response_format);
 
     try {
-      const response = (await openRouter.chat.send(
-        this.toSdkChatParams(openRouterRequest) as Parameters<
-          typeof openRouter.chat.send
-        >[0],
+      const response = (await openRouter.chatCompletion(
+        this.toWireBody(openRouterRequest),
         signal ? { signal } : undefined,
-      )) as AnnotatedOpenRouterResponse;
+      )) as unknown as AnnotatedOpenRouterResponse;
       if (wantsStructuredOutput) {
         response.__jaypieStructuredOutput = true;
       }
@@ -548,12 +594,10 @@ export class OpenRouterAdapter extends BaseProviderAdapter {
         this.rememberModelRejectsTemperature(openRouterRequest.model);
         const retryRequest = { ...openRouterRequest } as OpenRouterRequest;
         delete (retryRequest as unknown as Record<string, unknown>).temperature;
-        const response = (await openRouter.chat.send(
-          this.toSdkChatParams(retryRequest) as Parameters<
-            typeof openRouter.chat.send
-          >[0],
+        const response = (await openRouter.chatCompletion(
+          this.toWireBody(retryRequest),
           signal ? { signal } : undefined,
-        )) as AnnotatedOpenRouterResponse;
+        )) as unknown as AnnotatedOpenRouterResponse;
         if (wantsStructuredOutput) {
           response.__jaypieStructuredOutput = true;
         }
@@ -570,12 +614,10 @@ export class OpenRouterAdapter extends BaseProviderAdapter {
         );
         const fallbackRequest =
           this.toFallbackStructuredOutputRequest(openRouterRequest);
-        return (await openRouter.chat.send(
-          this.toSdkChatParams(fallbackRequest) as Parameters<
-            typeof openRouter.chat.send
-          >[0],
+        return (await openRouter.chatCompletion(
+          this.toWireBody(fallbackRequest),
           signal ? { signal } : undefined,
-        )) as OpenRouterResponse;
+        )) as unknown as OpenRouterResponse;
       }
 
       throw error;
@@ -587,39 +629,20 @@ export class OpenRouterAdapter extends BaseProviderAdapter {
    * camelCase shape, forwarding only the fields we care about (the SDK
    * silently strips unknown fields).
    */
-  private toSdkChatParams(
+  /**
+   * Serialize the internal request into the OpenAI-compatible wire body for
+   * OpenRouter's Chat Completions endpoint. Top-level fields (model, tools,
+   * tool_choice, response_format, user, temperature, and any providerOptions)
+   * are already wire-shaped (snake_case); only messages carry camelCase tool
+   * fields that must become snake_case on the wire.
+   */
+  private toWireBody(
     openRouterRequest: OpenRouterRequest,
-    { stream }: { stream?: boolean } = {},
   ): Record<string, unknown> {
-    const chatRequest: Record<string, unknown> = {
-      model: openRouterRequest.model,
-      messages: openRouterRequest.messages,
-      tools: openRouterRequest.tools,
-      toolChoice: openRouterRequest.tool_choice,
-      user: openRouterRequest.user,
+    return {
+      ...openRouterRequest,
+      messages: openRouterRequest.messages.map(messageToWire),
     };
-    if (openRouterRequest.response_format) {
-      const format = openRouterRequest.response_format;
-      if (format.type === "json_schema") {
-        chatRequest.responseFormat = {
-          type: "json_schema",
-          jsonSchema: format.json_schema,
-        };
-      } else {
-        chatRequest.responseFormat = format;
-      }
-    }
-    const temperature = (
-      openRouterRequest as unknown as { temperature?: number }
-    ).temperature;
-    if (temperature !== undefined) {
-      chatRequest.temperature = temperature;
-    }
-    if (stream) {
-      chatRequest.stream = true;
-    }
-    // The SDK (>=0.13) wraps the chat completion payload in `chatRequest`.
-    return { chatRequest };
   }
 
   /**
@@ -660,20 +683,15 @@ export class OpenRouterAdapter extends BaseProviderAdapter {
     request: unknown,
     signal?: AbortSignal,
   ): AsyncIterable<LlmStreamChunk> {
-    const openRouter = client as OpenRouter;
+    const openRouter = client as OpenRouterClient;
     const openRouterRequest = request as OpenRouterRequest;
 
-    // Use chat.send with stream: true for streaming responses.
-    // Cast the result to AsyncIterable: when stream: true, the SDK returns a
-    // stream we can iterate, but the typed result is the union with the
-    // non-stream response.
-    const streamParams = this.toSdkChatParams(openRouterRequest, {
-      stream: true,
-    });
-    const stream = (await openRouter.chat.send(
-      streamParams as Parameters<typeof openRouter.chat.send>[0],
+    // streamChatCompletion adds `stream: true` + `stream_options.include_usage`
+    // and yields decoded SSE chunks in OpenAI-compatible (snake_case) shape.
+    const stream = openRouter.streamChatCompletion(
+      this.toWireBody(openRouterRequest),
       signal ? { signal } : undefined,
-    )) as AsyncIterable<unknown>;
+    ) as AsyncIterable<unknown>;
 
     // Track current tool call being built
     let currentToolCall: {

--- a/packages/llm/src/operate/adapters/OpenRouterAdapter.ts
+++ b/packages/llm/src/operate/adapters/OpenRouterAdapter.ts
@@ -589,8 +589,9 @@ export class OpenRouterAdapter extends BaseProviderAdapter {
    */
   private toSdkChatParams(
     openRouterRequest: OpenRouterRequest,
+    { stream }: { stream?: boolean } = {},
   ): Record<string, unknown> {
-    const params: Record<string, unknown> = {
+    const chatRequest: Record<string, unknown> = {
       model: openRouterRequest.model,
       messages: openRouterRequest.messages,
       tools: openRouterRequest.tools,
@@ -600,21 +601,25 @@ export class OpenRouterAdapter extends BaseProviderAdapter {
     if (openRouterRequest.response_format) {
       const format = openRouterRequest.response_format;
       if (format.type === "json_schema") {
-        params.responseFormat = {
+        chatRequest.responseFormat = {
           type: "json_schema",
           jsonSchema: format.json_schema,
         };
       } else {
-        params.responseFormat = format;
+        chatRequest.responseFormat = format;
       }
     }
     const temperature = (
       openRouterRequest as unknown as { temperature?: number }
     ).temperature;
     if (temperature !== undefined) {
-      params.temperature = temperature;
+      chatRequest.temperature = temperature;
     }
-    return params;
+    if (stream) {
+      chatRequest.stream = true;
+    }
+    // The SDK (>=0.13) wraps the chat completion payload in `chatRequest`.
+    return { chatRequest };
   }
 
   /**
@@ -662,10 +667,9 @@ export class OpenRouterAdapter extends BaseProviderAdapter {
     // Cast the result to AsyncIterable: when stream: true, the SDK returns a
     // stream we can iterate, but the typed result is the union with the
     // non-stream response.
-    const streamParams = {
-      ...this.toSdkChatParams(openRouterRequest),
+    const streamParams = this.toSdkChatParams(openRouterRequest, {
       stream: true,
-    };
+    });
     const stream = (await openRouter.chat.send(
       streamParams as Parameters<typeof openRouter.chat.send>[0],
       signal ? { signal } : undefined,

--- a/packages/llm/src/operate/adapters/XaiAdapter.ts
+++ b/packages/llm/src/operate/adapters/XaiAdapter.ts
@@ -1,6 +1,5 @@
-import { BadRequestError } from "openai";
-
 import { PROVIDER } from "../../constants.js";
+import { BadRequestError } from "../../providers/openai/client.js";
 import { ClassifiedError, ErrorCategory } from "../types.js";
 import { OpenAiAdapter } from "./OpenAiAdapter.js";
 

--- a/packages/llm/src/operate/adapters/__tests__/AnthropicAdapter.spec.ts
+++ b/packages/llm/src/operate/adapters/__tests__/AnthropicAdapter.spec.ts
@@ -14,58 +14,6 @@ import {
 // Mock
 //
 
-vi.mock("@anthropic-ai/sdk", () => ({
-  Anthropic: vi.fn(),
-  APIConnectionError: class APIConnectionError extends Error {
-    constructor(..._args: any[]) {
-      super("Connection error");
-      this.name = "APIConnectionError";
-    }
-  },
-  APIConnectionTimeoutError: class APIConnectionTimeoutError extends Error {
-    constructor(..._args: any[]) {
-      super("Timeout");
-      this.name = "APIConnectionTimeoutError";
-    }
-  },
-  AuthenticationError: class AuthenticationError extends Error {
-    constructor(..._args: any[]) {
-      super("Auth error");
-      this.name = "AuthenticationError";
-    }
-  },
-  BadRequestError: class BadRequestError extends Error {
-    constructor(..._args: any[]) {
-      super("Bad request");
-      this.name = "BadRequestError";
-    }
-  },
-  InternalServerError: class InternalServerError extends Error {
-    constructor(..._args: any[]) {
-      super("Internal error");
-      this.name = "InternalServerError";
-    }
-  },
-  NotFoundError: class NotFoundError extends Error {
-    constructor(..._args: any[]) {
-      super("Not found");
-      this.name = "NotFoundError";
-    }
-  },
-  PermissionDeniedError: class PermissionDeniedError extends Error {
-    constructor(..._args: any[]) {
-      super("Permission denied");
-      this.name = "PermissionDeniedError";
-    }
-  },
-  RateLimitError: class RateLimitError extends Error {
-    constructor(..._args: any[]) {
-      super("Rate limit");
-      this.name = "RateLimitError";
-    }
-  },
-}));
-
 vi.mock("zod/v4", () => ({
   z: {
     ZodType: class ZodType {},
@@ -767,7 +715,8 @@ describe("AnthropicAdapter", () => {
 
     describe("classifyError", () => {
       it("classifies rate limit error", async () => {
-        const { RateLimitError } = await import("@anthropic-ai/sdk");
+        const { RateLimitError } =
+          await import("../../../providers/anthropic/client.js");
         // @ts-expect-error Mock doesn't require constructor args
         const error = new RateLimitError();
 
@@ -778,7 +727,8 @@ describe("AnthropicAdapter", () => {
       });
 
       it("classifies retryable error", async () => {
-        const { InternalServerError } = await import("@anthropic-ai/sdk");
+        const { InternalServerError } =
+          await import("../../../providers/anthropic/client.js");
         // @ts-expect-error Mock doesn't require constructor args
         const error = new InternalServerError();
 
@@ -789,7 +739,8 @@ describe("AnthropicAdapter", () => {
       });
 
       it("classifies unrecoverable error", async () => {
-        const { AuthenticationError } = await import("@anthropic-ai/sdk");
+        const { AuthenticationError } =
+          await import("../../../providers/anthropic/client.js");
         // @ts-expect-error Mock doesn't require constructor args
         const error = new AuthenticationError();
 
@@ -936,7 +887,8 @@ describe("AnthropicAdapter", () => {
     });
 
     it("retries without temperature when Anthropic rejects it with 400", async () => {
-      const { BadRequestError } = await import("@anthropic-ai/sdk");
+      const { BadRequestError } =
+        await import("../../../providers/anthropic/client.js");
       // @ts-expect-error Mock doesn't require constructor args
       const error = new BadRequestError();
       (error as unknown as { status: number }).status = 400;
@@ -971,7 +923,8 @@ describe("AnthropicAdapter", () => {
     });
 
     it("caches the model so subsequent buildRequest strips temperature", async () => {
-      const { BadRequestError } = await import("@anthropic-ai/sdk");
+      const { BadRequestError } =
+        await import("../../../providers/anthropic/client.js");
       // @ts-expect-error Mock doesn't require constructor args
       const error = new BadRequestError();
       (error as unknown as { status: number }).status = 400;
@@ -1003,7 +956,8 @@ describe("AnthropicAdapter", () => {
     });
 
     it("does not retry on 400 unrelated to temperature", async () => {
-      const { BadRequestError } = await import("@anthropic-ai/sdk");
+      const { BadRequestError } =
+        await import("../../../providers/anthropic/client.js");
       // @ts-expect-error Mock doesn't require constructor args
       const error = new BadRequestError();
       (error as unknown as { status: number }).status = 400;
@@ -1030,7 +984,8 @@ describe("AnthropicAdapter", () => {
     });
 
     it("does not retry when request has no temperature", async () => {
-      const { BadRequestError } = await import("@anthropic-ai/sdk");
+      const { BadRequestError } =
+        await import("../../../providers/anthropic/client.js");
       // @ts-expect-error Mock doesn't require constructor args
       const error = new BadRequestError();
       (error as unknown as { status: number }).status = 400;
@@ -1062,7 +1017,8 @@ describe("AnthropicAdapter", () => {
     });
 
     it("retries with fake-tool emulation when output_config is rejected", async () => {
-      const { BadRequestError } = await import("@anthropic-ai/sdk");
+      const { BadRequestError } =
+        await import("../../../providers/anthropic/client.js");
       // @ts-expect-error Mock doesn't require constructor args
       const error = new BadRequestError();
       (error as unknown as { status: number }).status = 400;
@@ -1119,7 +1075,8 @@ describe("AnthropicAdapter", () => {
     });
 
     it("caches the model so subsequent buildRequest uses fake-tool path", async () => {
-      const { BadRequestError } = await import("@anthropic-ai/sdk");
+      const { BadRequestError } =
+        await import("../../../providers/anthropic/client.js");
       // @ts-expect-error Mock doesn't require constructor args
       const error = new BadRequestError();
       (error as unknown as { status: number }).status = 400;
@@ -1175,7 +1132,8 @@ describe("AnthropicAdapter", () => {
     });
 
     it("does not fall back when 400 mentions citations", async () => {
-      const { BadRequestError } = await import("@anthropic-ai/sdk");
+      const { BadRequestError } =
+        await import("../../../providers/anthropic/client.js");
       // @ts-expect-error Mock doesn't require constructor args
       const error = new BadRequestError();
       (error as unknown as { status: number }).status = 400;
@@ -1214,7 +1172,8 @@ describe("AnthropicAdapter", () => {
       // adapter code somehow sends the old field, the API returns a 400
       // mentioning "deprecated" — that's a code-path bug and should
       // propagate, NOT silently engage the fake-tool fallback.
-      const { BadRequestError } = await import("@anthropic-ai/sdk");
+      const { BadRequestError } =
+        await import("../../../providers/anthropic/client.js");
       // @ts-expect-error Mock doesn't require constructor args
       const error = new BadRequestError();
       (error as unknown as { status: number }).status = 400;
@@ -1249,7 +1208,8 @@ describe("AnthropicAdapter", () => {
     });
 
     it("does not fall back when 400 is unrelated to structured output", async () => {
-      const { BadRequestError } = await import("@anthropic-ai/sdk");
+      const { BadRequestError } =
+        await import("../../../providers/anthropic/client.js");
       // @ts-expect-error Mock doesn't require constructor args
       const error = new BadRequestError();
       (error as unknown as { status: number }).status = 400;

--- a/packages/llm/src/operate/adapters/__tests__/GoogleAdapter.spec.ts
+++ b/packages/llm/src/operate/adapters/__tests__/GoogleAdapter.spec.ts
@@ -14,10 +14,6 @@ import {
 // Mock
 //
 
-vi.mock("@google/genai", () => ({
-  GoogleGenAI: vi.fn(),
-}));
-
 vi.mock("zod/v4", () => ({
   z: {
     ZodType: class ZodType {},

--- a/packages/llm/src/operate/adapters/__tests__/OpenAiAdapter.spec.ts
+++ b/packages/llm/src/operate/adapters/__tests__/OpenAiAdapter.spec.ts
@@ -14,7 +14,7 @@ import {
 // Mock
 //
 
-vi.mock("openai", () => ({
+vi.mock("../../../providers/openai/client.js", () => ({
   APIConnectionError: class APIConnectionError extends Error {
     constructor(..._args: any[]) {
       super("Connection error");
@@ -63,7 +63,7 @@ vi.mock("openai", () => ({
       this.name = "NotFoundError";
     }
   },
-  OpenAI: vi.fn(),
+  OpenAIClient: vi.fn(),
   PermissionDeniedError: class PermissionDeniedError extends Error {
     constructor(..._args: any[]) {
       super("Permission denied");
@@ -84,7 +84,7 @@ vi.mock("openai", () => ({
   },
 }));
 
-vi.mock("openai/helpers/zod", () => ({
+vi.mock("../../../providers/openai/responseFormat.js", () => ({
   zodResponseFormat: vi.fn(() => ({
     json_schema: {
       name: "response",
@@ -403,7 +403,8 @@ describe("OpenAiAdapter", () => {
 
     describe("classifyError", () => {
       it("classifies rate limit error", async () => {
-        const { RateLimitError } = await import("openai");
+        const { RateLimitError } =
+          await import("../../../providers/openai/client.js");
         // @ts-expect-error Mock doesn't require constructor args
         const error = new RateLimitError();
 
@@ -414,7 +415,8 @@ describe("OpenAiAdapter", () => {
       });
 
       it("classifies retryable error", async () => {
-        const { InternalServerError } = await import("openai");
+        const { InternalServerError } =
+          await import("../../../providers/openai/client.js");
         // @ts-expect-error Mock doesn't require constructor args
         const error = new InternalServerError();
 
@@ -425,7 +427,8 @@ describe("OpenAiAdapter", () => {
       });
 
       it("classifies unrecoverable error", async () => {
-        const { AuthenticationError } = await import("openai");
+        const { AuthenticationError } =
+          await import("../../../providers/openai/client.js");
         // @ts-expect-error Mock doesn't require constructor args
         const error = new AuthenticationError();
 
@@ -676,7 +679,8 @@ describe("OpenAiAdapter", () => {
     });
 
     it("retries without temperature when OpenAI rejects it with 400", async () => {
-      const { BadRequestError } = await import("openai");
+      const { BadRequestError } =
+        await import("../../../providers/openai/client.js");
       // @ts-expect-error Mock doesn't require constructor args
       const error = new BadRequestError();
       (error as unknown as { status: number }).status = 400;
@@ -710,7 +714,8 @@ describe("OpenAiAdapter", () => {
     });
 
     it("caches the model so subsequent buildRequest strips temperature", async () => {
-      const { BadRequestError } = await import("openai");
+      const { BadRequestError } =
+        await import("../../../providers/openai/client.js");
       // @ts-expect-error Mock doesn't require constructor args
       const error = new BadRequestError();
       (error as unknown as { status: number }).status = 400;
@@ -741,7 +746,8 @@ describe("OpenAiAdapter", () => {
     });
 
     it("does not retry on 400 unrelated to temperature", async () => {
-      const { BadRequestError } = await import("openai");
+      const { BadRequestError } =
+        await import("../../../providers/openai/client.js");
       // @ts-expect-error Mock doesn't require constructor args
       const error = new BadRequestError();
       (error as unknown as { status: number }).status = 400;
@@ -766,7 +772,8 @@ describe("OpenAiAdapter", () => {
     });
 
     it("does not retry when request has no temperature", async () => {
-      const { BadRequestError } = await import("openai");
+      const { BadRequestError } =
+        await import("../../../providers/openai/client.js");
       // @ts-expect-error Mock doesn't require constructor args
       const error = new BadRequestError();
       (error as unknown as { status: number }).status = 400;

--- a/packages/llm/src/operate/adapters/__tests__/OpenRouterAdapter.spec.ts
+++ b/packages/llm/src/operate/adapters/__tests__/OpenRouterAdapter.spec.ts
@@ -14,10 +14,6 @@ import {
 // Mock
 //
 
-vi.mock("@openrouter/sdk", () => ({
-  OpenRouter: vi.fn(),
-}));
-
 vi.mock("zod/v4", () => ({
   z: {
     ZodType: class ZodType {},
@@ -882,7 +878,7 @@ describe("OpenRouterAdapter", () => {
           .fn()
           .mockRejectedValueOnce(error)
           .mockResolvedValueOnce(successResponse);
-        const mockClient = { chat: { send: mockSend } };
+        const mockClient = { chatCompletion: mockSend };
         const request: OperateRequest = {
           model: PROVIDER.OPENROUTER.MODEL.DEFAULT,
           messages: [
@@ -901,8 +897,8 @@ describe("OpenRouterAdapter", () => {
         const result = await adapter.executeRequest(mockClient, built);
 
         expect(mockSend).toHaveBeenCalledTimes(2);
-        const fallbackCallParams = mockSend.mock.calls[1][0].chatRequest;
-        expect(fallbackCallParams.responseFormat).toBeUndefined();
+        const fallbackCallParams = mockSend.mock.calls[1][0];
+        expect(fallbackCallParams.response_format).toBeUndefined();
         expect(fallbackCallParams.tools).toBeDefined();
         expect(
           fallbackCallParams.tools.some(
@@ -947,7 +943,7 @@ describe("OpenRouterAdapter", () => {
           status: 400,
         });
         const mockSend = vi.fn().mockRejectedValue(error);
-        const mockClient = { chat: { send: mockSend } };
+        const mockClient = { chatCompletion: mockSend };
         const request: OperateRequest = {
           model: PROVIDER.OPENROUTER.MODEL.DEFAULT,
           messages: [],
@@ -1095,7 +1091,7 @@ describe("OpenRouterAdapter", () => {
           id: "resp-1",
           choices: [{ message: { role: "assistant", content: "Hi" } }],
         });
-        const mockClient = { chat: { send: mockSend } };
+        const mockClient = { chatCompletion: mockSend };
         const request = {
           model: PROVIDER.OPENROUTER.MODEL.DEFAULT,
           messages: [{ role: "user", content: "Hello" }],
@@ -1118,7 +1114,7 @@ describe("OpenRouterAdapter", () => {
         controller.abort("retry");
 
         const mockSend = vi.fn().mockRejectedValue(new TypeError("terminated"));
-        const mockClient = { chat: { send: mockSend } };
+        const mockClient = { chatCompletion: mockSend };
         const request = {
           model: PROVIDER.OPENROUTER.MODEL.DEFAULT,
           messages: [{ role: "user", content: "Hello" }],
@@ -1137,7 +1133,7 @@ describe("OpenRouterAdapter", () => {
         const controller = new AbortController();
 
         const mockSend = vi.fn().mockRejectedValue(new Error("real error"));
-        const mockClient = { chat: { send: mockSend } };
+        const mockClient = { chatCompletion: mockSend };
         const request = {
           model: PROVIDER.OPENROUTER.MODEL.DEFAULT,
           messages: [{ role: "user", content: "Hello" }],
@@ -1157,7 +1153,7 @@ describe("OpenRouterAdapter", () => {
           id: "resp-1",
           choices: [{ message: { role: "assistant", content: "Hi" } }],
         });
-        const mockClient = { chat: { send: mockSend } };
+        const mockClient = { chatCompletion: mockSend };
         const request = {
           model: PROVIDER.OPENROUTER.MODEL.DEFAULT,
           messages: [{ role: "user", content: "Hello" }],

--- a/packages/llm/src/operate/adapters/__tests__/OpenRouterAdapter.spec.ts
+++ b/packages/llm/src/operate/adapters/__tests__/OpenRouterAdapter.spec.ts
@@ -901,7 +901,7 @@ describe("OpenRouterAdapter", () => {
         const result = await adapter.executeRequest(mockClient, built);
 
         expect(mockSend).toHaveBeenCalledTimes(2);
-        const fallbackCallParams = mockSend.mock.calls[1][0];
+        const fallbackCallParams = mockSend.mock.calls[1][0].chatRequest;
         expect(fallbackCallParams.responseFormat).toBeUndefined();
         expect(fallbackCallParams.tools).toBeDefined();
         expect(

--- a/packages/llm/src/operate/adapters/__tests__/XaiAdapter.spec.ts
+++ b/packages/llm/src/operate/adapters/__tests__/XaiAdapter.spec.ts
@@ -14,7 +14,7 @@ import {
 // Mock
 //
 
-vi.mock("openai", () => ({
+vi.mock("../../../providers/openai/client.js", () => ({
   APIConnectionError: class APIConnectionError extends Error {
     constructor(..._args: any[]) {
       super("Connection error");
@@ -63,7 +63,7 @@ vi.mock("openai", () => ({
       this.name = "NotFoundError";
     }
   },
-  OpenAI: vi.fn(),
+  OpenAIClient: vi.fn(),
   PermissionDeniedError: class PermissionDeniedError extends Error {
     constructor(..._args: any[]) {
       super("Permission denied");
@@ -84,7 +84,7 @@ vi.mock("openai", () => ({
   },
 }));
 
-vi.mock("openai/helpers/zod", () => ({
+vi.mock("../../../providers/openai/responseFormat.js", () => ({
   zodResponseFormat: vi.fn(() => ({
     json_schema: {
       name: "response",
@@ -219,7 +219,8 @@ describe("XaiAdapter", () => {
   describe("Features", () => {
     describe("classifyError", () => {
       it("classifies rate limit error", async () => {
-        const { RateLimitError } = await import("openai");
+        const { RateLimitError } =
+          await import("../../../providers/openai/client.js");
         // @ts-expect-error Mock doesn't require constructor args
         const error = new RateLimitError();
 
@@ -230,7 +231,8 @@ describe("XaiAdapter", () => {
       });
 
       it("classifies retryable error", async () => {
-        const { InternalServerError } = await import("openai");
+        const { InternalServerError } =
+          await import("../../../providers/openai/client.js");
         // @ts-expect-error Mock doesn't require constructor args
         const error = new InternalServerError();
 
@@ -241,7 +243,8 @@ describe("XaiAdapter", () => {
       });
 
       it("classifies unrecoverable error", async () => {
-        const { AuthenticationError } = await import("openai");
+        const { AuthenticationError } =
+          await import("../../../providers/openai/client.js");
         // @ts-expect-error Mock doesn't require constructor args
         const error = new AuthenticationError();
 
@@ -252,7 +255,8 @@ describe("XaiAdapter", () => {
       });
 
       it("retries on transient xAI ingest-bytes error (400 with 'failed to ingest inline file bytes')", async () => {
-        const { BadRequestError } = await import("openai");
+        const { BadRequestError } =
+          await import("../../../providers/openai/client.js");
         // @ts-expect-error Mock doesn't require constructor args
         const error = new BadRequestError();
         error.message = "400 failed to ingest inline file bytes";
@@ -264,7 +268,8 @@ describe("XaiAdapter", () => {
       });
 
       it("does not retry on unrelated BadRequestError", async () => {
-        const { BadRequestError } = await import("openai");
+        const { BadRequestError } =
+          await import("../../../providers/openai/client.js");
         // @ts-expect-error Mock doesn't require constructor args
         const error = new BadRequestError();
         error.message = "400 invalid model";

--- a/packages/llm/src/providers/anthropic/AnthropicProvider.class.ts
+++ b/packages/llm/src/providers/anthropic/AnthropicProvider.class.ts
@@ -1,4 +1,4 @@
-import type Anthropic from "@anthropic-ai/sdk";
+import type { AnthropicClient } from "./client.js";
 import { JsonObject } from "@jaypie/types";
 import { PROVIDER } from "../../constants.js";
 import {
@@ -30,7 +30,7 @@ import {
 // Main class implementation
 export class AnthropicProvider implements LlmProvider {
   private model: string;
-  private _client?: Anthropic;
+  private _client?: AnthropicClient;
   private _operateLoop?: OperateLoop;
   private _streamLoop?: StreamLoop;
   private apiKey?: string;
@@ -45,7 +45,7 @@ export class AnthropicProvider implements LlmProvider {
     this.apiKey = apiKey;
   }
 
-  private async getClient(): Promise<Anthropic> {
+  private async getClient(): Promise<AnthropicClient> {
     if (this._client) {
       return this._client;
     }

--- a/packages/llm/src/providers/anthropic/__tests__/AnthropicProvider.spec.ts
+++ b/packages/llm/src/providers/anthropic/__tests__/AnthropicProvider.spec.ts
@@ -1,59 +1,18 @@
 import { getEnvSecret } from "@jaypie/aws";
-import Anthropic from "@anthropic-ai/sdk";
+import { AnthropicClient } from "../client.js";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { z } from "zod/v4";
 import { AnthropicProvider } from "../AnthropicProvider.class.js";
 import { PROVIDER } from "../../../constants.js";
 import {
   LlmMessageType,
-  LlmInputMessage,
-  LlmOutputMessage,
   LlmMessageRole,
   LlmResponseStatus,
 } from "../../../types/LlmProvider.interface.js";
 import { Toolkit } from "../../../tools/Toolkit.class.js";
 
-// Create a mock implementation for Anthropic client
-vi.mock("@anthropic-ai/sdk", () => {
-  // Create mock error classes
-  class APIConnectionError extends Error {
-    name = "APIConnectionError";
-  }
-  class APIConnectionTimeoutError extends Error {
-    name = "APIConnectionTimeoutError";
-  }
-  class AuthenticationError extends Error {
-    name = "AuthenticationError";
-  }
-  class BadRequestError extends Error {
-    name = "BadRequestError";
-  }
-  class InternalServerError extends Error {
-    name = "InternalServerError";
-  }
-  class NotFoundError extends Error {
-    name = "NotFoundError";
-  }
-  class PermissionDeniedError extends Error {
-    name = "PermissionDeniedError";
-  }
-  class RateLimitError extends Error {
-    name = "RateLimitError";
-  }
-
-  return {
-    default: vi.fn(),
-    Anthropic: vi.fn(),
-    APIConnectionError,
-    APIConnectionTimeoutError,
-    AuthenticationError,
-    BadRequestError,
-    InternalServerError,
-    NotFoundError,
-    PermissionDeniedError,
-    RateLimitError,
-  };
-});
+// Mock the HTTP client
+vi.mock("../client.js", () => ({ AnthropicClient: vi.fn() }));
 
 vi.mock("@jaypie/aws", async () => {
   const actual = await vi.importActual("@jaypie/aws");
@@ -90,7 +49,7 @@ describe("AnthropicProvider", () => {
     vi.resetAllMocks();
 
     // Set up the mock response for Anthropic client
-    vi.mocked(Anthropic).mockImplementation(
+    vi.mocked(AnthropicClient).mockImplementation(
       class {
         messages = {
           create: vi.fn(),
@@ -150,7 +109,7 @@ describe("AnthropicProvider", () => {
       };
 
       const mockCreate = vi.fn().mockResolvedValue(mockResponse);
-      vi.mocked(Anthropic).mockImplementation(
+      vi.mocked(AnthropicClient).mockImplementation(
         class {
           messages = {
             create: mockCreate,
@@ -185,7 +144,7 @@ describe("AnthropicProvider", () => {
       };
 
       const mockCreate = vi.fn().mockResolvedValue(mockResponse);
-      vi.mocked(Anthropic).mockImplementation(
+      vi.mocked(AnthropicClient).mockImplementation(
         class {
           messages = {
             create: mockCreate,
@@ -212,7 +171,7 @@ describe("AnthropicProvider", () => {
       };
 
       const mockCreate = vi.fn().mockResolvedValue(mockResponse);
-      vi.mocked(Anthropic).mockImplementation(
+      vi.mocked(AnthropicClient).mockImplementation(
         class {
           messages = {
             create: mockCreate,
@@ -254,7 +213,7 @@ describe("AnthropicProvider", () => {
         };
 
         const mockCreate = vi.fn().mockResolvedValue(mockResponse);
-        vi.mocked(Anthropic).mockImplementation(
+        vi.mocked(AnthropicClient).mockImplementation(
           class {
             messages = {
               create: mockCreate,
@@ -297,7 +256,7 @@ describe("AnthropicProvider", () => {
         };
 
         const mockCreate = vi.fn().mockResolvedValue(mockResponse);
-        vi.mocked(Anthropic).mockImplementation(
+        vi.mocked(AnthropicClient).mockImplementation(
           class {
             messages = {
               create: mockCreate,
@@ -327,7 +286,7 @@ describe("AnthropicProvider", () => {
         };
 
         const mockCreate = vi.fn().mockResolvedValue(mockResponse);
-        vi.mocked(Anthropic).mockImplementation(
+        vi.mocked(AnthropicClient).mockImplementation(
           class {
             messages = {
               create: mockCreate,
@@ -353,7 +312,7 @@ describe("AnthropicProvider", () => {
         };
 
         const mockCreate = vi.fn().mockResolvedValue(mockResponse);
-        vi.mocked(Anthropic).mockImplementation(
+        vi.mocked(AnthropicClient).mockImplementation(
           class {
             messages = {
               create: mockCreate,
@@ -643,7 +602,7 @@ describe("AnthropicProvider", () => {
         };
 
         const mockCreate = vi.fn().mockResolvedValue(mockResponse);
-        vi.mocked(Anthropic).mockImplementation(
+        vi.mocked(AnthropicClient).mockImplementation(
           class {
             messages = {
               create: mockCreate,
@@ -674,7 +633,7 @@ describe("AnthropicProvider", () => {
         };
 
         const mockCreate = vi.fn().mockResolvedValue(mockResponse);
-        vi.mocked(Anthropic).mockImplementation(
+        vi.mocked(AnthropicClient).mockImplementation(
           class {
             messages = {
               create: mockCreate,
@@ -703,7 +662,7 @@ describe("AnthropicProvider", () => {
         };
 
         const mockCreate = vi.fn().mockResolvedValue(mockResponse);
-        vi.mocked(Anthropic).mockImplementation(
+        vi.mocked(AnthropicClient).mockImplementation(
           class {
             messages = {
               create: mockCreate,
@@ -733,7 +692,7 @@ describe("AnthropicProvider", () => {
         };
 
         const mockCreate = vi.fn().mockResolvedValue(mockResponse);
-        vi.mocked(Anthropic).mockImplementation(
+        vi.mocked(AnthropicClient).mockImplementation(
           class {
             messages = {
               create: mockCreate,

--- a/packages/llm/src/providers/anthropic/__tests__/client.hot.spec.ts
+++ b/packages/llm/src/providers/anthropic/__tests__/client.hot.spec.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import { PROVIDER } from "../../../constants.js";
+import { AnthropicClient } from "../client.js";
+import { AnthropicProvider } from "../AnthropicProvider.class.js";
+
+//
+//
+// Hot tests
+//
+// Live tests against the real Anthropic Messages API. Skipped unless
+// ANTHROPIC_API_KEY is set, so CI stays green and `npm test` runs them
+// automatically with a key.
+//
+//   ANTHROPIC_API_KEY=sk-ant-... npm run test -w packages/llm
+//
+
+const apiKey = process.env.ANTHROPIC_API_KEY;
+const MODEL = PROVIDER.ANTHROPIC.MODEL.TINY;
+const TIMEOUT = 60_000;
+
+describe.skipIf(!apiKey)("AnthropicClient (hot)", () => {
+  describe("messages.create", () => {
+    it(
+      "returns assistant text from the live endpoint",
+      async () => {
+        const client = new AnthropicClient({ apiKey: apiKey! });
+        const response = await client.messages.create({
+          model: MODEL,
+          max_tokens: 64,
+          messages: [
+            { role: "user", content: "Reply with the single word: pong" },
+          ],
+        });
+        const block = response.content.find((b) => b.type === "text");
+        const text = block && "text" in block ? block.text : "";
+        expect(text.toLowerCase()).toContain("pong");
+      },
+      TIMEOUT,
+    );
+
+    it(
+      "streams text deltas",
+      async () => {
+        const client = new AnthropicClient({ apiKey: apiKey! });
+        const stream = await client.messages.create({
+          model: MODEL,
+          max_tokens: 64,
+          messages: [{ role: "user", content: "Count: one two three" }],
+          stream: true,
+        });
+
+        let text = "";
+        for await (const event of stream) {
+          if (
+            event.type === "content_block_delta" &&
+            event.delta.type === "text_delta"
+          ) {
+            text += event.delta.text;
+          }
+        }
+        expect(text.length).toBeGreaterThan(0);
+      },
+      TIMEOUT,
+    );
+  });
+
+  describe("AnthropicProvider.operate", () => {
+    it(
+      "completes a text turn end-to-end",
+      async () => {
+        const provider = new AnthropicProvider(MODEL, { apiKey: apiKey! });
+        const response = await provider.operate(
+          "Reply with the single word: pong",
+        );
+        expect(String(response.content).toLowerCase()).toContain("pong");
+      },
+      TIMEOUT,
+    );
+
+    it(
+      "returns structured output via native output_config",
+      async () => {
+        const provider = new AnthropicProvider(MODEL, { apiKey: apiKey! });
+        const response = await provider.operate("Give the capital of France.", {
+          format: { capital: String },
+        });
+        expect(response.content).toMatchObject({ capital: expect.any(String) });
+      },
+      TIMEOUT,
+    );
+  });
+});

--- a/packages/llm/src/providers/anthropic/__tests__/client.spec.ts
+++ b/packages/llm/src/providers/anthropic/__tests__/client.spec.ts
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { AnthropicClient, RateLimitError } from "../client.js";
+
+//
+//
+// Helpers
+//
+
+function jsonResponse(
+  body: unknown,
+  { ok = true, status = 200 } = {},
+): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+function sseResponse(text: string): Response {
+  const bytes = new TextEncoder().encode(text);
+  let sent = false;
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (sent) {
+        controller.close();
+        return;
+      }
+      controller.enqueue(bytes);
+      sent = true;
+    },
+  });
+  return { ok: true, status: 200, body } as unknown as Response;
+}
+
+const BASE_PARAMS = {
+  model: "claude-haiku-4-5",
+  max_tokens: 64,
+  messages: [{ role: "user" as const, content: "hi" }],
+};
+
+//
+//
+// Tests
+//
+
+describe("AnthropicClient", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("messages.create (non-streaming)", () => {
+    it("POSTs to /messages with x-api-key and version headers", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        jsonResponse({
+          content: [{ type: "text", text: "ok" }],
+          stop_reason: "end_turn",
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new AnthropicClient({ apiKey: "sk-ant" });
+      await client.messages.create(BASE_PARAMS);
+
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe("https://api.anthropic.com/v1/messages");
+      expect(init.headers["x-api-key"]).toBe("sk-ant");
+      expect(init.headers["anthropic-version"]).toBe("2023-06-01");
+      // Internal params are already wire-shaped: serialized verbatim
+      expect(JSON.parse(init.body)).toMatchObject({
+        model: "claude-haiku-4-5",
+      });
+    });
+
+    it("throws a status-named error (RateLimitError for 429) so classifyError works", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(
+          jsonResponse(
+            { error: { message: "slow down" } },
+            { ok: false, status: 429 },
+          ),
+        );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new AnthropicClient({ apiKey: "sk-ant" });
+      const error = await client.messages.create(BASE_PARAMS).catch((e) => e);
+
+      expect(error).toBeInstanceOf(RateLimitError);
+      expect(error.constructor.name).toBe("RateLimitError");
+      expect(error.status).toBe(429);
+      expect(error.message).toBe("slow down");
+    });
+  });
+
+  describe("messages.create (streaming)", () => {
+    it("returns an async iterable of decoded SSE events", async () => {
+      const sse =
+        'event: message_start\ndata: {"type":"message_start","message":{"model":"m","usage":{"input_tokens":1,"output_tokens":0}}}\n\n' +
+        'event: content_block_delta\ndata: {"type":"content_block_delta","delta":{"type":"text_delta","text":"hello"}}\n\n' +
+        'event: message_stop\ndata: {"type":"message_stop"}\n\n';
+      const fetchMock = vi.fn().mockResolvedValue(sseResponse(sse));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new AnthropicClient({ apiKey: "sk-ant" });
+      const stream = await client.messages.create({
+        ...BASE_PARAMS,
+        stream: true,
+      });
+
+      const events = [];
+      for await (const event of stream) events.push(event);
+
+      expect(events.map((e) => e.type)).toEqual([
+        "message_start",
+        "content_block_delta",
+        "message_stop",
+      ]);
+      const init = fetchMock.mock.calls[0][1];
+      expect(init.headers.accept).toBe("text/event-stream");
+    });
+  });
+});

--- a/packages/llm/src/providers/anthropic/__tests__/utils.spec.ts
+++ b/packages/llm/src/providers/anthropic/__tests__/utils.spec.ts
@@ -1,6 +1,6 @@
 import { getEnvSecret } from "@jaypie/aws";
 import { log } from "@jaypie/logger";
-import Anthropic from "@anthropic-ai/sdk";
+import { AnthropicClient } from "../client.js";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { PROVIDER } from "../../../constants.js";
 import {
@@ -52,15 +52,11 @@ vi.mock("@jaypie/logger", () => {
   };
 });
 
-vi.mock("@anthropic-ai/sdk", () => {
-  return {
-    default: vi.fn().mockImplementation(() => ({
-      messages: {
-        create: vi.fn(),
-      },
-    })),
-  };
-});
+vi.mock("../client.js", () => ({
+  AnthropicClient: vi.fn().mockImplementation(() => ({
+    messages: { create: vi.fn() },
+  })),
+}));
 
 describe("Anthropic Utils", () => {
   beforeEach(() => {
@@ -111,7 +107,9 @@ describe("Anthropic Utils", () => {
         vi.mocked(log.lib).mockReturnValue(mockLogger);
 
         await initializeClient({ apiKey: "provided-key" });
-        expect(Anthropic).toHaveBeenCalledWith({ apiKey: "provided-key" });
+        expect(AnthropicClient).toHaveBeenCalledWith({
+          apiKey: "provided-key",
+        });
         expect(mockLogger.trace).toHaveBeenCalledWith(
           "Initialized Anthropic client",
         );
@@ -127,7 +125,9 @@ describe("Anthropic Utils", () => {
         vi.mocked(log.lib).mockReturnValue(mockLogger);
 
         await initializeClient();
-        expect(Anthropic).toHaveBeenCalledWith({ apiKey: "test-api-key" });
+        expect(AnthropicClient).toHaveBeenCalledWith({
+          apiKey: "test-api-key",
+        });
         expect(mockLogger.trace).toHaveBeenCalledWith(
           "Initialized Anthropic client",
         );

--- a/packages/llm/src/providers/anthropic/client.ts
+++ b/packages/llm/src/providers/anthropic/client.ts
@@ -1,0 +1,172 @@
+import { parseSseStream } from "../../util/sse.js";
+import { Anthropic } from "./types.js";
+
+//
+//
+// Constants
+//
+
+const ANTHROPIC_BASE_URL = "https://api.anthropic.com/v1";
+
+const ANTHROPIC_VERSION = "2023-06-01";
+
+//
+//
+// Errors
+//
+// The adapter's `classifyError` keys off `error.constructor.name` (the SDK's
+// class names), so the client throws errors whose class names match. Status →
+// class mapping mirrors the SDK.
+//
+
+export class AnthropicApiError extends Error {
+  readonly status: number;
+  readonly error?: { message?: string };
+
+  constructor(status: number, message: string, error?: { message?: string }) {
+    super(message);
+    this.name = this.constructor.name;
+    this.status = status;
+    this.error = error;
+  }
+}
+
+export class BadRequestError extends AnthropicApiError {}
+export class AuthenticationError extends AnthropicApiError {}
+export class PermissionDeniedError extends AnthropicApiError {}
+export class NotFoundError extends AnthropicApiError {}
+export class RateLimitError extends AnthropicApiError {}
+export class InternalServerError extends AnthropicApiError {}
+export class APIConnectionError extends AnthropicApiError {}
+
+function errorForStatus(
+  status: number,
+  message: string,
+  error?: { message?: string },
+): AnthropicApiError {
+  if (status === 400) return new BadRequestError(status, message, error);
+  if (status === 401) return new AuthenticationError(status, message, error);
+  if (status === 403) return new PermissionDeniedError(status, message, error);
+  if (status === 404) return new NotFoundError(status, message, error);
+  if (status === 429) return new RateLimitError(status, message, error);
+  if (status >= 500) return new InternalServerError(status, message, error);
+  return new AnthropicApiError(status, message, error);
+}
+
+//
+//
+// Types
+//
+
+export interface AnthropicClientOptions {
+  apiKey: string;
+  baseURL?: string;
+}
+
+export interface CreateOptions {
+  signal?: AbortSignal;
+}
+
+interface MessagesApi {
+  create(
+    params: Anthropic.MessageCreateParamsStreaming,
+    options?: CreateOptions,
+  ): Promise<AsyncIterable<Anthropic.MessageStreamEvent>>;
+  create(
+    params: Anthropic.MessageCreateParams,
+    options?: CreateOptions,
+  ): Promise<Anthropic.Message>;
+}
+
+//
+//
+// Main
+//
+
+/**
+ * Minimal `fetch`-based client for Anthropic's Messages API. Replaces
+ * `@anthropic-ai/sdk` — the adapter only needs `messages.create` (streaming and
+ * non-streaming), header auth, and HTTP errors whose class names drive
+ * `classifyError`. Internal request params are already Anthropic's wire shape,
+ * so they serialize verbatim. Exposes a `messages` facade mirroring the SDK so
+ * the adapter call sites are unchanged.
+ */
+export class AnthropicClient {
+  private readonly apiKey: string;
+  private readonly baseURL: string;
+  readonly messages: MessagesApi;
+
+  constructor({
+    apiKey,
+    baseURL = ANTHROPIC_BASE_URL,
+  }: AnthropicClientOptions) {
+    this.apiKey = apiKey;
+    this.baseURL = baseURL;
+    this.messages = {
+      create: ((
+        params: Anthropic.MessageCreateParams,
+        options?: CreateOptions,
+      ) =>
+        params.stream
+          ? this.createStream(params, options)
+          : this.createMessage(params, options)) as MessagesApi["create"],
+    };
+  }
+
+  private headers(): Record<string, string> {
+    return {
+      "anthropic-version": ANTHROPIC_VERSION,
+      "content-type": "application/json",
+      "x-api-key": this.apiKey,
+    };
+  }
+
+  private async toError(response: Response): Promise<AnthropicApiError> {
+    let message = `Anthropic request failed with status ${response.status}`;
+    let error: { message?: string } | undefined;
+    try {
+      const body = (await response.json()) as { error?: { message?: string } };
+      if (body?.error?.message) {
+        message = body.error.message;
+        error = body.error;
+      }
+    } catch {
+      // Non-JSON error body; keep the status-based message.
+    }
+    return errorForStatus(response.status, message, error);
+  }
+
+  private async createMessage(
+    params: Anthropic.MessageCreateParams,
+    { signal }: CreateOptions = {},
+  ): Promise<Anthropic.Message> {
+    const response = await fetch(`${this.baseURL}/messages`, {
+      method: "POST",
+      headers: this.headers(),
+      body: JSON.stringify(params),
+      signal,
+    });
+
+    if (!response.ok) throw await this.toError(response);
+    return (await response.json()) as Anthropic.Message;
+  }
+
+  private async createStream(
+    params: Anthropic.MessageCreateParams,
+    { signal }: CreateOptions = {},
+  ): Promise<AsyncIterable<Anthropic.MessageStreamEvent>> {
+    const response = await fetch(`${this.baseURL}/messages`, {
+      method: "POST",
+      headers: { ...this.headers(), accept: "text/event-stream" },
+      body: JSON.stringify(params),
+      signal,
+    });
+
+    if (!response.ok) throw await this.toError(response);
+    if (!response.body) return (async function* () {})();
+
+    return parseSseStream(
+      response.body,
+    ) as AsyncIterable<Anthropic.MessageStreamEvent>;
+  }
+}

--- a/packages/llm/src/providers/anthropic/types.ts
+++ b/packages/llm/src/providers/anthropic/types.ts
@@ -1,3 +1,4 @@
+import { JsonObject } from "@jaypie/types";
 import { LlmMessageRole } from "../../types/LlmProvider.interface.js";
 import { PROVIDER } from "../../constants.js";
 
@@ -8,3 +9,138 @@ export const ROLE_MAP: Record<LlmMessageRole, string> = {
   [LlmMessageRole.Assistant]: PROVIDER.ANTHROPIC.ROLE.ASSISTANT,
   [LlmMessageRole.Developer]: PROVIDER.ANTHROPIC.ROLE.SYSTEM,
 };
+
+//
+//
+// Anthropic API types
+//
+// Local mirror of the subset of `@anthropic-ai/sdk`'s `Anthropic` namespace the
+// adapter and utils use. Defining it here lets us drop the SDK dependency while
+// keeping every `Anthropic.X` reference unchanged. The internal request shapes
+// are already Anthropic's snake_case wire format, so the HTTP client serializes
+// them verbatim.
+//
+
+/* eslint-disable @typescript-eslint/no-namespace */
+export namespace Anthropic {
+  export interface TextBlock {
+    type: "text";
+    text: string;
+  }
+
+  export interface ToolUseBlock {
+    type: "tool_use";
+    id: string;
+    name: string;
+    input: unknown;
+  }
+
+  export interface ThinkingBlock {
+    type: "thinking";
+    thinking: string;
+    signature?: string;
+  }
+
+  export type ContentBlock = TextBlock | ToolUseBlock | ThinkingBlock;
+
+  export interface Base64ImageSource {
+    type: "base64";
+    media_type: string;
+    data: string;
+  }
+
+  export interface Base64PDFSource {
+    type: "base64";
+    media_type: string;
+    data: string;
+  }
+
+  export interface ToolResultBlockParam {
+    type: "tool_result";
+    tool_use_id: string;
+    content: string;
+  }
+
+  export type ContentBlockParam =
+    | { type: "text"; text: string }
+    | {
+        type: "image";
+        source: Base64ImageSource | { type: "url"; url: string };
+      }
+    | {
+        type: "document";
+        source: Base64PDFSource | { type: "url"; url: string };
+      }
+    | ToolUseBlock
+    | ToolResultBlockParam;
+
+  export interface MessageParam {
+    role: "user" | "assistant";
+    content: string | ContentBlockParam[];
+  }
+
+  export namespace Messages {
+    export namespace Tool {
+      export type InputSchema = JsonObject;
+    }
+  }
+
+  export interface Tool {
+    name: string;
+    description?: string;
+    input_schema: Messages.Tool.InputSchema;
+    type?: "custom";
+  }
+
+  export interface Usage {
+    input_tokens: number;
+    output_tokens: number;
+    thinking_tokens?: number;
+  }
+
+  export interface MessageCreateParams {
+    model: string;
+    messages: MessageParam[];
+    max_tokens: number;
+    system?: string;
+    tools?: Tool[];
+    tool_choice?: { type: "auto" | "any" | "tool"; name?: string };
+    temperature?: number;
+    stream?: boolean;
+    // Allow `output_config` and arbitrary providerOptions passthrough.
+    [key: string]: unknown;
+  }
+
+  export type MessageCreateParamsStreaming = MessageCreateParams & {
+    stream: true;
+  };
+
+  export interface Message {
+    id: string;
+    type: "message";
+    role: "assistant";
+    model: string;
+    content: ContentBlock[];
+    stop_reason: string | null;
+    stop_sequence?: string | null;
+    usage: Usage;
+  }
+
+  export type ContentBlockDelta =
+    | { type: "text_delta"; text: string }
+    | { type: "input_json_delta"; partial_json: string };
+
+  export type MessageStreamEvent =
+    | { type: "message_start"; message: Message }
+    | {
+        type: "content_block_start";
+        index: number;
+        content_block: ContentBlock;
+      }
+    | { type: "content_block_delta"; index: number; delta: ContentBlockDelta }
+    | { type: "content_block_stop"; index: number }
+    | { type: "message_delta"; delta: Record<string, unknown>; usage: Usage }
+    | { type: "message_stop" }
+    | { type: "ping" };
+}
+/* eslint-enable @typescript-eslint/no-namespace */

--- a/packages/llm/src/providers/anthropic/utils.ts
+++ b/packages/llm/src/providers/anthropic/utils.ts
@@ -2,27 +2,13 @@ import { getEnvSecret } from "@jaypie/aws";
 import { ConfigurationError } from "@jaypie/errors";
 import { JAYPIE, placeholders as replacePlaceholders } from "@jaypie/kit";
 import { createLogger, log as defaultLog, log } from "@jaypie/logger";
-import type Anthropic from "@anthropic-ai/sdk";
 import { PROVIDER } from "../../constants.js";
 import { LlmMessageOptions } from "../../types/LlmProvider.interface.js";
 import { naturalZodSchema } from "../../util/index.js";
 import { z } from "zod/v4";
 import { JsonObject, NaturalSchema } from "@jaypie/types";
-
-// SDK loader with caching
-let cachedSdk: typeof import("@anthropic-ai/sdk") | null = null;
-
-export async function loadSdk(): Promise<typeof import("@anthropic-ai/sdk")> {
-  if (cachedSdk) return cachedSdk;
-  try {
-    cachedSdk = await import("@anthropic-ai/sdk");
-    return cachedSdk;
-  } catch {
-    throw new ConfigurationError(
-      "@anthropic-ai/sdk is required but not installed. Run: npm install @anthropic-ai/sdk",
-    );
-  }
-}
+import { AnthropicClient } from "./client.js";
+import type { Anthropic } from "./types.js";
 
 // Logger
 export const getLogger = (): ReturnType<typeof createLogger> =>
@@ -33,7 +19,7 @@ export async function initializeClient({
   apiKey,
 }: {
   apiKey?: string;
-} = {}): Promise<Anthropic> {
+} = {}): Promise<AnthropicClient> {
   const logger = getLogger();
   const resolvedApiKey = apiKey || (await getEnvSecret("ANTHROPIC_API_KEY"));
 
@@ -43,8 +29,7 @@ export async function initializeClient({
     );
   }
 
-  const sdk = await loadSdk();
-  const client = new sdk.default({ apiKey: resolvedApiKey });
+  const client = new AnthropicClient({ apiKey: resolvedApiKey });
   logger.trace("Initialized Anthropic client");
   return client;
 }
@@ -91,7 +76,7 @@ export function prepareMessages(
 
 // Basic text completion
 export async function createTextCompletion(
-  client: Anthropic,
+  client: AnthropicClient,
   messages: Anthropic.MessageParam[],
   model: string,
   systemMessage?: string,
@@ -124,7 +109,7 @@ export async function createTextCompletion(
 // field. Returns a JsonObject parsed and validated against the caller's
 // Zod schema.
 export async function createStructuredCompletion(
-  client: Anthropic,
+  client: AnthropicClient,
   messages: Anthropic.MessageParam[],
   model: string,
   responseSchema: z.ZodType | NaturalSchema,

--- a/packages/llm/src/providers/google/GoogleProvider.class.ts
+++ b/packages/llm/src/providers/google/GoogleProvider.class.ts
@@ -1,5 +1,5 @@
 import { JsonObject } from "@jaypie/types";
-import type { GoogleGenAI } from "@google/genai";
+import type { GoogleClient } from "./client.js";
 import { PROVIDER } from "../../constants.js";
 import {
   createOperateLoop,
@@ -22,7 +22,7 @@ import { getLogger, initializeClient, prepareMessages } from "./utils.js";
 
 export class GoogleProvider implements LlmProvider {
   private model: string;
-  private _client?: GoogleGenAI;
+  private _client?: GoogleClient;
   private _operateLoop?: OperateLoop;
   private _streamLoop?: StreamLoop;
   private apiKey?: string;
@@ -37,7 +37,7 @@ export class GoogleProvider implements LlmProvider {
     this.apiKey = apiKey;
   }
 
-  private async getClient(): Promise<GoogleGenAI> {
+  private async getClient(): Promise<GoogleClient> {
     if (this._client) {
       return this._client;
     }

--- a/packages/llm/src/providers/google/__tests__/GoogleProvider.spec.ts
+++ b/packages/llm/src/providers/google/__tests__/GoogleProvider.spec.ts
@@ -1,5 +1,5 @@
 import { getEnvSecret } from "@jaypie/aws";
-import { GoogleGenAI } from "@google/genai";
+import { GoogleClient } from "../client.js";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { GoogleProvider } from "../GoogleProvider.class";
 import {
@@ -10,8 +10,8 @@ import {
   LlmResponseStatus,
 } from "../../../types/LlmProvider.interface.js";
 
-// Mock the operate module
-vi.mock("@google/genai");
+// Mock the HTTP client
+vi.mock("../client.js");
 
 // Mock the OperateLoop for conversation history tests
 vi.mock("../../../operate/index.js", async (importOriginal) => {
@@ -35,7 +35,7 @@ vi.mock("@jaypie/aws", async () => {
 
 describe("GoogleProvider", () => {
   beforeEach(() => {
-    vi.mocked(GoogleGenAI).mockImplementation(
+    vi.mocked(GoogleClient).mockImplementation(
       class {
         models = {
           generateContent: vi.fn(),
@@ -78,7 +78,7 @@ describe("GoogleProvider", () => {
       };
 
       const mockGenerateContent = vi.fn().mockResolvedValue(mockResponse);
-      vi.mocked(GoogleGenAI).mockImplementation(
+      vi.mocked(GoogleClient).mockImplementation(
         class {
           models = {
             generateContent: mockGenerateContent,
@@ -111,7 +111,7 @@ describe("GoogleProvider", () => {
         };
 
         const mockGenerateContent = vi.fn().mockResolvedValue(mockResponse);
-        vi.mocked(GoogleGenAI).mockImplementation(
+        vi.mocked(GoogleClient).mockImplementation(
           class {
             models = {
               generateContent: mockGenerateContent,
@@ -144,7 +144,7 @@ describe("GoogleProvider", () => {
         };
 
         const mockGenerateContent = vi.fn().mockResolvedValue(mockResponse);
-        vi.mocked(GoogleGenAI).mockImplementation(
+        vi.mocked(GoogleClient).mockImplementation(
           class {
             models = {
               generateContent: mockGenerateContent,
@@ -167,7 +167,7 @@ describe("GoogleProvider", () => {
         };
 
         const mockGenerateContent = vi.fn().mockResolvedValue(mockResponse);
-        vi.mocked(GoogleGenAI).mockImplementation(
+        vi.mocked(GoogleClient).mockImplementation(
           class {
             models = {
               generateContent: mockGenerateContent,
@@ -191,7 +191,7 @@ describe("GoogleProvider", () => {
         };
 
         const mockGenerateContent = vi.fn().mockResolvedValue(mockResponse);
-        vi.mocked(GoogleGenAI).mockImplementation(
+        vi.mocked(GoogleClient).mockImplementation(
           class {
             models = {
               generateContent: mockGenerateContent,
@@ -218,7 +218,7 @@ describe("GoogleProvider", () => {
         };
 
         const mockGenerateContent = vi.fn().mockResolvedValue(mockResponse);
-        vi.mocked(GoogleGenAI).mockImplementation(
+        vi.mocked(GoogleClient).mockImplementation(
           class {
             models = {
               generateContent: mockGenerateContent,
@@ -245,7 +245,7 @@ describe("GoogleProvider", () => {
         };
 
         const mockGenerateContent = vi.fn().mockResolvedValue(mockResponse);
-        vi.mocked(GoogleGenAI).mockImplementation(
+        vi.mocked(GoogleClient).mockImplementation(
           class {
             models = {
               generateContent: mockGenerateContent,

--- a/packages/llm/src/providers/google/__tests__/client.hot.spec.ts
+++ b/packages/llm/src/providers/google/__tests__/client.hot.spec.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import { PROVIDER } from "../../../constants.js";
+import { GoogleClient } from "../client.js";
+import { GoogleProvider } from "../GoogleProvider.class.js";
+
+//
+//
+// Hot tests
+//
+// Live tests against the real Gemini API. Skipped unless GEMINI_API_KEY is
+// set, so CI stays green and `npm test` runs them automatically with a key.
+//
+//   GEMINI_API_KEY=... npm run test -w packages/llm
+//
+
+const apiKey = process.env.GEMINI_API_KEY;
+const MODEL = PROVIDER.GOOGLE.MODEL.DEFAULT;
+const TIMEOUT = 60_000;
+
+describe.skipIf(!apiKey)("GoogleClient (hot)", () => {
+  describe("generateContent", () => {
+    it(
+      "returns text from the live endpoint",
+      async () => {
+        const client = new GoogleClient({ apiKey: apiKey! });
+        const response = await client.models.generateContent({
+          model: MODEL,
+          contents: [
+            {
+              role: "user",
+              parts: [{ text: "Reply with the single word: pong" }],
+            },
+          ],
+        });
+        expect((response.text ?? "").toLowerCase()).toContain("pong");
+      },
+      TIMEOUT,
+    );
+  });
+
+  describe("generateContentStream", () => {
+    it(
+      "streams text chunks",
+      async () => {
+        const client = new GoogleClient({ apiKey: apiKey! });
+        const stream = await client.models.generateContentStream({
+          model: MODEL,
+          contents: [
+            { role: "user", parts: [{ text: "Count: one two three" }] },
+          ],
+        });
+
+        let text = "";
+        for await (const chunk of stream) {
+          const part = chunk.candidates?.[0]?.content?.parts?.[0];
+          if (part?.text) text += part.text;
+        }
+        expect(text.length).toBeGreaterThan(0);
+      },
+      TIMEOUT,
+    );
+  });
+
+  describe("GoogleProvider.operate", () => {
+    it(
+      "completes a text turn end-to-end",
+      async () => {
+        const provider = new GoogleProvider(MODEL, { apiKey: apiKey! });
+        const response = await provider.operate(
+          "Reply with the single word: pong",
+        );
+        expect(String(response.content).toLowerCase()).toContain("pong");
+      },
+      TIMEOUT,
+    );
+
+    it(
+      "returns native structured output",
+      async () => {
+        const provider = new GoogleProvider(MODEL, { apiKey: apiKey! });
+        const response = await provider.operate("Give the capital of France.", {
+          format: { capital: String },
+        });
+        expect(response.content).toMatchObject({ capital: expect.any(String) });
+      },
+      TIMEOUT,
+    );
+  });
+});

--- a/packages/llm/src/providers/google/__tests__/client.spec.ts
+++ b/packages/llm/src/providers/google/__tests__/client.spec.ts
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { GoogleClient, GoogleHttpError } from "../client.js";
+
+//
+//
+// Helpers
+//
+
+function jsonResponse(
+  body: unknown,
+  { ok = true, status = 200 } = {},
+): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+function sseResponse(text: string): Response {
+  const bytes = new TextEncoder().encode(text);
+  let sent = false;
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (sent) {
+        controller.close();
+        return;
+      }
+      controller.enqueue(bytes);
+      sent = true;
+    },
+  });
+  return { ok: true, status: 200, body } as unknown as Response;
+}
+
+//
+//
+// Tests
+//
+
+describe("GoogleClient", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("models.generateContent", () => {
+    it("POSTs to generateContent with the api-key header and REST body", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        jsonResponse({
+          candidates: [{ content: { parts: [{ text: "hi" }] } }],
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new GoogleClient({ apiKey: "k" });
+      const response = await client.models.generateContent({
+        model: "gemini-2.5-flash",
+        contents: [{ role: "user", parts: [{ text: "hello" }] }],
+        config: {
+          systemInstruction: "be brief",
+          temperature: 0.2,
+          responseMimeType: "application/json",
+        },
+      });
+
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe(
+        "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent",
+      );
+      expect(init.headers["x-goog-api-key"]).toBe("k");
+
+      const sent = JSON.parse(init.body);
+      // systemInstruction (string) -> Content; generation params -> generationConfig
+      expect(sent.systemInstruction).toEqual({ parts: [{ text: "be brief" }] });
+      expect(sent.generationConfig).toEqual({
+        temperature: 0.2,
+        responseMimeType: "application/json",
+      });
+      expect(sent.contents).toHaveLength(1);
+
+      // `.text` convenience getter is synthesized from candidate parts
+      expect(response.text).toBe("hi");
+    });
+
+    it("throws GoogleHttpError carrying status on non-2xx", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(
+          jsonResponse(
+            { error: { message: "bad key" } },
+            { ok: false, status: 403 },
+          ),
+        );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new GoogleClient({ apiKey: "k" });
+      await expect(
+        client.models.generateContent({ model: "m", contents: [] }),
+      ).rejects.toMatchObject({ status: 403, code: 403, message: "bad key" });
+      await expect(
+        client.models.generateContent({ model: "m", contents: [] }),
+      ).rejects.toBeInstanceOf(GoogleHttpError);
+    });
+  });
+
+  describe("models.generateContentStream", () => {
+    it("hits streamGenerateContent?alt=sse and yields decoded chunks", async () => {
+      const sse =
+        'data: {"candidates":[{"content":{"parts":[{"text":"one"}]}}]}\n\n' +
+        'data: {"candidates":[{"content":{"parts":[{"text":"two"}]}}],"usageMetadata":{"promptTokenCount":1}}\n\n';
+      const fetchMock = vi.fn().mockResolvedValue(sseResponse(sse));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new GoogleClient({ apiKey: "k" });
+      const stream = await client.models.generateContentStream({
+        model: "gemini-2.5-flash",
+        contents: [{ role: "user", parts: [{ text: "hi" }] }],
+      });
+
+      const chunks = [];
+      for await (const chunk of stream) chunks.push(chunk);
+
+      expect(chunks).toHaveLength(2);
+      const [url] = fetchMock.mock.calls[0];
+      expect(url).toContain(":streamGenerateContent?alt=sse");
+    });
+  });
+});

--- a/packages/llm/src/providers/google/client.ts
+++ b/packages/llm/src/providers/google/client.ts
@@ -1,0 +1,209 @@
+import { JsonObject } from "@jaypie/types";
+
+import { parseSseStream } from "../../util/sse.js";
+import {
+  GeminiContent,
+  GeminiGenerateContentConfig,
+  GeminiRawResponse,
+} from "./types.js";
+
+//
+//
+// Constants
+//
+
+const GOOGLE_BASE_URL = "https://generativelanguage.googleapis.com/v1beta";
+
+// Config keys the REST API expects at the top level of the request body. Every
+// other key in the SDK-style `config` object belongs under `generationConfig`.
+const TOP_LEVEL_CONFIG_KEYS = new Set([
+  "systemInstruction",
+  "tools",
+  "toolConfig",
+  "safetySettings",
+  "cachedContent",
+]);
+
+//
+//
+// Types
+//
+
+export interface GoogleClientOptions {
+  apiKey: string;
+  baseURL?: string;
+}
+
+export interface GenerateContentParams {
+  model: string;
+  contents: GeminiContent[];
+  config?: GeminiGenerateContentConfig;
+}
+
+export interface GenerateContentOptions {
+  signal?: AbortSignal;
+}
+
+/**
+ * HTTP error carrying the upstream status and parsed API message. The
+ * GoogleAdapter classifies errors by reading `.status` / `.code` and
+ * `.message`, so this shape keeps `classifyError` working unchanged after
+ * dropping the SDK.
+ */
+export class GoogleHttpError extends Error {
+  readonly status: number;
+  readonly code: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "GoogleHttpError";
+    this.status = status;
+    this.code = status;
+  }
+}
+
+//
+//
+// Helpers
+//
+
+/**
+ * Translate the SDK-style `{ model, contents, config }` request into the REST
+ * `generateContent` body. `systemInstruction` (a string) becomes a Content;
+ * top-level config keys pass through; all remaining config keys (temperature,
+ * responseMimeType, responseSchema, responseJsonSchema, ...) move under
+ * `generationConfig`.
+ */
+function toRestBody(params: GenerateContentParams): JsonObject {
+  const body: JsonObject = {
+    contents: params.contents as unknown as JsonObject[],
+  };
+  const config = params.config;
+  if (!config) return body;
+
+  const generationConfig: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(config)) {
+    if (value === undefined) continue;
+    if (key === "systemInstruction") {
+      body.systemInstruction =
+        typeof value === "string"
+          ? { parts: [{ text: value }] }
+          : (value as JsonObject);
+    } else if (TOP_LEVEL_CONFIG_KEYS.has(key)) {
+      body[key] = value as JsonObject;
+    } else {
+      generationConfig[key] = value;
+    }
+  }
+  if (Object.keys(generationConfig).length > 0) {
+    body.generationConfig = generationConfig as JsonObject;
+  }
+  return body;
+}
+
+/**
+ * Concatenate the non-thought text parts of the first candidate, matching the
+ * SDK's `response.text` convenience getter (consumed by `GoogleProvider.send`).
+ */
+function responseText(response: GeminiRawResponse): string | undefined {
+  const parts = response.candidates?.[0]?.content?.parts;
+  if (!parts) return undefined;
+  const text = parts
+    .filter((part) => part.text && !part.thought)
+    .map((part) => part.text)
+    .join("");
+  return text.length > 0 ? text : undefined;
+}
+
+//
+//
+// Main
+//
+
+/**
+ * Minimal `fetch`-based client for Google's Generative Language (Gemini) REST
+ * API. Replaces `@google/genai` — the adapter only needs `generateContent`
+ * (streaming and non-streaming), an api-key header, and HTTP error surfacing.
+ * Exposes a `models` facade mirroring the SDK so the adapter call sites are
+ * unchanged.
+ */
+export class GoogleClient {
+  private readonly apiKey: string;
+  private readonly baseURL: string;
+  readonly models: {
+    generateContent: (
+      params: GenerateContentParams,
+      options?: GenerateContentOptions,
+    ) => Promise<GeminiRawResponse>;
+    generateContentStream: (
+      params: GenerateContentParams,
+      options?: GenerateContentOptions,
+    ) => Promise<AsyncIterable<GeminiRawResponse>>;
+  };
+
+  constructor({ apiKey, baseURL = GOOGLE_BASE_URL }: GoogleClientOptions) {
+    this.apiKey = apiKey;
+    this.baseURL = baseURL;
+    this.models = {
+      generateContent: (params, options) =>
+        this.generateContent(params, options),
+      generateContentStream: (params, options) =>
+        this.generateContentStream(params, options),
+    };
+  }
+
+  private headers(): Record<string, string> {
+    return {
+      "Content-Type": "application/json",
+      "x-goog-api-key": this.apiKey,
+    };
+  }
+
+  private async toError(response: Response): Promise<GoogleHttpError> {
+    let message = `Google request failed with status ${response.status}`;
+    try {
+      const body = (await response.json()) as { error?: { message?: string } };
+      if (body?.error?.message) message = body.error.message;
+    } catch {
+      // Non-JSON error body; keep the status-based message.
+    }
+    return new GoogleHttpError(response.status, message);
+  }
+
+  private async generateContent(
+    params: GenerateContentParams,
+    { signal }: GenerateContentOptions = {},
+  ): Promise<GeminiRawResponse> {
+    const url = `${this.baseURL}/models/${params.model}:generateContent`;
+    const response = await fetch(url, {
+      method: "POST",
+      headers: this.headers(),
+      body: JSON.stringify(toRestBody(params)),
+      signal,
+    });
+
+    if (!response.ok) throw await this.toError(response);
+
+    const json = (await response.json()) as GeminiRawResponse;
+    json.text = responseText(json);
+    return json;
+  }
+
+  private async generateContentStream(
+    params: GenerateContentParams,
+    { signal }: GenerateContentOptions = {},
+  ): Promise<AsyncIterable<GeminiRawResponse>> {
+    const url = `${this.baseURL}/models/${params.model}:streamGenerateContent?alt=sse`;
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { ...this.headers(), Accept: "text/event-stream" },
+      body: JSON.stringify(toRestBody(params)),
+      signal,
+    });
+
+    if (!response.ok) throw await this.toError(response);
+    if (!response.body) return (async function* () {})();
+
+    return parseSseStream(response.body) as AsyncIterable<GeminiRawResponse>;
+  }
+}

--- a/packages/llm/src/providers/google/utils.ts
+++ b/packages/llm/src/providers/google/utils.ts
@@ -2,23 +2,8 @@ import { getEnvSecret } from "@jaypie/aws";
 import { ConfigurationError } from "@jaypie/errors";
 import { JAYPIE, placeholders as replacePlaceholders } from "@jaypie/kit";
 import { createLogger, log as defaultLog } from "@jaypie/logger";
-import type { GoogleGenAI } from "@google/genai";
 import { LlmMessageOptions } from "../../types/LlmProvider.interface.js";
-
-// SDK loader with caching
-let cachedSdk: typeof import("@google/genai") | null = null;
-
-export async function loadSdk(): Promise<typeof import("@google/genai")> {
-  if (cachedSdk) return cachedSdk;
-  try {
-    cachedSdk = await import("@google/genai");
-    return cachedSdk;
-  } catch {
-    throw new ConfigurationError(
-      "@google/genai is required but not installed. Run: npm install @google/genai",
-    );
-  }
-}
+import { GoogleClient } from "./client.js";
 
 // Logger
 export const getLogger = (): ReturnType<typeof createLogger> =>
@@ -29,7 +14,7 @@ export async function initializeClient({
   apiKey,
 }: {
   apiKey?: string;
-} = {}): Promise<GoogleGenAI> {
+} = {}): Promise<GoogleClient> {
   const logger = getLogger();
   const resolvedApiKey = apiKey || (await getEnvSecret("GEMINI_API_KEY"));
 
@@ -39,8 +24,7 @@ export async function initializeClient({
     );
   }
 
-  const sdk = await loadSdk();
-  const client = new sdk.GoogleGenAI({ apiKey: resolvedApiKey });
+  const client = new GoogleClient({ apiKey: resolvedApiKey });
   logger.trace("Initialized Gemini client");
   return client;
 }

--- a/packages/llm/src/providers/openai/OpenAiProvider.class.ts
+++ b/packages/llm/src/providers/openai/OpenAiProvider.class.ts
@@ -1,5 +1,4 @@
 import { JsonObject } from "@jaypie/types";
-import { OpenAI } from "openai";
 import { PROVIDER } from "../../constants.js";
 import {
   createOperateLoop,
@@ -18,6 +17,7 @@ import {
   LlmHistoryItem,
 } from "../../types/LlmProvider.interface.js";
 import { LlmStreamChunk } from "../../types/LlmStreamChunk.interface.js";
+import { OpenAIClient } from "./client.js";
 import {
   createStructuredCompletion,
   createTextCompletion,
@@ -28,7 +28,7 @@ import {
 
 export class OpenAiProvider implements LlmProvider {
   private model: string;
-  private _client?: OpenAI;
+  private _client?: OpenAIClient;
   private _operateLoop?: OperateLoop;
   private _streamLoop?: StreamLoop;
   private apiKey?: string;
@@ -43,7 +43,7 @@ export class OpenAiProvider implements LlmProvider {
     this.apiKey = apiKey;
   }
 
-  private async getClient(): Promise<OpenAI> {
+  private async getClient(): Promise<OpenAIClient> {
     if (this._client) {
       return this._client;
     }

--- a/packages/llm/src/providers/openai/__tests__/OpenAiProvider.spec.ts
+++ b/packages/llm/src/providers/openai/__tests__/OpenAiProvider.spec.ts
@@ -1,7 +1,7 @@
 import { getEnvSecret } from "@jaypie/aws";
-import { OpenAI } from "openai";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { z } from "zod/v4";
+import { OpenAIClient } from "../client.js";
 import { OpenAiProvider } from "../OpenAiProvider.class";
 import {
   LlmHistoryItem,
@@ -12,7 +12,7 @@ import {
 } from "../../../types/LlmProvider.interface.js";
 // Mock the operate module
 vi.mock("../operate.js");
-vi.mock("openai");
+vi.mock("../client.js");
 
 // Mock the OperateLoop for conversation history tests
 vi.mock("../../../operate/index.js", async (importOriginal) => {
@@ -36,7 +36,7 @@ vi.mock("@jaypie/aws", async () => {
 
 describe("OpenAiProvider", () => {
   beforeEach(() => {
-    vi.mocked(OpenAI).mockImplementation(
+    vi.mocked(OpenAIClient).mockImplementation(
       class {
         chat = {
           completions: {
@@ -82,7 +82,7 @@ describe("OpenAiProvider", () => {
       };
 
       const mockCreate = vi.fn().mockResolvedValue(mockResponse);
-      vi.mocked(OpenAI).mockImplementation(
+      vi.mocked(OpenAIClient).mockImplementation(
         class {
           chat = {
             completions: {
@@ -122,7 +122,7 @@ describe("OpenAiProvider", () => {
         };
 
         const mockParse = vi.fn().mockResolvedValue(mockResponse);
-        vi.mocked(OpenAI).mockImplementation(
+        vi.mocked(OpenAIClient).mockImplementation(
           class {
             chat = {
               completions: {
@@ -166,7 +166,7 @@ describe("OpenAiProvider", () => {
         };
 
         const mockParse = vi.fn().mockResolvedValue(mockResponse);
-        vi.mocked(OpenAI).mockImplementation(
+        vi.mocked(OpenAIClient).mockImplementation(
           class {
             chat = {
               completions: {
@@ -201,7 +201,7 @@ describe("OpenAiProvider", () => {
         };
 
         const mockCreate = vi.fn().mockResolvedValue(mockResponse);
-        vi.mocked(OpenAI).mockImplementation(
+        vi.mocked(OpenAIClient).mockImplementation(
           class {
             chat = {
               completions: {
@@ -232,7 +232,7 @@ describe("OpenAiProvider", () => {
         };
 
         const mockCreate = vi.fn().mockResolvedValue(mockResponse);
-        vi.mocked(OpenAI).mockImplementation(
+        vi.mocked(OpenAIClient).mockImplementation(
           class {
             chat = {
               completions: {
@@ -264,7 +264,7 @@ describe("OpenAiProvider", () => {
         };
 
         const mockCreate = vi.fn().mockResolvedValue(mockResponse);
-        vi.mocked(OpenAI).mockImplementation(
+        vi.mocked(OpenAIClient).mockImplementation(
           class {
             chat = {
               completions: {
@@ -292,7 +292,7 @@ describe("OpenAiProvider", () => {
         };
 
         const mockCreate = vi.fn().mockResolvedValue(mockResponse);
-        vi.mocked(OpenAI).mockImplementation(
+        vi.mocked(OpenAIClient).mockImplementation(
           class {
             chat = {
               completions: {
@@ -321,7 +321,7 @@ describe("OpenAiProvider", () => {
         };
 
         const mockCreate = vi.fn().mockResolvedValue(mockResponse);
-        vi.mocked(OpenAI).mockImplementation(
+        vi.mocked(OpenAIClient).mockImplementation(
           class {
             chat = {
               completions: {

--- a/packages/llm/src/providers/openai/__tests__/client.hot.spec.ts
+++ b/packages/llm/src/providers/openai/__tests__/client.hot.spec.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import { PROVIDER } from "../../../constants.js";
+import { OpenAIClient } from "../client.js";
+import { OpenAiProvider } from "../OpenAiProvider.class.js";
+
+//
+//
+// Hot tests
+//
+// Live tests against the real OpenAI API. Skipped unless OPENAI_API_KEY is set,
+// so CI stays green and `npm test` runs them automatically with a key.
+//
+//   OPENAI_API_KEY=sk-... npm run test -w packages/llm
+//
+
+const apiKey = process.env.OPENAI_API_KEY;
+const MODEL = PROVIDER.OPENAI.MODEL.TINY;
+const TIMEOUT = 60_000;
+
+describe.skipIf(!apiKey)("OpenAIClient (hot)", () => {
+  describe("chat.completions.create", () => {
+    it(
+      "returns assistant text from the live endpoint",
+      async () => {
+        const client = new OpenAIClient({ apiKey: apiKey! });
+        const completion = (await client.chat.completions.create({
+          model: MODEL,
+          messages: [
+            { role: "user", content: "Reply with the single word: pong" },
+          ],
+        })) as { choices: Array<{ message: { content: string } }> };
+        const text = completion.choices[0]?.message?.content ?? "";
+        expect(text.toLowerCase()).toContain("pong");
+      },
+      TIMEOUT,
+    );
+  });
+
+  describe("responses.create", () => {
+    it(
+      "streams text deltas",
+      async () => {
+        const client = new OpenAIClient({ apiKey: apiKey! });
+        const stream = await client.responses.create({
+          model: MODEL,
+          input: "Count: one two three",
+          stream: true,
+        });
+
+        let text = "";
+        for await (const event of stream) {
+          if (event.type === "response.output_text.delta") {
+            text += (event as { delta?: string }).delta ?? "";
+          }
+        }
+        expect(text.length).toBeGreaterThan(0);
+      },
+      TIMEOUT,
+    );
+  });
+
+  describe("OpenAiProvider.operate", () => {
+    it(
+      "completes a text turn end-to-end",
+      async () => {
+        const provider = new OpenAiProvider(MODEL, { apiKey: apiKey! });
+        const response = await provider.operate(
+          "Reply with the single word: pong",
+        );
+        expect(String(response.content).toLowerCase()).toContain("pong");
+      },
+      TIMEOUT,
+    );
+
+    it(
+      "returns structured output via native format",
+      async () => {
+        const provider = new OpenAiProvider(MODEL, { apiKey: apiKey! });
+        const response = await provider.operate("Give the capital of France.", {
+          format: { capital: String },
+        });
+        expect(response.content).toMatchObject({ capital: expect.any(String) });
+      },
+      TIMEOUT,
+    );
+  });
+});

--- a/packages/llm/src/providers/openai/client.ts
+++ b/packages/llm/src/providers/openai/client.ts
@@ -1,0 +1,245 @@
+import { JsonObject } from "@jaypie/types";
+
+import { parseSseStream } from "../../util/sse.js";
+
+//
+//
+// Constants
+//
+
+const OPENAI_BASE_URL = "https://api.openai.com/v1";
+
+//
+//
+// Errors
+//
+// The adapter's `classifyError` uses `instanceof` against these classes, so the
+// client throws them directly. Status → class mapping mirrors the SDK; the
+// non-HTTP classes (connection/abort) are thrown when `fetch` itself rejects.
+//
+
+export class OpenAiApiError extends Error {
+  readonly status: number;
+  readonly error?: { message?: string };
+
+  constructor(status: number, message: string, error?: { message?: string }) {
+    super(message);
+    this.name = this.constructor.name;
+    this.status = status;
+    this.error = error;
+  }
+}
+
+export class BadRequestError extends OpenAiApiError {}
+export class AuthenticationError extends OpenAiApiError {}
+export class PermissionDeniedError extends OpenAiApiError {}
+export class NotFoundError extends OpenAiApiError {}
+export class ConflictError extends OpenAiApiError {}
+export class UnprocessableEntityError extends OpenAiApiError {}
+export class RateLimitError extends OpenAiApiError {}
+export class InternalServerError extends OpenAiApiError {}
+export class APIConnectionError extends OpenAiApiError {}
+export class APIConnectionTimeoutError extends APIConnectionError {}
+export class APIUserAbortError extends OpenAiApiError {}
+
+function errorForStatus(
+  status: number,
+  message: string,
+  error?: { message?: string },
+): OpenAiApiError {
+  if (status === 400) return new BadRequestError(status, message, error);
+  if (status === 401) return new AuthenticationError(status, message, error);
+  if (status === 403) return new PermissionDeniedError(status, message, error);
+  if (status === 404) return new NotFoundError(status, message, error);
+  if (status === 409) return new ConflictError(status, message, error);
+  if (status === 422) {
+    return new UnprocessableEntityError(status, message, error);
+  }
+  if (status === 429) return new RateLimitError(status, message, error);
+  if (status >= 500) return new InternalServerError(status, message, error);
+  return new OpenAiApiError(status, message, error);
+}
+
+//
+//
+// Types
+//
+
+export interface OpenAIClientOptions {
+  apiKey: string;
+  baseURL?: string;
+}
+
+export interface RequestOptions {
+  signal?: AbortSignal;
+}
+
+interface ResponsesApi {
+  create(
+    params: Record<string, unknown> & { stream: true },
+    options?: RequestOptions,
+  ): Promise<AsyncIterable<Record<string, unknown>>>;
+  create(
+    params: Record<string, unknown>,
+    options?: RequestOptions,
+  ): Promise<JsonObject>;
+}
+
+interface ChatCompletionsApi {
+  create(
+    params: Record<string, unknown>,
+    options?: RequestOptions,
+  ): Promise<JsonObject>;
+  parse(
+    params: Record<string, unknown>,
+    options?: RequestOptions,
+  ): Promise<JsonObject>;
+}
+
+//
+//
+// Main
+//
+
+/**
+ * Minimal `fetch`-based client for the OpenAI API. Replaces the `openai` SDK —
+ * the adapters and provider utilities only need the Responses API
+ * (`/responses`, streaming and non-streaming) for `operate`/`stream` and the
+ * Chat Completions API (`/chat/completions`, plus a `parse` helper for
+ * structured output) for `send`. Mirrors the SDK's `responses.create` and
+ * `chat.completions.create` / `chat.completions.parse` surface so call sites are
+ * unchanged. Also serves xAI via a custom `baseURL`.
+ */
+export class OpenAIClient {
+  private readonly apiKey: string;
+  private readonly baseURL: string;
+  readonly responses: ResponsesApi;
+  readonly chat: { completions: ChatCompletionsApi };
+
+  constructor({ apiKey, baseURL = OPENAI_BASE_URL }: OpenAIClientOptions) {
+    this.apiKey = apiKey;
+    this.baseURL = baseURL;
+    this.responses = {
+      create: ((params: Record<string, unknown>, options?: RequestOptions) =>
+        params.stream
+          ? this.createResponseStream(params, options)
+          : this.createResponse(params, options)) as ResponsesApi["create"],
+    };
+    this.chat = {
+      completions: {
+        create: (params, options) =>
+          this.chatCompletion(params, options, { parse: false }),
+        parse: (params, options) =>
+          this.chatCompletion(params, options, { parse: true }),
+      },
+    };
+  }
+
+  private headers(extra?: Record<string, string>): Record<string, string> {
+    return {
+      Authorization: `Bearer ${this.apiKey}`,
+      "Content-Type": "application/json",
+      ...extra,
+    };
+  }
+
+  private async post(
+    path: string,
+    body: Record<string, unknown>,
+    { signal }: RequestOptions = {},
+    { stream = false }: { stream?: boolean } = {},
+  ): Promise<Response> {
+    let response: Response;
+    try {
+      response = await fetch(`${this.baseURL}${path}`, {
+        method: "POST",
+        headers: this.headers(
+          stream ? { Accept: "text/event-stream" } : undefined,
+        ),
+        body: JSON.stringify(body),
+        signal,
+      });
+    } catch (cause) {
+      if (signal?.aborted) {
+        throw new APIUserAbortError(0, "Request was aborted");
+      }
+      const message =
+        cause instanceof Error ? cause.message : "Connection error";
+      const error = new APIConnectionError(0, message);
+      (error as { cause?: unknown }).cause = cause;
+      throw error;
+    }
+    if (!response.ok) throw await this.toError(response);
+    return response;
+  }
+
+  private async toError(response: Response): Promise<OpenAiApiError> {
+    let message = `OpenAI request failed with status ${response.status}`;
+    let error: { message?: string } | undefined;
+    try {
+      const body = (await response.json()) as { error?: { message?: string } };
+      if (body?.error?.message) {
+        message = body.error.message;
+        error = body.error;
+      }
+    } catch {
+      // Non-JSON error body; keep the status-based message.
+    }
+    return errorForStatus(response.status, message, error);
+  }
+
+  private async createResponse(
+    params: Record<string, unknown>,
+    options?: RequestOptions,
+  ): Promise<JsonObject> {
+    const response = await this.post("/responses", params, options);
+    return (await response.json()) as JsonObject;
+  }
+
+  private async createResponseStream(
+    params: Record<string, unknown>,
+    options?: RequestOptions,
+  ): Promise<AsyncIterable<Record<string, unknown>>> {
+    const response = await this.post("/responses", params, options, {
+      stream: true,
+    });
+    if (!response.body) return (async function* () {})();
+    // The Responses API streams typed events and does not emit a `[DONE]`
+    // sentinel; the empty default sentinel never matches, so the stream ends
+    // when the connection closes.
+    return parseSseStream(response.body);
+  }
+
+  private async chatCompletion(
+    params: Record<string, unknown>,
+    options: RequestOptions | undefined,
+    { parse }: { parse: boolean },
+  ): Promise<JsonObject> {
+    const response = await this.post("/chat/completions", params, options);
+    const json = (await response.json()) as JsonObject;
+    // `chat.completions.parse` surfaces parsed JSON on each message; replicate
+    // the SDK by JSON-parsing the assistant content into `message.parsed`.
+    if (parse) {
+      const choices = json.choices as
+        | Array<Record<string, unknown>>
+        | undefined;
+      if (Array.isArray(choices)) {
+        for (const choice of choices) {
+          const message = choice.message as Record<string, unknown> | undefined;
+          if (
+            message &&
+            typeof message.content === "string" &&
+            !message.refusal
+          ) {
+            try {
+              message.parsed = JSON.parse(message.content);
+            } catch {
+              message.parsed = null;
+            }
+          }
+        }
+      }
+    }
+    return json;
+  }
+}

--- a/packages/llm/src/providers/openai/responseFormat.ts
+++ b/packages/llm/src/providers/openai/responseFormat.ts
@@ -1,0 +1,41 @@
+import { JsonObject } from "@jaypie/types";
+import { z } from "zod/v4";
+
+//
+//
+// Types
+//
+
+export interface JsonSchemaResponseFormat {
+  type: "json_schema";
+  json_schema: {
+    name: string;
+    strict: boolean;
+    schema: JsonObject;
+  };
+}
+
+//
+//
+// Main
+//
+
+/**
+ * Local replacement for `openai/helpers/zod`'s `zodResponseFormat`. Builds the
+ * `response_format` payload OpenAI's Chat Completions / Responses APIs expect
+ * from a Zod schema. The SDK always emits `strict: true`; callers re-derive or
+ * sanitize `schema` as needed (e.g. forcing `additionalProperties: false`).
+ */
+export function zodResponseFormat(
+  schema: z.ZodType,
+  name: string,
+): JsonSchemaResponseFormat {
+  return {
+    type: "json_schema",
+    json_schema: {
+      name,
+      strict: true,
+      schema: z.toJSONSchema(schema) as JsonObject,
+    },
+  };
+}

--- a/packages/llm/src/providers/openai/utils.ts
+++ b/packages/llm/src/providers/openai/utils.ts
@@ -3,11 +3,11 @@ import { ConfigurationError } from "@jaypie/errors";
 import { JAYPIE, placeholders as replacePlaceholders } from "@jaypie/kit";
 import { createLogger, log as defaultLog } from "@jaypie/logger";
 import { JsonObject, NaturalSchema } from "@jaypie/types";
-import { OpenAI } from "openai";
-import { zodResponseFormat } from "openai/helpers/zod";
 import { z } from "zod/v4";
 import { LlmMessageOptions } from "../../types/LlmProvider.interface.js";
 import { naturalZodSchema } from "../../util";
+import { OpenAIClient } from "./client.js";
+import { zodResponseFormat } from "./responseFormat.js";
 
 // Logger
 export const getLogger = (): ReturnType<typeof createLogger> =>
@@ -18,7 +18,7 @@ export async function initializeClient({
   apiKey,
 }: {
   apiKey?: string;
-} = {}): Promise<OpenAI> {
+} = {}): Promise<OpenAIClient> {
   const logger = getLogger();
   const resolvedApiKey = apiKey || (await getEnvSecret("OPENAI_API_KEY"));
 
@@ -28,7 +28,7 @@ export async function initializeClient({
     );
   }
 
-  const client = new OpenAI({ apiKey: resolvedApiKey });
+  const client = new OpenAIClient({ apiKey: resolvedApiKey });
   logger.trace("Initialized OpenAI client");
   return client;
 }
@@ -91,7 +91,7 @@ export function prepareMessages(
 
 // Completion requests
 export async function createStructuredCompletion(
-  client: OpenAI,
+  client: OpenAIClient,
   {
     messages,
     responseSchema,
@@ -128,20 +128,20 @@ export async function createStructuredCompletion(
     });
     checks.shift();
   }
-  responseFormat.json_schema.schema = jsonSchema;
+  responseFormat.json_schema.schema = jsonSchema as JsonObject;
 
-  const completion = await client.chat.completions.parse({
+  const completion = (await client.chat.completions.parse({
     messages,
     model,
     response_format: responseFormat,
-  });
+  })) as { choices: Array<{ message: { parsed: JsonObject } }> };
 
   logger.var({ assistantReply: completion.choices[0].message.parsed });
   return completion.choices[0].message.parsed;
 }
 
 export async function createTextCompletion(
-  client: OpenAI,
+  client: OpenAIClient,
   {
     messages,
     model,
@@ -153,14 +153,14 @@ export async function createTextCompletion(
   const logger = getLogger();
   logger.trace("Using text output (unstructured)");
 
-  const completion = await client.chat.completions.create({
+  const completion = (await client.chat.completions.create({
     messages,
     model,
-  });
+  })) as { choices?: Array<{ message?: { content?: string } }> };
 
   logger.trace(
-    `Assistant reply: ${completion.choices[0]?.message?.content?.length} characters`,
+    `Assistant reply: ${completion.choices?.[0]?.message?.content?.length} characters`,
   );
 
-  return completion.choices[0]?.message?.content || "";
+  return completion.choices?.[0]?.message?.content || "";
 }

--- a/packages/llm/src/providers/openrouter/OpenRouterProvider.class.ts
+++ b/packages/llm/src/providers/openrouter/OpenRouterProvider.class.ts
@@ -1,5 +1,5 @@
 import { JsonObject } from "@jaypie/types";
-import type { OpenRouter } from "@openrouter/sdk";
+import type { OpenRouterClient } from "./client.js";
 import {
   createOperateLoop,
   createStreamLoop,
@@ -26,7 +26,7 @@ import {
 
 export class OpenRouterProvider implements LlmProvider {
   private model: string;
-  private _client?: OpenRouter;
+  private _client?: OpenRouterClient;
   private _operateLoop?: OperateLoop;
   private _streamLoop?: StreamLoop;
   private apiKey?: string;
@@ -41,7 +41,7 @@ export class OpenRouterProvider implements LlmProvider {
     this.apiKey = apiKey;
   }
 
-  private async getClient(): Promise<OpenRouter> {
+  private async getClient(): Promise<OpenRouterClient> {
     if (this._client) {
       return this._client;
     }
@@ -84,17 +84,16 @@ export class OpenRouterProvider implements LlmProvider {
     const messages = prepareMessages(message, options);
     const modelToUse = options?.model || this.model;
 
-    // Build the request. The SDK (>=0.13) wraps the payload in `chatRequest`.
-    const response = await client.chat.send({
-      chatRequest: {
-        model: modelToUse,
-        messages: messages as Parameters<
-          typeof client.chat.send
-        >[0]["chatRequest"]["messages"],
-      },
+    // OpenAI-compatible Chat Completions body; messages are already wire-shaped.
+    const response = await client.chatCompletion({
+      model: modelToUse,
+      messages,
     });
 
-    const rawContent = response.choices?.[0]?.message?.content;
+    const choices = response.choices as
+      | Array<{ message?: { content?: unknown } }>
+      | undefined;
+    const rawContent = choices?.[0]?.message?.content;
     // Extract text content - content could be string or array of content items
     const content =
       typeof rawContent === "string"

--- a/packages/llm/src/providers/openrouter/OpenRouterProvider.class.ts
+++ b/packages/llm/src/providers/openrouter/OpenRouterProvider.class.ts
@@ -84,10 +84,14 @@ export class OpenRouterProvider implements LlmProvider {
     const messages = prepareMessages(message, options);
     const modelToUse = options?.model || this.model;
 
-    // Build the request
+    // Build the request. The SDK (>=0.13) wraps the payload in `chatRequest`.
     const response = await client.chat.send({
-      model: modelToUse,
-      messages: messages as Parameters<typeof client.chat.send>[0]["messages"],
+      chatRequest: {
+        model: modelToUse,
+        messages: messages as Parameters<
+          typeof client.chat.send
+        >[0]["chatRequest"]["messages"],
+      },
     });
 
     const rawContent = response.choices?.[0]?.message?.content;

--- a/packages/llm/src/providers/openrouter/__tests__/client.hot.spec.ts
+++ b/packages/llm/src/providers/openrouter/__tests__/client.hot.spec.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+
+import { PROVIDER } from "../../../constants.js";
+import { OpenRouterClient } from "../client.js";
+import { OpenRouterProvider } from "../OpenRouterProvider.class.js";
+
+//
+//
+// Hot tests
+//
+// Live tests against the real OpenRouter API. Skipped unless
+// OPENROUTER_API_KEY is set, so CI stays green and `npm test` runs them
+// automatically on machines that have a key.
+//
+//   OPENROUTER_API_KEY=sk-or-... npm run test -w packages/llm
+//
+
+const apiKey = process.env.OPENROUTER_API_KEY;
+const MODEL = PROVIDER.OPENROUTER.MODEL.TINY;
+const TIMEOUT = 60_000;
+
+describe.skipIf(!apiKey)("OpenRouterClient (hot)", () => {
+  describe("chatCompletion", () => {
+    it(
+      "returns assistant text from the live endpoint",
+      async () => {
+        const client = new OpenRouterClient({ apiKey: apiKey! });
+        const response = (await client.chatCompletion({
+          model: MODEL,
+          messages: [
+            { role: "user", content: "Reply with the single word: pong" },
+          ],
+        })) as { choices: Array<{ message: { content: string } }> };
+
+        const content = response.choices?.[0]?.message?.content ?? "";
+        expect(content.toLowerCase()).toContain("pong");
+      },
+      TIMEOUT,
+    );
+  });
+
+  describe("streamChatCompletion", () => {
+    it(
+      "streams text deltas and a usage chunk",
+      async () => {
+        const client = new OpenRouterClient({ apiKey: apiKey! });
+        let text = "";
+        let sawUsage = false;
+        for await (const chunk of client.streamChatCompletion({
+          model: MODEL,
+          messages: [{ role: "user", content: "Count: one two three" }],
+        })) {
+          const typed = chunk as {
+            choices?: Array<{ delta?: { content?: string } }>;
+            usage?: { completion_tokens?: number };
+          };
+          if (typed.choices?.[0]?.delta?.content) {
+            text += typed.choices[0].delta.content;
+          }
+          if (typed.usage) sawUsage = true;
+        }
+
+        expect(text.length).toBeGreaterThan(0);
+        expect(sawUsage).toBe(true);
+      },
+      TIMEOUT,
+    );
+  });
+
+  describe("OpenRouterProvider.operate", () => {
+    it(
+      "completes a text turn end-to-end",
+      async () => {
+        const provider = new OpenRouterProvider(MODEL, { apiKey: apiKey! });
+        const response = await provider.operate(
+          "Reply with the single word: pong",
+        );
+        expect(String(response.content).toLowerCase()).toContain("pong");
+      },
+      TIMEOUT,
+    );
+
+    it(
+      "returns structured output via native response_format",
+      async () => {
+        const provider = new OpenRouterProvider(MODEL, { apiKey: apiKey! });
+        const response = await provider.operate("Give the capital of France.", {
+          format: { capital: String },
+        });
+        expect(response.content).toMatchObject({ capital: expect.any(String) });
+      },
+      TIMEOUT,
+    );
+  });
+});

--- a/packages/llm/src/providers/openrouter/__tests__/client.spec.ts
+++ b/packages/llm/src/providers/openrouter/__tests__/client.spec.ts
@@ -1,0 +1,173 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { OpenRouterClient, OpenRouterHttpError } from "../client.js";
+
+//
+//
+// Helpers
+//
+
+function jsonResponse(
+  body: unknown,
+  { ok = true, status = 200 } = {},
+): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+/** Build a Response whose body streams the given SSE text in arbitrary slices. */
+function sseResponse(text: string, sliceAt: number[] = []): Response {
+  const encoder = new TextEncoder();
+  const bytes = encoder.encode(text);
+  const bounds = [0, ...sliceAt, bytes.length];
+  let index = 0;
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (index >= bounds.length - 1) {
+        controller.close();
+        return;
+      }
+      controller.enqueue(bytes.slice(bounds[index], bounds[index + 1]));
+      index += 1;
+    },
+  });
+  return { ok: true, status: 200, body } as unknown as Response;
+}
+
+//
+//
+// Tests
+//
+
+describe("OpenRouterClient", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("Base Cases", () => {
+    it("is a class", () => {
+      expect(OpenRouterClient).toBeTypeOf("function");
+    });
+  });
+
+  describe("chatCompletion", () => {
+    it("POSTs to the chat completions endpoint with bearer auth", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(jsonResponse({ choices: [] }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new OpenRouterClient({ apiKey: "sk-test" });
+      await client.chatCompletion({ model: "m", messages: [] });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe("https://openrouter.ai/api/v1/chat/completions");
+      expect(init.method).toBe("POST");
+      expect(init.headers.Authorization).toBe("Bearer sk-test");
+      expect(JSON.parse(init.body)).toEqual({ model: "m", messages: [] });
+    });
+
+    it("normalizes snake_case wire fields to camelCase", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        jsonResponse({
+          choices: [
+            {
+              message: {
+                role: "assistant",
+                content: null,
+                tool_calls: [
+                  {
+                    id: "c1",
+                    type: "function",
+                    function: { name: "t", arguments: "{}" },
+                  },
+                ],
+              },
+              finish_reason: "tool_calls",
+            },
+          ],
+          usage: { prompt_tokens: 3, completion_tokens: 5, total_tokens: 8 },
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new OpenRouterClient({ apiKey: "sk-test" });
+      const response = (await client.chatCompletion({
+        model: "m",
+        messages: [],
+      })) as {
+        choices: Array<{
+          message: { toolCalls: unknown[] };
+          finishReason: string;
+        }>;
+        usage: {
+          promptTokens: number;
+          completionTokens: number;
+          totalTokens: number;
+        };
+      };
+
+      expect(response.choices[0].message.toolCalls).toHaveLength(1);
+      expect(response.choices[0].finishReason).toBe("tool_calls");
+      expect(response.usage.promptTokens).toBe(3);
+      expect(response.usage.completionTokens).toBe(5);
+      expect(response.usage.totalTokens).toBe(8);
+    });
+
+    it("throws OpenRouterHttpError carrying status and message on non-2xx", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(
+          jsonResponse(
+            { error: { message: "rate limited" } },
+            { ok: false, status: 429 },
+          ),
+        );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new OpenRouterClient({ apiKey: "sk-test" });
+      await expect(
+        client.chatCompletion({ model: "m", messages: [] }),
+      ).rejects.toMatchObject({
+        status: 429,
+        statusCode: 429,
+        message: "rate limited",
+      });
+      await expect(
+        client.chatCompletion({ model: "m", messages: [] }),
+      ).rejects.toBeInstanceOf(OpenRouterHttpError);
+    });
+  });
+
+  describe("streamChatCompletion", () => {
+    it("requests usage and yields decoded SSE chunks until [DONE]", async () => {
+      const sse =
+        'data: {"choices":[{"delta":{"content":"He"}}]}\n\n' +
+        'data: {"choices":[{"delta":{"content":"llo"}}]}\n\n' +
+        'data: {"usage":{"prompt_tokens":1,"completion_tokens":2}}\n\n' +
+        "data: [DONE]\n\n";
+      // Split mid-chunk to exercise cross-read buffering.
+      const fetchMock = vi.fn().mockResolvedValue(sseResponse(sse, [20, 55]));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new OpenRouterClient({ apiKey: "sk-test" });
+      const chunks: unknown[] = [];
+      for await (const chunk of client.streamChatCompletion({
+        model: "m",
+        messages: [],
+      })) {
+        chunks.push(chunk);
+      }
+
+      expect(chunks).toHaveLength(3);
+      const init = fetchMock.mock.calls[0][1];
+      const sentBody = JSON.parse(init.body);
+      expect(sentBody.stream).toBe(true);
+      expect(sentBody.stream_options).toEqual({ include_usage: true });
+    });
+  });
+});

--- a/packages/llm/src/providers/openrouter/client.ts
+++ b/packages/llm/src/providers/openrouter/client.ts
@@ -1,13 +1,13 @@
 import { JsonObject } from "@jaypie/types";
 
+import { parseSseStream } from "../../util/sse.js";
+
 //
 //
 // Constants
 //
 
 const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
-
-const SSE_DONE = "[DONE]";
 
 //
 //
@@ -48,44 +48,6 @@ export class OpenRouterHttpError extends Error {
 //
 // Helpers
 //
-
-/**
- * Parse an OpenAI-style Server-Sent Events stream into decoded JSON chunks.
- * Buffers across network reads, dispatches on blank lines, and stops at the
- * `[DONE]` sentinel. Comment lines (`: ...`, used by OpenRouter for keep-alive)
- * are ignored.
- */
-async function* parseSseStream(
-  body: ReadableStream<Uint8Array>,
-): AsyncIterable<JsonObject> {
-  const reader = body.getReader();
-  const decoder = new TextDecoder();
-  let buffer = "";
-
-  try {
-    for (;;) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      buffer += decoder.decode(value, { stream: true });
-
-      let newlineIndex: number;
-      while ((newlineIndex = buffer.indexOf("\n")) !== -1) {
-        const line = buffer.slice(0, newlineIndex).replace(/\r$/, "");
-        buffer = buffer.slice(newlineIndex + 1);
-
-        if (line === "" || line.startsWith(":")) continue;
-        if (!line.startsWith("data:")) continue;
-
-        const data = line.slice("data:".length).trim();
-        if (data === SSE_DONE) return;
-
-        yield JSON.parse(data) as JsonObject;
-      }
-    }
-  } finally {
-    reader.releaseLock();
-  }
-}
 
 /**
  * Normalize the snake_case wire response into the camelCase shape the adapter

--- a/packages/llm/src/providers/openrouter/client.ts
+++ b/packages/llm/src/providers/openrouter/client.ts
@@ -1,0 +1,223 @@
+import { JsonObject } from "@jaypie/types";
+
+//
+//
+// Constants
+//
+
+const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
+
+const SSE_DONE = "[DONE]";
+
+//
+//
+// Types
+//
+
+export interface OpenRouterClientOptions {
+  apiKey: string;
+  baseURL?: string;
+}
+
+export interface ChatCompletionOptions {
+  signal?: AbortSignal;
+}
+
+/**
+ * HTTP error carrying the upstream status and parsed API message. The
+ * OpenRouterAdapter classifies errors by reading `.status` / `.statusCode` and
+ * `.message` / `.error.message`, so this shape keeps `classifyError`,
+ * `isTemperatureDeprecationError`, and `isStructuredOutputUnsupportedError`
+ * working unchanged after dropping the SDK.
+ */
+export class OpenRouterHttpError extends Error {
+  readonly status: number;
+  readonly statusCode: number;
+  readonly error?: { message?: string };
+
+  constructor(status: number, message: string, error?: { message?: string }) {
+    super(message);
+    this.name = "OpenRouterHttpError";
+    this.status = status;
+    this.statusCode = status;
+    this.error = error;
+  }
+}
+
+//
+//
+// Helpers
+//
+
+/**
+ * Parse an OpenAI-style Server-Sent Events stream into decoded JSON chunks.
+ * Buffers across network reads, dispatches on blank lines, and stops at the
+ * `[DONE]` sentinel. Comment lines (`: ...`, used by OpenRouter for keep-alive)
+ * are ignored.
+ */
+async function* parseSseStream(
+  body: ReadableStream<Uint8Array>,
+): AsyncIterable<JsonObject> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      let newlineIndex: number;
+      while ((newlineIndex = buffer.indexOf("\n")) !== -1) {
+        const line = buffer.slice(0, newlineIndex).replace(/\r$/, "");
+        buffer = buffer.slice(newlineIndex + 1);
+
+        if (line === "" || line.startsWith(":")) continue;
+        if (!line.startsWith("data:")) continue;
+
+        const data = line.slice("data:".length).trim();
+        if (data === SSE_DONE) return;
+
+        yield JSON.parse(data) as JsonObject;
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+/**
+ * Normalize the snake_case wire response into the camelCase shape the adapter
+ * readers expect (the SDK previously returned camelCase). Only protocol fields
+ * are touched — user content (schema property names, tool argument JSON) is
+ * left untouched.
+ */
+function normalizeResponse(json: JsonObject): JsonObject {
+  const choices = json.choices as Array<Record<string, unknown>> | undefined;
+  if (Array.isArray(choices)) {
+    for (const choice of choices) {
+      if (
+        choice.finish_reason !== undefined &&
+        choice.finishReason === undefined
+      ) {
+        choice.finishReason = choice.finish_reason;
+      }
+      const message = choice.message as Record<string, unknown> | undefined;
+      if (
+        message?.tool_calls !== undefined &&
+        message.toolCalls === undefined
+      ) {
+        message.toolCalls = message.tool_calls;
+      }
+    }
+  }
+
+  const usage = json.usage as Record<string, unknown> | undefined;
+  if (usage) {
+    if (usage.promptTokens === undefined)
+      usage.promptTokens = usage.prompt_tokens;
+    if (usage.completionTokens === undefined) {
+      usage.completionTokens = usage.completion_tokens;
+    }
+    if (usage.totalTokens === undefined) usage.totalTokens = usage.total_tokens;
+    const details = usage.completion_tokens_details as
+      | { reasoning_tokens?: number }
+      | undefined;
+    if (
+      details?.reasoning_tokens !== undefined &&
+      !usage.completionTokensDetails
+    ) {
+      usage.completionTokensDetails = {
+        reasoningTokens: details.reasoning_tokens,
+      };
+    }
+  }
+
+  return json;
+}
+
+//
+//
+// Main
+//
+
+/**
+ * Minimal `fetch`-based client for OpenRouter's OpenAI-compatible Chat
+ * Completions endpoint. Replaces `@openrouter/sdk` — the adapter only needs a
+ * single POST (streaming and non-streaming), header auth, and HTTP error
+ * surfacing.
+ */
+export class OpenRouterClient {
+  private readonly apiKey: string;
+  private readonly baseURL: string;
+
+  constructor({
+    apiKey,
+    baseURL = OPENROUTER_BASE_URL,
+  }: OpenRouterClientOptions) {
+    this.apiKey = apiKey;
+    this.baseURL = baseURL;
+  }
+
+  private headers(): Record<string, string> {
+    return {
+      Authorization: `Bearer ${this.apiKey}`,
+      "Content-Type": "application/json",
+    };
+  }
+
+  private async toError(response: Response): Promise<OpenRouterHttpError> {
+    let message = `OpenRouter request failed with status ${response.status}`;
+    let error: { message?: string } | undefined;
+    try {
+      const body = (await response.json()) as { error?: { message?: string } };
+      if (body?.error?.message) {
+        message = body.error.message;
+        error = body.error;
+      }
+    } catch {
+      // Non-JSON error body; keep the status-based message.
+    }
+    return new OpenRouterHttpError(response.status, message, error);
+  }
+
+  async chatCompletion(
+    body: Record<string, unknown>,
+    { signal }: ChatCompletionOptions = {},
+  ): Promise<JsonObject> {
+    const response = await fetch(`${this.baseURL}/chat/completions`, {
+      method: "POST",
+      headers: this.headers(),
+      body: JSON.stringify(body),
+      signal,
+    });
+
+    if (!response.ok) throw await this.toError(response);
+
+    const json = (await response.json()) as JsonObject;
+    return normalizeResponse(json);
+  }
+
+  async *streamChatCompletion(
+    body: Record<string, unknown>,
+    { signal }: ChatCompletionOptions = {},
+  ): AsyncIterable<JsonObject> {
+    const response = await fetch(`${this.baseURL}/chat/completions`, {
+      method: "POST",
+      headers: { ...this.headers(), Accept: "text/event-stream" },
+      // OpenAI-style streams only include usage when explicitly requested.
+      body: JSON.stringify({
+        ...body,
+        stream: true,
+        stream_options: { include_usage: true },
+      }),
+      signal,
+    });
+
+    if (!response.ok) throw await this.toError(response);
+    if (!response.body) return;
+
+    yield* parseSseStream(response.body);
+  }
+}

--- a/packages/llm/src/providers/openrouter/utils.ts
+++ b/packages/llm/src/providers/openrouter/utils.ts
@@ -2,24 +2,9 @@ import { getEnvSecret } from "@jaypie/aws";
 import { ConfigurationError } from "@jaypie/errors";
 import { JAYPIE, placeholders as replacePlaceholders } from "@jaypie/kit";
 import { createLogger, log as defaultLog } from "@jaypie/logger";
-import type { OpenRouter } from "@openrouter/sdk";
 import { LlmMessageOptions } from "../../types/LlmProvider.interface.js";
 import { PROVIDER } from "../../constants.js";
-
-// SDK loader with caching
-let cachedSdk: typeof import("@openrouter/sdk") | null = null;
-
-export async function loadSdk(): Promise<typeof import("@openrouter/sdk")> {
-  if (cachedSdk) return cachedSdk;
-  try {
-    cachedSdk = await import("@openrouter/sdk");
-    return cachedSdk;
-  } catch {
-    throw new ConfigurationError(
-      "@openrouter/sdk is required but not installed. Run: npm install @openrouter/sdk",
-    );
-  }
-}
+import { OpenRouterClient } from "./client.js";
 
 // Logger
 export const getLogger = (): ReturnType<typeof createLogger> =>
@@ -30,7 +15,7 @@ export async function initializeClient({
   apiKey,
 }: {
   apiKey?: string;
-} = {}): Promise<OpenRouter> {
+} = {}): Promise<OpenRouterClient> {
   const logger = getLogger();
   const resolvedApiKey = apiKey || (await getEnvSecret("OPENROUTER_API_KEY"));
 
@@ -40,8 +25,7 @@ export async function initializeClient({
     );
   }
 
-  const sdk = await loadSdk();
-  const client = new sdk.OpenRouter({ apiKey: resolvedApiKey });
+  const client = new OpenRouterClient({ apiKey: resolvedApiKey });
   logger.trace("Initialized OpenRouter client");
   return client;
 }

--- a/packages/llm/src/providers/xai/XaiProvider.class.ts
+++ b/packages/llm/src/providers/xai/XaiProvider.class.ts
@@ -1,5 +1,4 @@
 import { JsonObject } from "@jaypie/types";
-import { OpenAI } from "openai";
 import { PROVIDER } from "../../constants.js";
 import {
   createOperateLoop,
@@ -18,6 +17,7 @@ import {
   LlmHistoryItem,
 } from "../../types/LlmProvider.interface.js";
 import { LlmStreamChunk } from "../../types/LlmStreamChunk.interface.js";
+import { OpenAIClient } from "../openai/client.js";
 import {
   createStructuredCompletion,
   createTextCompletion,
@@ -28,7 +28,7 @@ import { initializeClient } from "./utils.js";
 
 export class XaiProvider implements LlmProvider {
   private model: string;
-  private _client?: OpenAI;
+  private _client?: OpenAIClient;
   private _operateLoop?: OperateLoop;
   private _streamLoop?: StreamLoop;
   private apiKey?: string;
@@ -43,7 +43,7 @@ export class XaiProvider implements LlmProvider {
     this.apiKey = apiKey;
   }
 
-  private async getClient(): Promise<OpenAI> {
+  private async getClient(): Promise<OpenAIClient> {
     if (this._client) {
       return this._client;
     }

--- a/packages/llm/src/providers/xai/__tests__/XaiProvider.spec.ts
+++ b/packages/llm/src/providers/xai/__tests__/XaiProvider.spec.ts
@@ -1,11 +1,11 @@
 import { getEnvSecret } from "@jaypie/aws";
-import { OpenAI } from "openai";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { XaiProvider } from "../XaiProvider.class";
+import { OpenAIClient } from "../../openai/client.js";
 import { PROVIDER } from "../../../constants.js";
 
-// Mock the operate module
-vi.mock("openai");
+// Mock the OpenAI client
+vi.mock("../../openai/client.js");
 
 // Mock the OperateLoop for conversation history tests
 vi.mock("../../../operate/index.js", async (importOriginal) => {
@@ -29,7 +29,7 @@ vi.mock("@jaypie/aws", async () => {
 
 describe("XaiProvider", () => {
   beforeEach(() => {
-    vi.mocked(OpenAI).mockImplementation(
+    vi.mocked(OpenAIClient).mockImplementation(
       class {
         chat = {
           completions: {
@@ -85,7 +85,7 @@ describe("XaiProvider", () => {
       };
 
       const mockCreate = vi.fn().mockResolvedValue(mockResponse);
-      vi.mocked(OpenAI).mockImplementation(
+      vi.mocked(OpenAIClient).mockImplementation(
         class {
           chat = {
             completions: {
@@ -105,7 +105,7 @@ describe("XaiProvider", () => {
       const mockCreate = vi.fn().mockResolvedValue({
         choices: [{ message: { content: "response" } }],
       });
-      vi.mocked(OpenAI).mockImplementation(
+      vi.mocked(OpenAIClient).mockImplementation(
         class {
           chat = {
             completions: {
@@ -118,7 +118,7 @@ describe("XaiProvider", () => {
       const provider = new XaiProvider();
       await provider.send("test");
 
-      expect(OpenAI).toHaveBeenCalledWith({
+      expect(OpenAIClient).toHaveBeenCalledWith({
         apiKey: "test-xai-key",
         baseURL: PROVIDER.XAI.BASE_URL,
       });
@@ -128,7 +128,7 @@ describe("XaiProvider", () => {
       const mockCreate = vi.fn().mockResolvedValue({
         choices: [{ message: { content: "response" } }],
       });
-      vi.mocked(OpenAI).mockImplementation(
+      vi.mocked(OpenAIClient).mockImplementation(
         class {
           chat = {
             completions: {

--- a/packages/llm/src/providers/xai/__tests__/client.hot.spec.ts
+++ b/packages/llm/src/providers/xai/__tests__/client.hot.spec.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+
+import { PROVIDER } from "../../../constants.js";
+import { OpenAIClient } from "../../openai/client.js";
+import { XaiProvider } from "../XaiProvider.class.js";
+
+//
+//
+// Hot tests
+//
+// Live tests against the real xAI API (OpenAI-compatible, custom base URL).
+// Skipped unless XAI_API_KEY is set, so CI stays green and `npm test` runs them
+// automatically with a key.
+//
+//   XAI_API_KEY=xai-... npm run test -w packages/llm
+//
+
+const apiKey = process.env.XAI_API_KEY;
+const MODEL = PROVIDER.XAI.MODEL.TINY;
+const TIMEOUT = 60_000;
+
+describe.skipIf(!apiKey)("XaiClient (hot)", () => {
+  describe("chat.completions.create", () => {
+    it(
+      "returns assistant text from the live xAI endpoint",
+      async () => {
+        const client = new OpenAIClient({
+          apiKey: apiKey!,
+          baseURL: PROVIDER.XAI.BASE_URL,
+        });
+        const completion = (await client.chat.completions.create({
+          model: MODEL,
+          messages: [
+            { role: "user", content: "Reply with the single word: pong" },
+          ],
+        })) as { choices: Array<{ message: { content: string } }> };
+        const text = completion.choices[0]?.message?.content ?? "";
+        expect(text.toLowerCase()).toContain("pong");
+      },
+      TIMEOUT,
+    );
+  });
+
+  describe("responses.create", () => {
+    it(
+      "streams text deltas",
+      async () => {
+        const client = new OpenAIClient({
+          apiKey: apiKey!,
+          baseURL: PROVIDER.XAI.BASE_URL,
+        });
+        const stream = await client.responses.create({
+          model: MODEL,
+          input: "Count: one two three",
+          stream: true,
+        });
+
+        let text = "";
+        for await (const event of stream) {
+          if (event.type === "response.output_text.delta") {
+            text += (event as { delta?: string }).delta ?? "";
+          }
+        }
+        expect(text.length).toBeGreaterThan(0);
+      },
+      TIMEOUT,
+    );
+  });
+
+  describe("XaiProvider.operate", () => {
+    it(
+      "completes a text turn end-to-end",
+      async () => {
+        const provider = new XaiProvider(MODEL, { apiKey: apiKey! });
+        const response = await provider.operate(
+          "Reply with the single word: pong",
+        );
+        expect(String(response.content).toLowerCase()).toContain("pong");
+      },
+      TIMEOUT,
+    );
+
+    it(
+      "returns structured output via native format",
+      async () => {
+        const provider = new XaiProvider(MODEL, { apiKey: apiKey! });
+        const response = await provider.operate("Give the capital of France.", {
+          format: { capital: String },
+        });
+        expect(response.content).toMatchObject({ capital: expect.any(String) });
+      },
+      TIMEOUT,
+    );
+  });
+});

--- a/packages/llm/src/providers/xai/utils.ts
+++ b/packages/llm/src/providers/xai/utils.ts
@@ -2,9 +2,9 @@ import { getEnvSecret } from "@jaypie/aws";
 import { ConfigurationError } from "@jaypie/errors";
 import { JAYPIE } from "@jaypie/kit";
 import { createLogger, log as defaultLog } from "@jaypie/logger";
-import { OpenAI } from "openai";
 
 import { PROVIDER } from "../../constants.js";
+import { OpenAIClient } from "../openai/client.js";
 
 // Logger
 export const getLogger = (): ReturnType<typeof createLogger> =>
@@ -15,7 +15,7 @@ export async function initializeClient({
   apiKey,
 }: {
   apiKey?: string;
-} = {}): Promise<OpenAI> {
+} = {}): Promise<OpenAIClient> {
   const logger = getLogger();
   const resolvedApiKey = apiKey || (await getEnvSecret(PROVIDER.XAI.API_KEY));
 
@@ -25,7 +25,7 @@ export async function initializeClient({
     );
   }
 
-  const client = new OpenAI({
+  const client = new OpenAIClient({
     apiKey: resolvedApiKey,
     baseURL: PROVIDER.XAI.BASE_URL,
   });

--- a/packages/llm/src/util/index.ts
+++ b/packages/llm/src/util/index.ts
@@ -9,4 +9,5 @@ export * from "./maxTurnsFromOptions.js";
 export * from "./naturalZodSchema.js";
 export * from "./random.js";
 export * from "./repairFormatKeys.js";
+export * from "./sse.js";
 export * from "./tryParseNumber.js";

--- a/packages/llm/src/util/sse.ts
+++ b/packages/llm/src/util/sse.ts
@@ -1,0 +1,44 @@
+import { JsonObject } from "@jaypie/types";
+
+const DEFAULT_DONE_SENTINEL = "[DONE]";
+
+/**
+ * Parse a Server-Sent Events stream into decoded JSON chunks. Buffers across
+ * network reads, dispatches on newline-delimited `data:` lines, and stops at
+ * the done sentinel (OpenAI-style `[DONE]`; Gemini omits it and simply ends
+ * the stream). Comment lines (`: ...`, used for keep-alive) are ignored.
+ *
+ * Shared by the provider HTTP clients that replaced their vendor SDKs.
+ */
+export async function* parseSseStream(
+  body: ReadableStream<Uint8Array>,
+  { doneSentinel = DEFAULT_DONE_SENTINEL }: { doneSentinel?: string } = {},
+): AsyncIterable<JsonObject> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      let newlineIndex: number;
+      while ((newlineIndex = buffer.indexOf("\n")) !== -1) {
+        const line = buffer.slice(0, newlineIndex).replace(/\r$/, "");
+        buffer = buffer.slice(newlineIndex + 1);
+
+        if (line === "" || line.startsWith(":")) continue;
+        if (!line.startsWith("data:")) continue;
+
+        const data = line.slice("data:".length).trim();
+        if (data === doneSentinel) return;
+
+        yield JSON.parse(data) as JsonObject;
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.83",
+  "version": "0.8.84",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/llm/1.3.4.md
+++ b/packages/mcp/release-notes/llm/1.3.4.md
@@ -1,0 +1,34 @@
+---
+version: 1.3.4
+date: 2026-06-27
+summary: All first-class providers run on fetch-based clients; provider SDKs removed (Bedrock excepted)
+---
+
+## Changes
+
+- Completes the provider-SDK exodus. OpenRouter, Google, Anthropic, OpenAI, and
+  xAI now talk to their APIs through minimal `fetch`-based clients instead of
+  vendor SDKs. The published manifest drops `openai`, `@anthropic-ai/sdk`,
+  `@google/genai`, and `@openrouter/sdk` from dependencies.
+- OpenAI and xAI share a new `OpenAIClient` (`providers/openai/client.ts`) that
+  mirrors the SDK surface the adapters actually use — the Responses API
+  (`/responses`, streaming and non-streaming) for `operate`/`stream` and Chat
+  Completions (`/chat/completions`, plus a `parse` helper) for `send`. It throws
+  named error classes matching the SDK's, so the adapters' `instanceof`-based
+  `classifyError` is unchanged. xAI reuses the same client via a custom
+  `baseURL`.
+- A local `zodResponseFormat` (`providers/openai/responseFormat.ts`) replaces the
+  `openai/helpers/zod` import.
+
+## Bedrock
+
+- `@aws-sdk/client-bedrock-runtime` remains an **optional peer dependency** plus
+  a devDependency. It is never statically imported — all references are
+  `import type` (erased) or a lazy `await import()` guarded to throw a
+  `ConfigurationError` when absent. Only Bedrock consumers need it; everyone else
+  installs zero provider SDKs.
+
+## Migration
+
+No changes required. Provider behavior, error classification, structured output,
+and streaming are unchanged; verified live across all five providers.


### PR DESCRIPTION
## Summary

Completes the provider-SDK exodus in `@jaypie/llm`. All five first-class providers now talk to their APIs through minimal `fetch`-based clients instead of vendor SDKs.

- **OpenRouter, Google, Anthropic** — fetch clients (earlier commits in branch)
- **OpenAI + xAI** — new shared `OpenAIClient` (Responses API for `operate`/`stream`, Chat Completions for `send`); throws named error classes so adapter `instanceof` classification is unchanged; xAI reuses it via custom `baseURL`
- Local `zodResponseFormat` replaces `openai/helpers/zod`
- Dropped deps: `openai`, `@anthropic-ai/sdk`, `@google/genai`, `@openrouter/sdk`
- **Bedrock** stays on `@aws-sdk/client-bedrock-runtime` as an optional peer + devDep — never statically imported (type-only + lazy `await import()`)

## Versions

- `@jaypie/llm` 1.3.3 → 1.3.4 (+ release note)
- `@jaypie/mcp` 0.8.83 → 0.8.84 (release-note addition)

## Verification

- Typecheck + lint clean; 923 unit tests pass with SDKs uninstalled
- NPM Check green, including the live LLM Capability Matrix across openai / openrouter / gemini-xai

🤖 Generated with [Claude Code](https://claude.com/claude-code)