### PR TITLE
docs(mcp): add Fabric Composition vocabulary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29191,7 +29191,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.84",
+      "version": "0.8.85",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.3.3",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.84",
+  "version": "0.8.85",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/mcp/0.8.85.md
+++ b/packages/mcp/release-notes/mcp/0.8.85.md
@@ -1,0 +1,11 @@
+---
+version: 0.8.85
+date: 2026-06-27
+summary: Add Fabric Composition vocabulary (composition, edge, guard, selector, entry, terminal, workflow, agent)
+---
+
+## Changes
+
+- Vocabulary skill: add Composition to the ontological grounding
+- Vocabulary skill: add Fabric Composition section reserving edge, guard, selector, entry, terminal
+- Vocabulary skill: define workflow and agent as compositions that specify vs infer their selector, entry, and terminal

--- a/packages/mcp/skills/vocabulary.md
+++ b/packages/mcp/skills/vocabulary.md
@@ -19,8 +19,9 @@ The "Fabric Vocabulary" attempts to reserve words for implied uses and encourage
 8. Context: scope in which propositions hold
 9. Model: category bound to a specification of attributes; defines entity identity and structure
 10. Service: responds to event inputs and performs actions that transforms state within context
+11. Composition: services joined so emitted state becomes the next event-input; itself a service
 
-Arguably composition, identity, instance, and relation would form a more complete vocabulary.
+Arguably identity, instance, and relation would form a more complete vocabulary.
 
 ### Further Postulates
 
@@ -108,6 +109,21 @@ Avoid words defined elsewhere (services, terminology)
 - ~Servers~ are transport adapters that consume ~suites~
 - ~Suites~ are collections of services
 
+## Fabric Composition
+
+A composition wires services into a graph; it is itself a service.
+
+- edge: directed link carrying one service's emitted state to the next service's event-input
+- guard: per-edge predicate; whether an edge is eligible to fire; gates, does not choose; optional
+- selector: node function choosing which eligible edge fires
+- entry: where a composition begins
+- terminal: where a composition halts; a state it no longer transforms
+
+### Composition Models
+
+- workflow: a composition that specifies its selector, entry, and terminal
+- agent: a composition that infers its selector, entry, or terminal
+
 ## File Systems and Monorepos
 
 - bin: scripts
@@ -148,7 +164,7 @@ SEPARATOR = "#";
 
 ## Additional Terminology
 
-- debug: logging, 
+- debug: logging, operating checkpoint or abnormal condition
 - error: logging, detected an unrecoverable state and exiting (caught error)
 - fatal: logging, exiting because an unrecoverable state was encountered (uncaught exceptions)
 - info: logging, emits lifecycle start/stop, rarely for essential values (most metrics push directly to Datadog)

--- a/packages/mcp/src/suites/docs/index.ts
+++ b/packages/mcp/src/suites/docs/index.ts
@@ -82,7 +82,8 @@ async function parseReleaseNoteFile(filePath: string): Promise<{
     const filename = path.basename(filePath, ".md");
 
     if (content.startsWith("---")) {
-      const frontMatter = parseFrontmatter<ReleaseNoteFrontMatter>(content).data;
+      const frontMatter =
+        parseFrontmatter<ReleaseNoteFrontMatter>(content).data;
       return {
         date: frontMatter.date,
         filename,


### PR DESCRIPTION
## Summary

Adds a **Fabric Composition** section to the `~vocabulary` skill, reserving the composition layer the ontology flagged as missing.

- Ontological grounding gains `11. Composition`
- Reserves `edge`, `guard`, `selector`, `entry`, `terminal`
- Defines **workflow** vs **agent** by whether the selector, entry, and terminal are *specified* or *inferred* — same graph, the wires just go nondeterministic

## Housekeeping

- mcp patch bump `0.8.84 → 0.8.85` + lockfile
- Release note `release-notes/mcp/0.8.85.md`
- Rebuilt dist; lint/typecheck/test green

🤖 Generated with [Claude Code](https://claude.com/claude-code)