### PR TITLE
feat(constructs): add sponsor-first constructName helper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18874,7 +18874,7 @@
     },
     "packages/constructs": {
       "name": "@jaypie/constructs",
-      "version": "1.2.69",
+      "version": "1.2.70",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*",
@@ -19965,7 +19965,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.89",
+      "version": "0.8.90",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.3.3",

--- a/packages/constructs/CLAUDE.md
+++ b/packages/constructs/CLAUDE.md
@@ -15,6 +15,7 @@ packages/constructs/
 │   │   ├── index.ts
 │   │   ├── addDatadogLayers.ts
 │   │   ├── constructEnvName.ts
+│   │   ├── constructName.ts
 │   │   ├── constructStackName.ts
 │   │   ├── constructTagger.ts
 │   │   ├── envHostname.ts
@@ -457,7 +458,8 @@ new JaypieApiGateway(this, "Api", { handler: lambda, certificate: cert });
 |----------|-------------|
 | `constructStackName(key?)` | Generate stack name from env vars |
 | `constructTagger(construct)` | Apply standard tags to construct |
-| `constructEnvName(name)` | Generate environment-prefixed name |
+| `constructEnvName(name)` | Generate environment-prefixed name (no sponsor segment) |
+| `constructName(name, opts?)` | Generate sponsor-first name: `{sponsor}-{env}-{key}-{name}-{nonce}`; honors `PROJECT_SPONSOR`, accepts `{ sponsor, env, key, nonce }` overrides |
 | `envHostname()` | Get hostname from environment (supports `CDK_ENV_PERSONAL` as leading prefix) |
 | `isEnv(env)` / `isProductionEnv()` / `isSandboxEnv()` | Environment checks |
 | `isValidHostname(str)` / `isValidSubdomain(str)` | Validation helpers |

--- a/packages/constructs/package.json
+++ b/packages/constructs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/constructs",
-  "version": "1.2.69",
+  "version": "1.2.70",
   "description": "CDK constructs for Jaypie applications",
   "repository": {
     "type": "git",

--- a/packages/constructs/src/helpers/__tests__/constructName.spec.ts
+++ b/packages/constructs/src/helpers/__tests__/constructName.spec.ts
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { constructName } from "../constructName";
+
+describe("constructName", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env.PROJECT_SPONSOR = "findustryai";
+    process.env.PROJECT_ENV = "sandbox";
+    process.env.PROJECT_KEY = "agents";
+    process.env.PROJECT_NONCE = "a9c11a31";
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("is sponsor-first, honoring PROJECT_SPONSOR", () => {
+    expect(constructName("document-lake")).toBe(
+      "findustryai-sandbox-agents-document-lake-a9c11a31",
+    );
+  });
+
+  it("accepts a sponsor override", () => {
+    expect(constructName("document-lake", { sponsor: "finlaysonstudio" })).toBe(
+      "finlaysonstudio-sandbox-agents-document-lake-a9c11a31",
+    );
+  });
+
+  it("accepts env/key/nonce overrides", () => {
+    expect(
+      constructName("document-lake", {
+        env: "production",
+        key: "core",
+        nonce: "z1",
+      }),
+    ).toBe("findustryai-production-core-document-lake-z1");
+  });
+});

--- a/packages/constructs/src/helpers/constructName.ts
+++ b/packages/constructs/src/helpers/constructName.ts
@@ -1,0 +1,10 @@
+export function constructName(
+  name: string,
+  opts?: { env?: string; key?: string; nonce?: string; sponsor?: string },
+) {
+  const sponsor = opts?.sponsor ?? process.env.PROJECT_SPONSOR ?? "sponsor";
+  const env = opts?.env ?? process.env.PROJECT_ENV ?? "build";
+  const key = opts?.key ?? process.env.PROJECT_KEY ?? "project";
+  const nonce = opts?.nonce ?? process.env.PROJECT_NONCE ?? "cfe2"; // This default is intentionally short. It is not a special value but should not be changed.
+  return `${sponsor}-${env}-${key}-${name}-${nonce}`;
+}

--- a/packages/constructs/src/helpers/index.ts
+++ b/packages/constructs/src/helpers/index.ts
@@ -1,5 +1,6 @@
 export { addDatadogLayers } from "./addDatadogLayers";
 export { constructEnvName } from "./constructEnvName";
+export { constructName } from "./constructName";
 export { constructStackName } from "./constructStackName";
 export { constructTagger } from "./constructTagger";
 export { constructWafLogBucketName } from "./constructWafLogBucketName";

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.89",
+  "version": "0.8.90",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/constructs/1.2.70.md
+++ b/packages/mcp/release-notes/constructs/1.2.70.md
@@ -1,0 +1,17 @@
+---
+version: 1.2.70
+date: 2026-07-03
+summary: Add sponsor-first constructName helper
+---
+
+## Features
+
+- Added `constructName(name, opts?)`, a new helper alongside the existing
+  `constructEnvName`. Generates sponsor-first names
+  (`{sponsor}-{env}-{key}-{name}-{nonce}`) matching `constructStackName`'s
+  segment order, honors `process.env.PROJECT_SPONSOR` as the default sponsor
+  segment, and accepts a `sponsor` override alongside `env`/`key`/`nonce`
+  (#408).
+- `constructEnvName` is unchanged (no sponsor segment, no rename/deprecation)
+  — use `constructName` when a sponsor-qualified, globally-unique name is
+  needed.


### PR DESCRIPTION
## Summary
- Adds a new `constructName(name, opts?)` helper alongside `constructEnvName`, sponsor-first (`{sponsor}-{env}-{key}-{name}-{nonce}`), honoring `PROJECT_SPONSOR` with a `sponsor` override — matches `constructStackName`'s segment order
- `constructEnvName` is unchanged, per operator direction: no rename, no deprecation
- Bumps `@jaypie/constructs` to 1.2.70, `@jaypie/mcp` to 0.8.90 with release notes

Closes #408

## Test plan
- [x] `npm run test -w packages/constructs`
- [x] `npm run typecheck -w packages/constructs`
- [x] `npm run lint -w packages/constructs`
- [x] NPM Check workflow green