### PR TITLE
fix(dynamodb): raise @jaypie/errors peer floor to ^1.2.3 (#400)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28481,7 +28481,7 @@
     },
     "packages/dynamodb": {
       "name": "@jaypie/dynamodb",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.726.1",
@@ -28495,7 +28495,7 @@
         "typescript": "^5.3.3"
       },
       "peerDependencies": {
-        "@jaypie/errors": "*",
+        "@jaypie/errors": "^1.2.3",
         "@jaypie/kit": "*",
         "@jaypie/logger": "*",
         "@modelcontextprotocol/sdk": ">=1.0.0"
@@ -29191,7 +29191,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.85",
+      "version": "0.8.86",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.3.3",

--- a/packages/dynamodb/package.json
+++ b/packages/dynamodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/dynamodb",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"
@@ -58,7 +58,7 @@
     "typescript": "^5.3.3"
   },
   "peerDependencies": {
-    "@jaypie/errors": "*",
+    "@jaypie/errors": "^1.2.3",
     "@jaypie/kit": "*",
     "@jaypie/logger": "*",
     "@modelcontextprotocol/sdk": ">=1.0.0"

--- a/packages/dynamodb/src/__tests__/packageDependencies.spec.ts
+++ b/packages/dynamodb/src/__tests__/packageDependencies.spec.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { satisfies } from "semver";
+import { describe, expect, it } from "vitest";
+
+//
+//
+// Constants
+//
+
+// The version of @jaypie/errors that introduced ConflictError, which
+// entities.ts imports. Installs that resolve an older @jaypie/errors fail to
+// bundle ("No matching export ... for import ConflictError"). See issue #400.
+const CONFLICT_ERROR_FLOOR = "1.2.3";
+const PRE_CONFLICT_ERROR = "1.2.1";
+
+const packageJson = JSON.parse(
+  readFileSync(
+    resolve(dirname(fileURLToPath(import.meta.url)), "../../package.json"),
+    "utf8",
+  ),
+);
+
+//
+//
+// Run tests
+//
+
+describe("@jaypie/dynamodb dependency floors", () => {
+  it("imports ConflictError from @jaypie/errors", () => {
+    const entities = readFileSync(
+      resolve(dirname(fileURLToPath(import.meta.url)), "../entities.ts"),
+      "utf8",
+    );
+    expect(entities).toContain("ConflictError");
+    expect(entities).toContain('from "@jaypie/errors"');
+  });
+
+  it("declares an @jaypie/errors peer that requires ConflictError support", () => {
+    const range = packageJson.peerDependencies?.["@jaypie/errors"];
+    expect(range).toBeString();
+    // A floorless "*" satisfies the pre-ConflictError 1.2.1, which breaks bundling
+    expect(satisfies(PRE_CONFLICT_ERROR, range)).toBe(false);
+    expect(satisfies(CONFLICT_ERROR_FLOOR, range)).toBe(true);
+  });
+});

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.85",
+  "version": "0.8.86",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/dynamodb/0.6.5.md
+++ b/packages/mcp/release-notes/dynamodb/0.6.5.md
@@ -1,0 +1,18 @@
+---
+version: 0.6.5
+date: 2026-06-28
+summary: Raise @jaypie/errors peer floor to ^1.2.3 so ConflictError resolves
+---
+
+## Fixes
+
+- Raise the `@jaypie/errors` peer dependency from a floorless `*` to `^1.2.3`.
+- `0.6.4` imports `ConflictError`, which `@jaypie/errors` only began exporting in
+  `1.2.3`. The `*` peer was satisfied by an already-deduped older `@jaypie/errors`
+  (e.g. `1.2.1`), so esbuild and other bundlers failed with
+  `No matching export ... for import "ConflictError"` (and the runtime equivalent
+  `errors.ConflictError is not a constructor`).
+- With the floor in place, installs resolve an `@jaypie/errors` that exports
+  `ConflictError` and bundling succeeds.
+
+No runtime behavior changes.

--- a/packages/mcp/release-notes/mcp/0.8.86.md
+++ b/packages/mcp/release-notes/mcp/0.8.86.md
@@ -1,0 +1,9 @@
+---
+version: 0.8.86
+date: 2026-06-28
+summary: Ship @jaypie/dynamodb 0.6.5 release notes
+---
+
+## Changes
+
+- Bundle the `@jaypie/dynamodb` 0.6.5 release notes (errors peer floor fix).


### PR DESCRIPTION
## Summary

Fixes #400. `@jaypie/dynamodb@0.6.4` imports `ConflictError`, which `@jaypie/errors` only exports from `1.2.3`, but declared the peer as a floorless `"*"`. As a standalone package, dynamodb deduped to an older `@jaypie/errors` (e.g. `1.2.1`) on install, so esbuild/bundlers failed with `No matching export ... for import "ConflictError"`.

## Changes

- `@jaypie/dynamodb`: raise `@jaypie/errors` peer `"*"` → `"^1.2.3"`; bump `0.6.4` → `0.6.5`
- Add regression test asserting the peer floor rejects `1.2.1` and accepts `1.2.3`
- Release notes for `dynamodb@0.6.5`; bump `@jaypie/mcp` `0.8.85` → `0.8.86` (ships the notes) with its own note

## Notes

- `@jaypie/dynamodb` is standalone (not in the `jaypie` meta-package), so no meta bump needed. The meta-package already pins `@jaypie/errors ^1.2.3`.
- Pre-existing vitest 3→4 mock failures in `client`/`query`/`tables` specs are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)