### PR TITLE
feat: quiet operate logging, onProgress callback, logger serialization limits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,9 @@
 | `NODE_ENV` | Node environment (development, production) |
 | `LOG_LEVEL` | Logging level (trace, debug, info, warn, error) |
 | `LOG_LEVEL_FIELD` | Include level in JSON log output (`true`, custom key name, or `false`) |
+| `LOG_MAX_ENTRY_BYTES` | Cap serialized log entries (default 256KB; `false` disables) |
+| `LOG_MAX_STRING` | Truncate string fields beyond N characters (default off) |
+| `LOG_MAX_DEPTH` | Collapse objects nested beyond N levels (default off) |
 | `CDK_ENV_BUCKET` | AWS S3 bucket name |
 | `CDK_ENV_QUEUE_URL` | AWS SQS queue URL |
 | `CDK_ENV_SNS_ROLE_ARN` | SNS role ARN for notifications |

--- a/package-lock.json
+++ b/package-lock.json
@@ -19765,7 +19765,7 @@
       }
     },
     "packages/jaypie": {
-      "version": "1.2.60",
+      "version": "1.2.61",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "^1.2.10",
@@ -19775,7 +19775,7 @@
         "@jaypie/express": "^1.2.27",
         "@jaypie/kit": "^1.2.12",
         "@jaypie/lambda": "^1.2.11",
-        "@jaypie/logger": "^1.2.18"
+        "@jaypie/logger": "^1.2.19"
       },
       "devDependencies": {
         "@jaypie/types": "^0.1.7",
@@ -19790,7 +19790,7 @@
         "typescript-eslint": "^8.46.1"
       },
       "peerDependencies": {
-        "@jaypie/llm": "^1.3.6"
+        "@jaypie/llm": "^1.3.7"
       },
       "peerDependenciesMeta": {
         "@jaypie/llm": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19905,7 +19905,7 @@
     },
     "packages/llm": {
       "name": "@jaypie/llm",
-      "version": "1.3.6",
+      "version": "1.3.7",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "*",
@@ -19965,7 +19965,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.90",
+      "version": "0.8.91",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.3.3",
@@ -20316,7 +20316,7 @@
     },
     "packages/testkit": {
       "name": "@jaypie/testkit",
-      "version": "1.2.50",
+      "version": "1.2.51",
       "license": "MIT",
       "dependencies": {
         "jest-json-schema": "^6.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19935,7 +19935,7 @@
     },
     "packages/logger": {
       "name": "@jaypie/logger",
-      "version": "1.2.18",
+      "version": "1.2.19",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-typescript": "^12.1.2",

--- a/packages/jaypie/package.json
+++ b/packages/jaypie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jaypie",
-  "version": "1.2.60",
+  "version": "1.2.61",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"
@@ -44,7 +44,7 @@
     "@jaypie/express": "^1.2.27",
     "@jaypie/kit": "^1.2.12",
     "@jaypie/lambda": "^1.2.11",
-    "@jaypie/logger": "^1.2.18"
+    "@jaypie/logger": "^1.2.19"
   },
   "devDependencies": {
     "@jaypie/types": "^0.1.7",
@@ -59,7 +59,7 @@
     "typescript-eslint": "^8.46.1"
   },
   "peerDependencies": {
-    "@jaypie/llm": "^1.3.6"
+    "@jaypie/llm": "^1.3.7"
   },
   "peerDependenciesMeta": {
     "@jaypie/llm": {

--- a/packages/llm/CLAUDE.md
+++ b/packages/llm/CLAUDE.md
@@ -229,6 +229,46 @@ const response = await Llm.operate("What's the weather in NYC?", {
 });
 ```
 
+### Progress Events
+
+`operate()` accepts an `onProgress` callback that receives lightweight,
+serializable events as the loop runs — suitable for forwarding directly to
+websockets, queues, or UI updates:
+
+```typescript
+import Llm, { LlmProgressEventType } from "@jaypie/llm";
+
+const response = await Llm.operate(input, {
+  tools: toolkit,
+  onProgress: (event) => {
+    // event.type: start, model_request, model_response,
+    //             tool_call, tool_result, tool_error, retry, done
+    websocket.send(JSON.stringify(event));
+  },
+});
+```
+
+Event fields (all optional except `type`): `content` (`model_response`,
+`done`), `error` (`tool_error`, `retry`), `maxTurns`/`model`/`provider`
+(`start`), `tool` (`{ name, arguments }`), `toolCalls` (`model_response`),
+`turn` (1-indexed), `usage` (per-turn on `model_response`, cumulative on
+`done`).
+
+Errors thrown by the callback are logged at warn and never interrupt the
+loop. The `hooks` option remains the right choice when the full provider
+request/response payloads are needed. `stream()` communicates progress
+through its chunks; `onProgress` applies to `operate()`.
+
+### Operate Logging
+
+The operate loop logs `operate.input`, `operate.options`, `operate.request`,
+and `operate.response` vars at **trace**. Request and response vars are
+draconian subsets — the request logs `{ model, turn, messages, latest }` and
+the response logs only the text content or the requested tool calls. Full
+provider payloads are never logged; use `hooks`
+(`beforeEachModelRequest` / `afterEachModelResponse`) or LLM Observability
+to capture them.
+
 ### Streaming with Automatic Tool Execution
 
 The `stream()` method provides real-time streaming while **automatically executing tools** - combining the responsiveness of streaming with the full tool-calling lifecycle of `operate()`.

--- a/packages/llm/CLAUDE.md
+++ b/packages/llm/CLAUDE.md
@@ -248,11 +248,18 @@ const response = await Llm.operate(input, {
 });
 ```
 
-Event fields (all optional except `type`): `content` (`model_response`,
-`done`), `error` (`tool_error`, `retry`), `maxTurns`/`model`/`provider`
-(`start`), `tool` (`{ name, arguments }`), `toolCalls` (`model_response`),
-`turn` (1-indexed), `usage` (per-turn on `model_response`, cumulative on
-`done`).
+Fields carried by each event (`turn` is 1-indexed):
+
+| Event | Fields |
+|-------|--------|
+| `start` | `model`, `provider`, `maxTurns` |
+| `model_request` | `turn`, `model` |
+| `model_response` | `turn`, `content` (text, if any), `toolCalls` (`[{ name, arguments }]`, if any), `usage` (this turn) |
+| `tool_call` | `turn`, `tool: { name, arguments }` — before the tool runs; `arguments` is the JSON string |
+| `tool_result` | `turn`, `tool: { name }` — result value deliberately omitted; use `afterEachTool` to receive it |
+| `tool_error` | `turn`, `tool: { name }`, `error` (message string) |
+| `retry` | `turn`, `error` (message string) |
+| `done` | `turn` (total turns used), `content` (final), `usage` (cumulative) |
 
 Errors thrown by the callback are logged at warn and never interrupt the
 loop. The `hooks` option remains the right choice when the full provider

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/llm",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "Large language model utilities",
   "repository": {
     "type": "git",

--- a/packages/llm/src/index.ts
+++ b/packages/llm/src/index.ts
@@ -16,11 +16,15 @@ export type {
   LlmOperateOptions,
   LlmOperateResponse,
   LlmOptions,
+  LlmProgressCallback,
+  LlmProgressEvent,
+  LlmProgressToolCall,
   LlmProvider,
 } from "./types/LlmProvider.interface.js";
 export {
   LlmMessageRole,
   LlmMessageType,
+  LlmProgressEventType,
 } from "./types/LlmProvider.interface.js";
 export {
   isLlmOperateInput,

--- a/packages/llm/src/operate/OperateLoop.ts
+++ b/packages/llm/src/operate/OperateLoop.ts
@@ -4,6 +4,7 @@ import { JsonObject } from "@jaypie/types";
 import { Toolkit } from "../tools/Toolkit.class.js";
 import {
   LlmHistory,
+  LlmHistoryItem,
   LlmInputMessage,
   LlmMessageRole,
   LlmMessageType,
@@ -11,6 +12,7 @@ import {
   LlmOperateOptions,
   LlmOperateResponse,
   LlmOutputMessage,
+  LlmProgressEventType,
   LlmToolCall,
   LlmToolResult,
 } from "../types/LlmProvider.interface.js";
@@ -28,6 +30,7 @@ import {
 import { ProviderAdapter } from "./adapters/ProviderAdapter.interface.js";
 import { HookRunner, hookRunner, LlmHooks } from "./hooks/index.js";
 import { InputProcessor, inputProcessor } from "./input/index.js";
+import { emitProgress } from "./progress/index.js";
 import {
   createResponseBuilder,
   ResponseBuilderConfig,
@@ -126,13 +129,23 @@ export class OperateLoop {
     const log = getLogger();
     // Log what was passed to operate
     log.trace("[operate] Starting operate loop");
-    log.var({ "operate.input": input });
-    log.var({ "operate.options": options });
+    log.trace.var({ "operate.input": input });
+    log.trace.var({ "operate.options": options });
 
     // Initialize state
     const state = await this.initializeState(input, options);
     const context = this.createContext(options);
     const modelName = options.model ?? this.adapter.defaultModel;
+
+    await emitProgress({
+      event: {
+        maxTurns: state.maxTurns,
+        model: modelName,
+        provider: this.adapter.name,
+        type: LlmProgressEventType.Start,
+      },
+      onProgress: options.onProgress,
+    });
 
     // Enclosing LLM Observability span (no-op when DD_LLMOBS_ENABLED is unset).
     // Child llm/tool spans nest under it via the SDK's active-span context.
@@ -182,6 +195,15 @@ export class OperateLoop {
           inputData: input,
           metrics: usageToLlmObsMetrics(response.usage),
           outputData: response.content,
+        });
+        await emitProgress({
+          event: {
+            content: response.content,
+            turn: state.currentTurn,
+            type: LlmProgressEventType.Done,
+            usage: response.usage,
+          },
+          onProgress: options.onProgress,
         });
         return response;
       },
@@ -307,9 +329,28 @@ export class OperateLoop {
     // Build provider-specific request
     const providerRequest = this.adapter.buildRequest(request);
 
-    // Log what was passed to the model
+    // Log a draconian subset of the request; the full payload is available
+    // via the beforeEachModelRequest hook
     log.trace("[operate] Calling model");
-    log.var({ "operate.request": providerRequest });
+    log.trace.var({
+      "operate.request": {
+        latest: this.summarizeHistoryItem(
+          request.messages[request.messages.length - 1],
+        ),
+        messages: request.messages.length,
+        model: request.model,
+        turn: state.currentTurn,
+      },
+    });
+
+    await emitProgress({
+      event: {
+        model: request.model,
+        turn: state.currentTurn,
+        type: LlmProgressEventType.ModelRequest,
+      },
+      onProgress: options.onProgress,
+    });
 
     // Execute beforeEachModelRequest hook
     await this.hookRunnerInstance.runBeforeModelRequest(context.hooks, {
@@ -318,9 +359,31 @@ export class OperateLoop {
       providerRequest,
     });
 
+    // Emit retry progress alongside the caller's onRetryableModelError hook
+    const hooks = context.hooks as LlmHooks;
+    const hooksWithProgress: LlmHooks = options.onProgress
+      ? {
+          ...hooks,
+          onRetryableModelError: async (retryContext) => {
+            await emitProgress({
+              event: {
+                error:
+                  retryContext.error instanceof Error
+                    ? retryContext.error.message
+                    : String(retryContext.error),
+                turn: state.currentTurn,
+                type: LlmProgressEventType.Retry,
+              },
+              onProgress: options.onProgress,
+            });
+            return hooks?.onRetryableModelError?.(retryContext);
+          },
+        }
+      : hooks;
+
     // Execute with retry inside a child llm span (no-op when llmobs disabled).
     // RetryExecutor handles error hooks and throws appropriate errors.
-    const { parsed, response } = await withLlmObsSpan(
+    const { parsed, response, toolCalls } = await withLlmObsSpan(
       {
         kind: "llm",
         modelName: options.model ?? this.adapter.defaultModel,
@@ -337,16 +400,28 @@ export class OperateLoop {
               options,
               providerRequest,
             },
-            hooks: context.hooks as LlmHooks,
+            hooks: hooksWithProgress,
           },
         );
 
-        // Log what was returned from the model
-        log.trace("[operate] Model response received");
-        log.var({ "operate.response": response });
-
         // Parse response
         const parsed = this.adapter.parseResponse(response, options);
+        const toolCalls = parsed.hasToolCalls
+          ? this.adapter.extractToolCalls(response)
+          : [];
+
+        // Log only the text or tool calls; the full payload is available
+        // via the afterEachModelResponse hook
+        log.trace("[operate] Model response received");
+        log.trace.var({
+          "operate.response":
+            toolCalls.length > 0
+              ? toolCalls.map(({ arguments: args, name }) => ({
+                  arguments: args,
+                  name,
+                }))
+              : parsed.content,
+        });
 
         annotateLlmObs({
           inputData: state.currentInput,
@@ -356,9 +431,23 @@ export class OperateLoop {
           outputData: parsed.content ?? "",
         });
 
-        return { parsed, response };
+        return { parsed, response, toolCalls };
       },
     );
+
+    await emitProgress({
+      event: {
+        content: parsed.content,
+        toolCalls: toolCalls.map(({ arguments: args, name }) => ({
+          arguments: args,
+          name,
+        })),
+        turn: state.currentTurn,
+        type: LlmProgressEventType.ModelResponse,
+        usage: parsed.usage ? [parsed.usage] : undefined,
+      },
+      onProgress: options.onProgress,
+    });
 
     // Track usage
     if (parsed.usage) {
@@ -394,8 +483,6 @@ export class OperateLoop {
 
     // Handle tool calls
     if (parsed.hasToolCalls) {
-      const toolCalls = this.adapter.extractToolCalls(response);
-
       if (toolCalls.length > 0 && state.toolkit && state.maxTurns > 1) {
         // Track updated provider request for tool results
         let currentProviderRequest = providerRequest;
@@ -412,6 +499,15 @@ export class OperateLoop {
         // Process each tool call
         for (const toolCall of toolCalls) {
           try {
+            await emitProgress({
+              event: {
+                tool: { arguments: toolCall.arguments, name: toolCall.name },
+                turn: state.currentTurn,
+                type: LlmProgressEventType.ToolCall,
+              },
+              onProgress: options.onProgress,
+            });
+
             // Execute beforeEachTool hook
             await this.hookRunnerInstance.runBeforeTool(context.hooks, {
               args: toolCall.arguments,
@@ -435,6 +531,15 @@ export class OperateLoop {
                 return result;
               },
             );
+
+            await emitProgress({
+              event: {
+                tool: { name: toolCall.name },
+                turn: state.currentTurn,
+                type: LlmProgressEventType.ToolResult,
+              },
+              onProgress: options.onProgress,
+            });
 
             // Execute afterEachTool hook
             await this.hookRunnerInstance.runAfterTool(context.hooks, {
@@ -472,6 +577,16 @@ export class OperateLoop {
               toolResultFormatted as LlmInputMessage,
             );
           } catch (error) {
+            await emitProgress({
+              event: {
+                error: (error as Error).message,
+                tool: { name: toolCall.name },
+                turn: state.currentTurn,
+                type: LlmProgressEventType.ToolError,
+              },
+              onProgress: options.onProgress,
+            });
+
             // Execute onToolError hook
             await this.hookRunnerInstance.runOnToolError(context.hooks, {
               args: toolCall.arguments,
@@ -560,6 +675,21 @@ export class OperateLoop {
     }
 
     return false; // Stop loop
+  }
+
+  /**
+   * Draconian summary of a history item for trace logging: string message
+   * content is kept; everything else is reduced to its type.
+   */
+  private summarizeHistoryItem(item?: LlmHistoryItem): unknown {
+    if (!item) {
+      return undefined;
+    }
+    const record = item as unknown as Record<string, unknown>;
+    if (typeof record.content === "string") {
+      return { content: record.content, role: record.role };
+    }
+    return { type: record.type ?? "message" };
   }
 
   /**

--- a/packages/llm/src/operate/__tests__/OperateLoop.spec.ts
+++ b/packages/llm/src/operate/__tests__/OperateLoop.spec.ts
@@ -11,6 +11,8 @@ import {
   LlmMessageRole,
   LlmMessageType,
   LlmOperateOptions,
+  LlmProgressEvent,
+  LlmProgressEventType,
   LlmResponseStatus,
 } from "../../types/LlmProvider.interface.js";
 import { ErrorCategory, ParsedResponse, StandardToolCall } from "../types.js";
@@ -38,7 +40,7 @@ vi.mock("@jaypie/logger", () => ({
     lib: vi.fn(() => ({
       debug: vi.fn(),
       error: vi.fn(),
-      trace: vi.fn(),
+      trace: Object.assign(vi.fn(), { var: vi.fn() }),
       var: vi.fn(),
       warn: vi.fn(),
     })),
@@ -493,7 +495,7 @@ describe("OperateLoop", () => {
         const mockLogger = {
           debug: vi.fn(),
           error: vi.fn(),
-          trace: vi.fn(),
+          trace: Object.assign(vi.fn(), { var: vi.fn() }),
           var: vi.fn(),
           warn: vi.fn(),
         };
@@ -566,6 +568,196 @@ describe("OperateLoop", () => {
           expect.stringContaining("test_tool"),
         );
         expect(mockLogger.error).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("Progress", () => {
+      it("emits start, model_request, model_response, and done events in order", async () => {
+        const events: LlmProgressEvent[] = [];
+        const loop = new OperateLoop({
+          adapter: mockAdapter,
+          client: mockClient,
+        });
+
+        const result = await loop.execute("Hello", {
+          onProgress: (event) => {
+            events.push(event);
+          },
+        });
+
+        expect(result.status).toBe(LlmResponseStatus.Completed);
+        expect(events.map(({ type }) => type)).toEqual([
+          LlmProgressEventType.Start,
+          LlmProgressEventType.ModelRequest,
+          LlmProgressEventType.ModelResponse,
+          LlmProgressEventType.Done,
+        ]);
+        expect(events[0].model).toBe("mock-model");
+        expect(events[0].provider).toBe("mock");
+        expect(events[events.length - 1].content).toBe("Hello!");
+        expect(events[events.length - 1].usage).toHaveLength(1);
+      });
+
+      it("emits tool_call and tool_result events", async () => {
+        let callCount = 0;
+        mockAdapter.parseResponse = vi.fn((response): ParsedResponse => {
+          callCount++;
+          if (callCount === 1) {
+            return {
+              content: undefined,
+              hasToolCalls: true,
+              stopReason: "tool_use",
+              usage: {
+                input: 10,
+                output: 20,
+                reasoning: 0,
+                total: 30,
+                provider: "mock",
+                model: "mock-model",
+              },
+              raw: response,
+            };
+          }
+          return {
+            content: "Done!",
+            hasToolCalls: false,
+            stopReason: "end_turn",
+            usage: {
+              input: 10,
+              output: 20,
+              reasoning: 0,
+              total: 30,
+              provider: "mock",
+              model: "mock-model",
+            },
+            raw: response,
+          };
+        }) as Mock;
+        mockAdapter.extractToolCalls = vi.fn((): StandardToolCall[] => [
+          {
+            callId: "call-1",
+            name: "test_tool",
+            arguments: "{}",
+            raw: {},
+          },
+        ]);
+        const toolkit = new Toolkit([
+          {
+            name: "test_tool",
+            description: "A test tool",
+            parameters: { type: "object" },
+            type: "function",
+            call: vi.fn(() => "tool result"),
+          },
+        ]);
+
+        const events: LlmProgressEvent[] = [];
+        const loop = new OperateLoop({
+          adapter: mockAdapter,
+          client: mockClient,
+        });
+
+        await loop.execute("Call the tool", {
+          onProgress: (event) => {
+            events.push(event);
+          },
+          tools: toolkit,
+          turns: 3,
+        });
+
+        const toolCallEvent = events.find(
+          ({ type }) => type === LlmProgressEventType.ToolCall,
+        );
+        expect(toolCallEvent?.tool).toEqual({
+          arguments: "{}",
+          name: "test_tool",
+        });
+        const toolResultEvent = events.find(
+          ({ type }) => type === LlmProgressEventType.ToolResult,
+        );
+        expect(toolResultEvent?.tool?.name).toBe("test_tool");
+        const modelResponseEvent = events.find(
+          ({ type }) => type === LlmProgressEventType.ModelResponse,
+        );
+        expect(modelResponseEvent?.toolCalls).toEqual([
+          { arguments: "{}", name: "test_tool" },
+        ]);
+      });
+
+      it("emits tool_error when a tool throws", async () => {
+        let callCount = 0;
+        mockAdapter.parseResponse = vi.fn((response): ParsedResponse => {
+          callCount++;
+          return {
+            content: callCount === 1 ? undefined : "Done!",
+            hasToolCalls: callCount === 1,
+            stopReason: callCount === 1 ? "tool_use" : "end_turn",
+            usage: {
+              input: 10,
+              output: 20,
+              reasoning: 0,
+              total: 30,
+              provider: "mock",
+              model: "mock-model",
+            },
+            raw: response,
+          };
+        }) as Mock;
+        mockAdapter.extractToolCalls = vi.fn((): StandardToolCall[] => [
+          {
+            callId: "call-1",
+            name: "test_tool",
+            arguments: "{}",
+            raw: {},
+          },
+        ]);
+        const toolkit = new Toolkit([
+          {
+            name: "test_tool",
+            description: "A test tool",
+            parameters: { type: "object" },
+            type: "function",
+            call: vi.fn(() => {
+              throw new Error("boom");
+            }),
+          },
+        ]);
+
+        const events: LlmProgressEvent[] = [];
+        const loop = new OperateLoop({
+          adapter: mockAdapter,
+          client: mockClient,
+        });
+
+        await loop.execute("Call the tool", {
+          onProgress: (event) => {
+            events.push(event);
+          },
+          tools: toolkit,
+          turns: 3,
+        });
+
+        const toolErrorEvent = events.find(
+          ({ type }) => type === LlmProgressEventType.ToolError,
+        );
+        expect(toolErrorEvent?.error).toBe("boom");
+        expect(toolErrorEvent?.tool?.name).toBe("test_tool");
+      });
+
+      it("does not interrupt the loop when onProgress throws", async () => {
+        const loop = new OperateLoop({
+          adapter: mockAdapter,
+          client: mockClient,
+        });
+
+        const result = await loop.execute("Hello", {
+          onProgress: () => {
+            throw new Error("Progress failure");
+          },
+        });
+
+        expect(result.status).toBe(LlmResponseStatus.Completed);
+        expect(result.content).toBe("Hello!");
       });
     });
 

--- a/packages/llm/src/operate/progress/emitProgress.ts
+++ b/packages/llm/src/operate/progress/emitProgress.ts
@@ -1,0 +1,29 @@
+import {
+  LlmProgressCallback,
+  LlmProgressEvent,
+} from "../../types/LlmProvider.interface.js";
+import { getLogger } from "../../util/index.js";
+
+/**
+ * Deliver a progress event to the caller's onProgress callback.
+ * Errors thrown by the callback are logged and swallowed — progress
+ * reporting must never interrupt the operate loop.
+ */
+export async function emitProgress({
+  event,
+  onProgress,
+}: {
+  event: LlmProgressEvent;
+  onProgress?: LlmProgressCallback;
+}): Promise<void> {
+  if (!onProgress) {
+    return;
+  }
+  try {
+    await onProgress(event);
+  } catch (error) {
+    const log = getLogger();
+    log.warn(`[operate] onProgress callback threw on "${event.type}" event`);
+    log.var({ error });
+  }
+}

--- a/packages/llm/src/operate/progress/index.ts
+++ b/packages/llm/src/operate/progress/index.ts
@@ -1,0 +1,1 @@
+export { emitProgress } from "./emitProgress.js";

--- a/packages/llm/src/types/LlmProvider.interface.ts
+++ b/packages/llm/src/types/LlmProvider.interface.ts
@@ -221,6 +221,57 @@ export interface LlmMessageOptions {
   system?: string;
 }
 
+// Progress
+
+export enum LlmProgressEventType {
+  Done = "done",
+  ModelRequest = "model_request",
+  ModelResponse = "model_response",
+  Retry = "retry",
+  Start = "start",
+  ToolCall = "tool_call",
+  ToolError = "tool_error",
+  ToolResult = "tool_result",
+}
+
+export interface LlmProgressToolCall {
+  /** JSON string of arguments (tool_call events only) */
+  arguments?: string;
+  /** Tool name */
+  name: string;
+}
+
+/**
+ * Lightweight, serializable progress event emitted by the operate loop.
+ * Suitable for forwarding directly to websockets, queues, or UI updates.
+ */
+export interface LlmProgressEvent {
+  /** Text or structured content (model_response, done) */
+  content?: string | JsonObject;
+  /** Error message (tool_error, retry) */
+  error?: string;
+  /** Maximum turns allowed for the loop (start) */
+  maxTurns?: number;
+  /** Model handling the request (start, model_request) */
+  model?: string;
+  /** Provider name (start) */
+  provider?: string;
+  /** The tool involved (tool_call, tool_result, tool_error) */
+  tool?: LlmProgressToolCall;
+  /** Tools the model requested (model_response) */
+  toolCalls?: LlmProgressToolCall[];
+  /** Current turn, 1-indexed */
+  turn?: number;
+  /** Event type */
+  type: LlmProgressEventType;
+  /** Usage: this turn for model_response, cumulative for done */
+  usage?: LlmUsage;
+}
+
+export type LlmProgressCallback = (
+  event: LlmProgressEvent,
+) => unknown | Promise<unknown>;
+
 export interface LlmOperateOptions {
   data?: NaturalMap;
   explain?: boolean;
@@ -303,6 +354,13 @@ export interface LlmOperateOptions {
   };
   instructions?: string;
   model?: string;
+  /**
+   * Receives lightweight progress events as the operate loop runs:
+   * start, model_request, model_response, tool_call, tool_result,
+   * tool_error, retry, done. Errors thrown by the callback are logged
+   * and never interrupt the loop.
+   */
+  onProgress?: LlmProgressCallback;
   placeholders?: {
     input?: boolean;
     instructions?: boolean;

--- a/packages/logger/CLAUDE.md
+++ b/packages/logger/CLAUDE.md
@@ -57,6 +57,9 @@ Defined in `constants.ts` with numeric values for comparison:
 - `LOG_FORMAT` - Output format (`json` or `text`)
 - `LOG_LEVEL_FIELD` - Include log level in JSON output (`true` adds `level` key, or set to custom key name like `status`; `false`/unset to omit)
 - `LOG_VAR_LEVEL` - Level for `.var()` calls
+- `LOG_MAX_ENTRY_BYTES` - Cap on the serialized entry (default 262144 = 256KB, the CloudWatch event limit; `0`/`false` disables)
+- `LOG_MAX_STRING` - Truncate each string field beyond N characters (default off)
+- `LOG_MAX_DEPTH` - Replace objects/arrays nested beyond N levels with `[Object]`/`[Array(n)]` (default off)
 - `MODULE_LOGGER` - Enable library loggers (boolean)
 - `MODULE_LOG_LEVEL` - Override level for library loggers
 - `PROJECT_*` - Auto-tagged: COMMIT, ENV, KEY, SERVICE, SPONSOR, VERSION
@@ -121,6 +124,27 @@ log.teardown();                                           // Emits report, reset
 - `report(data)` merges key-value data into the report; warns on duplicate keys
 - Warn and error calls are auto-counted during an active session
 
+### Serialization Limits
+
+Entries are capped at 256KB by default (`maxEntryBytes: 262144` — the
+CloudWatch Logs event limit that fronts Datadog in Lambda; Datadog's own
+per-log cap is 1MB). Oversized entries truncate the top-level attributes of
+`data` largest-first, each keeping a 72-character preview plus a visible
+marker (`… [truncated 612,340 chars]`); only if every attribute is truncated
+and the entry is still oversized does `data` collapse to `[truncated N
+bytes]`. Two more limits are off by default: `maxStringLength` (truncate
+each string field beyond N chars) and `maxDepth` (replace nesting beyond N
+levels with `[Object]`/`[Array(n)]`).
+
+Resolution order: constructor options (`new Logger({ maxEntryBytes })`),
+then env vars (`LOG_MAX_ENTRY_BYTES`, `LOG_MAX_STRING`, `LOG_MAX_DEPTH`),
+then defaults. Pass `false` (or env `0`/`false`/`none`/`off`) to disable a
+limit. `log.config({ maxStringLength: 1024 })` overrides at runtime,
+propagates to derived loggers (`lib`, `with`, `flag`), and persists across
+`init()`. Limits apply at serialization time only — the caller's object is
+never mutated; class instances (Error, Date) are not traversed. See
+`src/limits.ts`.
+
 ### Tagging
 
 Tags are key-value pairs included in every log output:
@@ -139,6 +163,7 @@ Factory function returning a `JaypieLogger` instance.
 
 ### JaypieLogger Methods
 
+- `config({ maxDepth?, maxEntryBytes?, maxStringLength? })` - Update serialization limits at runtime (number sets, `false` disables, omitted unchanged)
 - `debug/info/warn/error/fatal/trace(...messages)` - Log at level
 - `*.var(keyValue)` - Log variable at level
 - `var(keyValue)` - Log variable at configured var level

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/logger",
-  "version": "1.2.18",
+  "version": "1.2.19",
   "description": "Logger utilities for Jaypie applications",
   "repository": {
     "type": "git",

--- a/packages/logger/src/JaypieLogger.ts
+++ b/packages/logger/src/JaypieLogger.ts
@@ -1,10 +1,11 @@
 import Logger from "./Logger";
 import { DEFAULT, FORMAT, LEVEL } from "./constants";
 import { _resetDatadogTransport } from "./datadogTransport";
+import { SerializationLimitOptions } from "./limits";
 import { logTags } from "./logTags";
 import { logVar } from "./logVar";
 
-interface JaypieLoggerOptions {
+interface JaypieLoggerOptions extends SerializationLimitOptions {
   level?: string;
   tags?: Record<string, string>;
 }
@@ -48,9 +49,12 @@ class JaypieLogger {
 
   constructor({
     level = process.env.LOG_LEVEL,
+    maxDepth,
+    maxEntryBytes,
+    maxStringLength,
     tags = {},
   }: JaypieLoggerOptions = {}) {
-    this._params = { level, tags };
+    this._params = { level, maxDepth, maxEntryBytes, maxStringLength, tags };
     this._loggers = [];
     this._tags = {};
     this._withLoggers = {};
@@ -61,6 +65,9 @@ class JaypieLogger {
     this._logger = new Logger({
       format: FORMAT.JSON,
       level: this.level,
+      maxDepth,
+      maxEntryBytes,
+      maxStringLength,
       tags: this._tags,
     });
     this._loggers = [this._logger];
@@ -111,6 +118,30 @@ class JaypieLogger {
       this._logger.var(logVar(messageObject, messageValue));
   }
 
+  /**
+   * Update serialization limits at runtime for this logger and all loggers
+   * derived from it (lib, with, flag). Pass a number to set a limit,
+   * `false` to disable one; omitted keys are unchanged. Persists across
+   * init().
+   */
+  public config(options: SerializationLimitOptions = {}): void {
+    if (options.maxDepth !== undefined) {
+      this._params.maxDepth = options.maxDepth;
+    }
+    if (options.maxEntryBytes !== undefined) {
+      this._params.maxEntryBytes = options.maxEntryBytes;
+    }
+    if (options.maxStringLength !== undefined) {
+      this._params.maxStringLength = options.maxStringLength;
+    }
+    for (const logger of this._loggers) {
+      logger.config(options);
+    }
+    for (const key of Object.keys(this._withLoggers)) {
+      this._withLoggers[key].config(options);
+    }
+  }
+
   public flag(flag?: string): JaypieLogger {
     if (typeof flag !== "string" || flag === "") {
       return this;
@@ -132,6 +163,9 @@ class JaypieLogger {
     this._logger = new Logger({
       format: FORMAT.JSON,
       level: this.level,
+      maxDepth: this._params.maxDepth,
+      maxEntryBytes: this._params.maxEntryBytes,
+      maxStringLength: this._params.maxStringLength,
       tags: this._tags,
     });
     this._loggers = [this._logger];
@@ -217,6 +251,9 @@ class JaypieLogger {
         }
         return LEVEL.SILENT;
       })(),
+      maxDepth: this._params.maxDepth,
+      maxEntryBytes: this._params.maxEntryBytes,
+      maxStringLength: this._params.maxStringLength,
       tags: newTags,
     });
     this._loggers.push(logger._logger);
@@ -305,6 +342,9 @@ class JaypieLogger {
     }
     const logger = new JaypieLogger({
       level: this.level,
+      maxDepth: this._params.maxDepth,
+      maxEntryBytes: this._params.maxEntryBytes,
+      maxStringLength: this._params.maxStringLength,
       tags: { ...this._tags },
     });
     logger._logger = this._logger.with(key, value);

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -1,4 +1,13 @@
 import { DEFAULT, ERROR, FORMAT, LEVEL, LEVEL_VALUES } from "./constants";
+import {
+  applyValueLimits,
+  enforceEntryLimit,
+  hasValueLimits,
+  resolveSerializationLimits,
+  SerializationLimitOptions,
+  SerializationLimits,
+  truncateToBudget,
+} from "./limits";
 import { filterByType, pipelines } from "./pipelines";
 import { sanitizeAuth } from "./sanitizeAuth";
 import { forceString, out, parse, parsesTo, stringify } from "./utils";
@@ -7,7 +16,7 @@ type LogLevel = string;
 type LogFormat = "json" | "text";
 type Tags = Record<string, string>;
 
-interface LoggerOptions {
+interface LoggerOptions extends SerializationLimitOptions {
   format?: LogFormat;
   level?: LogLevel;
   levelField?: boolean | string;
@@ -52,19 +61,33 @@ class Logger {
   public var: (messageObject: unknown, messageValue?: unknown) => void;
   public warn: LogMethod;
   private levelField: false | string;
+  private limits: SerializationLimits;
 
   constructor({
     format = (process.env.LOG_FORMAT as LogFormat) || DEFAULT.LEVEL,
     level = process.env.LOG_LEVEL || DEFAULT.LEVEL,
     levelField,
+    maxDepth,
+    maxEntryBytes,
+    maxStringLength,
     tags = {},
     varLevel = process.env.LOG_VAR_LEVEL || DEFAULT.VAR_LEVEL,
   }: LoggerOptions = {}) {
     this.levelField = resolveLevelField(levelField);
+    this.limits = resolveSerializationLimits({
+      maxDepth,
+      maxEntryBytes,
+      maxStringLength,
+    });
     this.options = {
       format,
       level,
       levelField: this.levelField || undefined,
+      // Pin resolved limits (false = explicitly off) so child loggers
+      // created via with() inherit this config instead of re-resolving
+      maxDepth: this.limits.maxDepth ?? false,
+      maxEntryBytes: this.limits.maxEntryBytes ?? false,
+      maxStringLength: this.limits.maxStringLength ?? false,
       varLevel,
     };
 
@@ -92,10 +115,18 @@ class Logger {
   ): LogMethod {
     const logFn = (...messages: unknown[]): void => {
       if (LEVEL_VALUES[logLevel] <= LEVEL_VALUES[checkLevel]) {
-        const sanitized = messages.map(sanitizeAuth);
+        let sanitized = messages.map(sanitizeAuth);
+        if (hasValueLimits(this.limits)) {
+          sanitized = sanitized.map((item) =>
+            applyValueLimits(item, this.limits),
+          );
+        }
         if (format === FORMAT.JSON) {
           let message = stringify(...sanitized);
           let parses = parsesTo(message);
+          // When data comes from the full message they mirror each other;
+          // entry-limit truncation must keep them in sync
+          let syncMessageToData = parses.parses;
           const last = sanitized[sanitized.length - 1];
           if (
             sanitized.length > 1 &&
@@ -109,6 +140,7 @@ class Logger {
             if (lastParses.parses) {
               message = stringify(...sanitized.slice(0, -1));
               parses = lastParses;
+              syncMessageToData = false;
             }
           }
           const json: LogJson = {
@@ -121,9 +153,19 @@ class Logger {
           if (this.levelField) {
             json[this.levelField] = logLevel;
           }
-          out(json, { level: logLevel });
+          let entry: LogJson = json;
+          if (this.limits.maxEntryBytes !== undefined) {
+            entry = enforceEntryLimit(json, {
+              maxEntryBytes: this.limits.maxEntryBytes,
+              syncMessageToData,
+            }) as LogJson;
+          }
+          out(entry, { level: logLevel });
         } else {
-          const message = stringify(...sanitized);
+          let message = stringify(...sanitized);
+          if (this.limits.maxEntryBytes !== undefined) {
+            message = truncateToBudget(message, this.limits.maxEntryBytes);
+          }
           out(message, { level: logLevel });
         }
       }
@@ -169,6 +211,9 @@ class Logger {
           }
         }
         messageVal = filterByType(messageVal);
+        if (hasValueLimits(this.limits)) {
+          messageVal = applyValueLimits(messageVal, this.limits);
+        }
 
         const json: LogJson = {
           data: parse(messageVal),
@@ -182,7 +227,14 @@ class Logger {
         }
 
         if (LEVEL_VALUES[logLevel] <= LEVEL_VALUES[checkLevel]) {
-          out(json, { level: logLevel });
+          let entry: LogJson = json;
+          if (this.limits.maxEntryBytes !== undefined) {
+            entry = enforceEntryLimit(json, {
+              maxEntryBytes: this.limits.maxEntryBytes,
+              syncMessageToData: true,
+            }) as LogJson;
+          }
+          out(entry, { level: logLevel });
         }
       } else {
         return logFn(msgObj);
@@ -190,6 +242,23 @@ class Logger {
     };
 
     return logFn as LogMethod;
+  }
+
+  /**
+   * Update serialization limits at runtime. Pass a number to set a limit,
+   * `false` to disable one; omitted keys are unchanged.
+   */
+  public config(options: SerializationLimitOptions = {}): void {
+    this.limits = resolveSerializationLimits({
+      maxDepth: options.maxDepth ?? this.limits.maxDepth ?? false,
+      maxEntryBytes:
+        options.maxEntryBytes ?? this.limits.maxEntryBytes ?? false,
+      maxStringLength:
+        options.maxStringLength ?? this.limits.maxStringLength ?? false,
+    });
+    this.options.maxDepth = this.limits.maxDepth ?? false;
+    this.options.maxEntryBytes = this.limits.maxEntryBytes ?? false;
+    this.options.maxStringLength = this.limits.maxStringLength ?? false;
   }
 
   public tag(key: unknown, value?: unknown): void {

--- a/packages/logger/src/__tests__/limits.spec.ts
+++ b/packages/logger/src/__tests__/limits.spec.ts
@@ -1,0 +1,309 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DEFAULT } from "../constants";
+import {
+  applyValueLimits,
+  byteLength,
+  enforceEntryLimit,
+  resolveSerializationLimits,
+  truncateString,
+} from "../limits";
+import Logger from "../Logger";
+import { createLogger } from "../JaypieLogger";
+
+//
+//
+// Helpers
+//
+
+function lastJsonOutput(spy: ReturnType<typeof vi.spyOn>): any {
+  const call = spy.mock.calls[spy.mock.calls.length - 1];
+  const line = call[0] as string;
+  return JSON.parse(line);
+}
+
+//
+//
+// Tests
+//
+
+describe("Serialization Limits", () => {
+  const ENV_KEYS = ["LOG_MAX_DEPTH", "LOG_MAX_ENTRY_BYTES", "LOG_MAX_STRING"];
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (savedEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = savedEnv[key];
+      }
+    }
+    vi.restoreAllMocks();
+  });
+
+  describe("resolveSerializationLimits", () => {
+    it("defaults maxEntryBytes on, others off", () => {
+      const limits = resolveSerializationLimits();
+      expect(limits.maxEntryBytes).toBe(DEFAULT.MAX_ENTRY_BYTES);
+      expect(limits.maxDepth).toBeUndefined();
+      expect(limits.maxStringLength).toBeUndefined();
+    });
+
+    it("reads env vars", () => {
+      process.env.LOG_MAX_DEPTH = "3";
+      process.env.LOG_MAX_ENTRY_BYTES = "1024";
+      process.env.LOG_MAX_STRING = "100";
+      const limits = resolveSerializationLimits();
+      expect(limits.maxDepth).toBe(3);
+      expect(limits.maxEntryBytes).toBe(1024);
+      expect(limits.maxStringLength).toBe(100);
+    });
+
+    it("disables via env values 0 and false", () => {
+      process.env.LOG_MAX_ENTRY_BYTES = "0";
+      expect(resolveSerializationLimits().maxEntryBytes).toBeUndefined();
+      process.env.LOG_MAX_ENTRY_BYTES = "false";
+      expect(resolveSerializationLimits().maxEntryBytes).toBeUndefined();
+    });
+
+    it("explicit options win over env", () => {
+      process.env.LOG_MAX_ENTRY_BYTES = "1024";
+      const limits = resolveSerializationLimits({ maxEntryBytes: 2048 });
+      expect(limits.maxEntryBytes).toBe(2048);
+    });
+
+    it("explicit false disables a defaulted limit", () => {
+      const limits = resolveSerializationLimits({ maxEntryBytes: false });
+      expect(limits.maxEntryBytes).toBeUndefined();
+    });
+  });
+
+  describe("truncateString", () => {
+    it("passes short strings through", () => {
+      expect(truncateString("hello", 10)).toBe("hello");
+    });
+
+    it("keeps the first N chars and appends a marker with the dropped count", () => {
+      const value = "a".repeat(1000);
+      const result = truncateString(value, 72);
+      expect(result.startsWith("a".repeat(72))).toBe(true);
+      expect(result).toContain("… [truncated 928 chars]");
+    });
+
+    it("formats large counts with commas", () => {
+      const value = "b".repeat(612412);
+      const result = truncateString(value, 72);
+      expect(result).toContain("… [truncated 612,340 chars]");
+    });
+  });
+
+  describe("applyValueLimits", () => {
+    it("truncates nested strings with maxStringLength", () => {
+      const value = { nested: { text: "x".repeat(100) } };
+      const result = applyValueLimits(value, { maxStringLength: 10 }) as any;
+      expect(result.nested.text).toContain("… [truncated 90 chars]");
+    });
+
+    it("never mutates the input", () => {
+      const value = { nested: { text: "x".repeat(100) } };
+      applyValueLimits(value, { maxStringLength: 10 });
+      expect(value.nested.text).toBe("x".repeat(100));
+    });
+
+    it("replaces objects beyond maxDepth with placeholders", () => {
+      const value = { a: { b: { c: 1 } }, list: [[1, 2, 3]] };
+      const result = applyValueLimits(value, { maxDepth: 1 }) as any;
+      expect(result.a).toEqual({ b: "[Object]" });
+      expect(result.list).toEqual(["[Array(3)]"]);
+    });
+
+    it("handles circular references", () => {
+      const value: Record<string, unknown> = { name: "loop" };
+      value.self = value;
+      const result = applyValueLimits(value, { maxStringLength: 100 }) as any;
+      expect(result.self).toBe("[Circular]");
+    });
+
+    it("leaves class instances untouched", () => {
+      const error = new Error("x".repeat(100));
+      const result = applyValueLimits(
+        { error },
+        { maxStringLength: 10 },
+      ) as any;
+      expect(result.error).toBe(error);
+    });
+  });
+
+  describe("enforceEntryLimit", () => {
+    it("returns the entry unchanged when under the limit", () => {
+      const entry = { data: { small: "ok" }, message: "ok" };
+      const result = enforceEntryLimit(entry, { maxEntryBytes: 10000 });
+      expect(result).toBe(entry);
+    });
+
+    it("truncates top-level attributes largest-first until under the limit", () => {
+      const entry = {
+        data: {
+          big: "b".repeat(5000),
+          medium: "m".repeat(500),
+          small: "keep-me",
+        },
+        message: "post body",
+        var: "request",
+      };
+      const result = enforceEntryLimit(entry, { maxEntryBytes: 1024 }) as any;
+      expect(result.data.big).toContain("… [truncated");
+      expect(result.data.big.startsWith("b".repeat(72))).toBe(true);
+      expect(result.data.small).toBe("keep-me");
+      expect(byteLength(result)).toBeLessThanOrEqual(1024);
+    });
+
+    it("previews stringified objects for non-string attributes", () => {
+      const entry = {
+        data: { payload: { inner: "z".repeat(5000) } },
+        message: "m",
+      };
+      const result = enforceEntryLimit(entry, { maxEntryBytes: 512 }) as any;
+      expect(typeof result.data.payload).toBe("string");
+      expect(result.data.payload).toContain("… [truncated");
+    });
+
+    it("syncs message to truncated data when syncMessageToData is set", () => {
+      const entry = {
+        data: { big: "b".repeat(5000) },
+        message: JSON.stringify({ big: "b".repeat(5000) }),
+        var: "request",
+      };
+      const result = enforceEntryLimit(entry, {
+        maxEntryBytes: 1024,
+        syncMessageToData: true,
+      }) as any;
+      expect(result.message).toContain("… [truncated");
+      expect(result.message.length).toBeLessThan(1024);
+    });
+
+    it("collapses data to a byte marker as a last resort", () => {
+      const data: Record<string, string> = {};
+      for (let i = 0; i < 50; i++) {
+        data[`key${i}`] = "v".repeat(200);
+      }
+      const result = enforceEntryLimit(
+        { data, message: "m" },
+        { maxEntryBytes: 256 },
+      ) as any;
+      expect(result.data).toMatch(/^\[truncated [\d,]+ bytes\]$/);
+    });
+
+    it("truncates message-only entries", () => {
+      const entry = { message: "m".repeat(5000) };
+      const result = enforceEntryLimit(entry, { maxEntryBytes: 1024 }) as any;
+      expect(result.message).toContain("… [truncated");
+      expect(byteLength(result)).toBeLessThanOrEqual(1024);
+    });
+
+    it("never mutates the input entry", () => {
+      const entry = { data: { big: "b".repeat(5000) }, message: "m" };
+      enforceEntryLimit(entry, { maxEntryBytes: 512 });
+      expect(entry.data.big).toBe("b".repeat(5000));
+    });
+  });
+
+  describe("Logger integration", () => {
+    it("truncates oversized var entries by default", () => {
+      const spy = vi.spyOn(console, "debug").mockImplementation(() => {});
+      const logger = new Logger({ format: "json" });
+      const request = { body: "x".repeat(DEFAULT.MAX_ENTRY_BYTES * 2) };
+      logger.debug.var({ request });
+      const json = lastJsonOutput(spy);
+      expect(json.var).toBe("request");
+      expect(json.data.body).toContain("… [truncated");
+      expect(byteLength(json)).toBeLessThanOrEqual(DEFAULT.MAX_ENTRY_BYTES);
+      // The caller's object is untouched
+      expect(request.body.length).toBe(DEFAULT.MAX_ENTRY_BYTES * 2);
+    });
+
+    it("honors constructor maxEntryBytes", () => {
+      const spy = vi.spyOn(console, "debug").mockImplementation(() => {});
+      const logger = new Logger({ format: "json", maxEntryBytes: 1024 });
+      logger.debug.var({ request: { big: "b".repeat(5000), small: "ok" } });
+      const json = lastJsonOutput(spy);
+      expect(json.data.big).toContain("… [truncated");
+      expect(json.data.small).toBe("ok");
+    });
+
+    it("honors constructor maxStringLength", () => {
+      const spy = vi.spyOn(console, "debug").mockImplementation(() => {});
+      const logger = new Logger({ format: "json", maxStringLength: 10 });
+      logger.debug.var({ value: { text: "x".repeat(100) } });
+      const json = lastJsonOutput(spy);
+      expect(json.data.text).toContain("… [truncated 90 chars]");
+    });
+
+    it("applies limits to standard log methods", () => {
+      const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const logger = new Logger({ format: "json", maxEntryBytes: 1024 });
+      logger.warn("Processing failed", { payload: "p".repeat(5000) });
+      const json = lastJsonOutput(spy);
+      expect(json.message).toBe("Processing failed");
+      expect(json.data.payload).toContain("… [truncated");
+    });
+
+    it("config() updates limits at runtime", () => {
+      const spy = vi.spyOn(console, "debug").mockImplementation(() => {});
+      const logger = new Logger({ format: "json" });
+      logger.config({ maxStringLength: 10 });
+      logger.debug.var({ value: { text: "x".repeat(100) } });
+      const json = lastJsonOutput(spy);
+      expect(json.data.text).toContain("… [truncated 90 chars]");
+    });
+
+    it("config(false) disables the default entry limit", () => {
+      const spy = vi.spyOn(console, "debug").mockImplementation(() => {});
+      const logger = new Logger({ format: "json" });
+      logger.config({ maxEntryBytes: false });
+      const body = "x".repeat(DEFAULT.MAX_ENTRY_BYTES * 2);
+      logger.debug.var({ request: { body } });
+      const json = lastJsonOutput(spy);
+      expect(json.data.body).toBe(body);
+    });
+
+    it("with() children inherit configured limits", () => {
+      const spy = vi.spyOn(console, "debug").mockImplementation(() => {});
+      const logger = new Logger({ format: "json", maxStringLength: 10 });
+      const child = logger.with("request", "abc");
+      child.debug.var({ value: { text: "x".repeat(100) } });
+      const json = lastJsonOutput(spy);
+      expect(json.data.text).toContain("… [truncated 90 chars]");
+    });
+  });
+
+  describe("JaypieLogger integration", () => {
+    it("exposes config() and propagates to derived loggers", () => {
+      const spy = vi.spyOn(console, "debug").mockImplementation(() => {});
+      const logger = createLogger();
+      const child = logger.with({ request: "abc" });
+      logger.config({ maxStringLength: 10 });
+      child.debug.var({ value: { text: "x".repeat(100) } });
+      const json = lastJsonOutput(spy);
+      expect(json.data.text).toContain("… [truncated 90 chars]");
+    });
+
+    it("config persists across init()", () => {
+      const spy = vi.spyOn(console, "debug").mockImplementation(() => {});
+      const logger = createLogger();
+      logger.config({ maxStringLength: 10 });
+      logger.init();
+      logger.debug.var({ value: { text: "x".repeat(100) } });
+      const json = lastJsonOutput(spy);
+      expect(json.data.text).toContain("… [truncated 90 chars]");
+    });
+  });
+});

--- a/packages/logger/src/constants.ts
+++ b/packages/logger/src/constants.ts
@@ -1,7 +1,16 @@
 export const DEFAULT = {
   LEVEL: "debug",
+  // CloudWatch Logs caps events at 256KB and fronts Datadog in Lambda;
+  // Datadog's own per-log cap is 1MB. Truncate deliberately below both.
+  MAX_ENTRY_BYTES: 262144,
   VAR_LEVEL: "debug",
 };
+
+export const LIMIT_ENV = {
+  MAX_DEPTH: "LOG_MAX_DEPTH",
+  MAX_ENTRY_BYTES: "LOG_MAX_ENTRY_BYTES",
+  MAX_STRING: "LOG_MAX_STRING",
+} as const;
 
 export const ERROR_PREFIX = "[logger]";
 

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -19,6 +19,7 @@ export {
   redactAuth,
   sanitizeAuth,
 };
+export type { SerializationLimitOptions, SerializationLimits } from "./limits";
 
 export const log = createLogger();
 

--- a/packages/logger/src/limits.ts
+++ b/packages/logger/src/limits.ts
@@ -1,0 +1,265 @@
+import { DEFAULT, LIMIT_ENV } from "./constants";
+
+//
+//
+// Types
+//
+
+/**
+ * Caller-facing limit options. `false` explicitly disables a limit;
+ * `undefined` resolves from env vars, then defaults.
+ */
+export interface SerializationLimitOptions {
+  maxDepth?: number | false;
+  maxEntryBytes?: number | false;
+  maxStringLength?: number | false;
+}
+
+/**
+ * Resolved limits. `undefined` means the limit is off.
+ */
+export interface SerializationLimits {
+  maxDepth?: number;
+  maxEntryBytes?: number;
+  maxStringLength?: number;
+}
+
+//
+//
+// Constants
+//
+
+const CIRCULAR_PLACEHOLDER = "[Circular]";
+const DISABLED_ENV_VALUES = ["", "0", "false", "none", "off"];
+const ELLIPSIS = "…";
+// Reserve headroom for the truncation marker when fitting a string to a
+// byte budget
+const MARKER_RESERVE_BYTES = 64;
+
+/** Characters preserved when an oversized entry truncates an attribute */
+export const ENTRY_PREVIEW_LENGTH = 72;
+
+//
+//
+// Helpers
+//
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function normalizeLimit(option: number | false): number | undefined {
+  if (option === false) return undefined;
+  if (typeof option === "number" && Number.isFinite(option) && option > 0) {
+    return Math.floor(option);
+  }
+  return undefined;
+}
+
+function resolveLimit(
+  option: number | false | undefined,
+  envKey: string,
+  defaultValue?: number,
+): number | undefined {
+  if (option !== undefined) {
+    return normalizeLimit(option);
+  }
+  const raw = process.env[envKey];
+  if (raw !== undefined) {
+    if (DISABLED_ENV_VALUES.includes(raw.toLowerCase())) return undefined;
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  }
+  return defaultValue;
+}
+
+function truncationMarker(droppedChars: number): string {
+  return `${ELLIPSIS} [truncated ${droppedChars.toLocaleString("en-US")} chars]`;
+}
+
+//
+//
+// Main
+//
+
+/**
+ * Resolve limits from explicit options, env vars, then defaults.
+ * `maxEntryBytes` defaults on (payloads must fit the log pipeline);
+ * `maxDepth` and `maxStringLength` default off.
+ */
+export function resolveSerializationLimits(
+  options: SerializationLimitOptions = {},
+): SerializationLimits {
+  return {
+    maxDepth: resolveLimit(options.maxDepth, LIMIT_ENV.MAX_DEPTH),
+    maxEntryBytes: resolveLimit(
+      options.maxEntryBytes,
+      LIMIT_ENV.MAX_ENTRY_BYTES,
+      DEFAULT.MAX_ENTRY_BYTES,
+    ),
+    maxStringLength: resolveLimit(
+      options.maxStringLength,
+      LIMIT_ENV.MAX_STRING,
+    ),
+  };
+}
+
+export function hasValueLimits(limits: SerializationLimits): boolean {
+  return limits.maxDepth !== undefined || limits.maxStringLength !== undefined;
+}
+
+export function byteLength(value: unknown): number {
+  try {
+    const str = typeof value === "string" ? value : JSON.stringify(value);
+    return Buffer.byteLength(str ?? "", "utf8");
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Keep the first `maxLength` characters and append a visible marker
+ * preserving the dropped size
+ */
+export function truncateString(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  return value.slice(0, maxLength) + truncationMarker(value.length - maxLength);
+}
+
+/**
+ * Fit a string to a byte budget, reserving room for the marker and
+ * never cutting below the preview length
+ */
+export function truncateToBudget(value: string, budgetBytes: number): string {
+  if (Buffer.byteLength(value, "utf8") <= budgetBytes) return value;
+  const maxLength = Math.max(
+    ENTRY_PREVIEW_LENGTH,
+    budgetBytes - MARKER_RESERVE_BYTES,
+  );
+  return truncateString(value, maxLength);
+}
+
+/**
+ * Walk a value applying maxStringLength and maxDepth. Returns a new value;
+ * never mutates the input. Only plain objects and arrays are traversed so
+ * class instances (Error, Date, ...) keep their serialization behavior.
+ */
+export function applyValueLimits(
+  value: unknown,
+  limits: SerializationLimits,
+  depth = 0,
+  seen: WeakSet<object> = new WeakSet(),
+): unknown {
+  const { maxDepth, maxStringLength } = limits;
+  if (typeof value === "string") {
+    return maxStringLength !== undefined
+      ? truncateString(value, maxStringLength)
+      : value;
+  }
+  if (Array.isArray(value)) {
+    if (seen.has(value)) return CIRCULAR_PLACEHOLDER;
+    if (maxDepth !== undefined && depth > maxDepth) {
+      return `[Array(${value.length})]`;
+    }
+    seen.add(value);
+    const result = value.map((item) =>
+      applyValueLimits(item, limits, depth + 1, seen),
+    );
+    seen.delete(value);
+    return result;
+  }
+  if (isPlainObject(value)) {
+    if (seen.has(value)) return CIRCULAR_PLACEHOLDER;
+    if (maxDepth !== undefined && depth > maxDepth) {
+      return "[Object]";
+    }
+    seen.add(value);
+    const result: Record<string, unknown> = {};
+    for (const key of Object.keys(value)) {
+      result[key] = applyValueLimits(value[key], limits, depth + 1, seen);
+    }
+    seen.delete(value);
+    return result;
+  }
+  return value;
+}
+
+function truncateToPreview(value: unknown): unknown {
+  const str =
+    typeof value === "string"
+      ? value
+      : (JSON.stringify(value) ?? String(value));
+  if (str.length <= ENTRY_PREVIEW_LENGTH) return value;
+  return truncateString(str, ENTRY_PREVIEW_LENGTH);
+}
+
+/**
+ * Fit a serialized log entry under maxEntryBytes. Truncates the top-level
+ * attributes of `data` largest-first to short previews until the entry fits,
+ * collapsing `data` to a byte-count marker only as a last resort. When
+ * `syncMessageToData` is set (var entries and single-object messages, where
+ * `message` mirrors `data`), the message is rebuilt from the truncated data.
+ * Returns a new entry; never mutates the input.
+ */
+export function enforceEntryLimit(
+  entry: Record<string, unknown>,
+  {
+    maxEntryBytes,
+    syncMessageToData = false,
+  }: { maxEntryBytes: number; syncMessageToData?: boolean },
+): Record<string, unknown> {
+  const originalBytes = byteLength(entry);
+  if (originalBytes <= maxEntryBytes) return entry;
+
+  const result = { ...entry };
+  const sync = () => {
+    if (syncMessageToData) {
+      result.message =
+        typeof result.data === "string"
+          ? result.data
+          : (JSON.stringify(result.data) ?? String(result.data));
+    }
+  };
+
+  const data = result.data;
+  if (typeof data === "string") {
+    result.data = truncateToPreview(data);
+    sync();
+  } else if (Array.isArray(data) || isPlainObject(data)) {
+    const container: Record<string, unknown> = Array.isArray(data)
+      ? ([...data] as unknown as Record<string, unknown>)
+      : { ...data };
+    result.data = container;
+    const keys = Object.keys(container).sort(
+      (a, b) => byteLength(container[b]) - byteLength(container[a]),
+    );
+    for (const key of keys) {
+      container[key] = truncateToPreview(container[key]);
+      sync();
+      if (byteLength(result) <= maxEntryBytes) return result;
+    }
+  } else if (typeof result.message === "string") {
+    // No structured data: the message itself is oversized
+    const overhead = originalBytes - byteLength(result.message);
+    result.message = truncateToBudget(
+      result.message,
+      Math.max(ENTRY_PREVIEW_LENGTH, maxEntryBytes - overhead),
+    );
+  }
+
+  if (byteLength(result) <= maxEntryBytes) return result;
+
+  // Last resort: entry is still oversized after attribute-level truncation
+  const marker = `[truncated ${originalBytes.toLocaleString("en-US")} bytes]`;
+  if ("data" in result) {
+    result.data = marker;
+    if (syncMessageToData) result.message = marker;
+  } else if (typeof result.message === "string") {
+    result.message = marker;
+  }
+  return result;
+}

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.90",
+  "version": "0.8.91",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/jaypie/1.2.61.md
+++ b/packages/mcp/release-notes/jaypie/1.2.61.md
@@ -1,0 +1,15 @@
+---
+version: 1.2.61
+date: 2026-07-04
+summary: Pick up @jaypie/logger 1.2.19 (serialization limits) and @jaypie/llm 1.3.7 (quiet operate logging, onProgress)
+---
+
+## Changes
+
+- `@jaypie/logger` dependency raised to `^1.2.19` — `log` now caps entries
+  at 256KB by default with largest-first attribute truncation, supports
+  `maxStringLength`/`maxDepth`, and exposes `log.config()` for runtime
+  overrides (issue #410)
+- `@jaypie/llm` optional peer raised to `^1.3.7` — `operate()` logs
+  `operate.*` vars at trace with minimal payloads and accepts an
+  `onProgress` progress-event callback

--- a/packages/mcp/release-notes/llm/1.3.7.md
+++ b/packages/mcp/release-notes/llm/1.3.7.md
@@ -1,0 +1,44 @@
+---
+version: 1.3.7
+date: 2026-07-04
+summary: Quiet operate.* logging to trace with minimal payloads; add onProgress callback for progress events
+---
+
+## Changes
+
+### Logging
+
+- All `operate.*` log vars (`operate.input`, `operate.options`,
+  `operate.request`, `operate.response`) now emit at **trace** instead of the
+  logger's var level (debug by default)
+- `operate.request` and `operate.response` log draconian subsets instead of
+  full provider payloads (which re-logged the entire conversation history
+  every turn):
+  - `operate.request`: `{ model, turn, messages: <count>, latest: <last message text or type> }`
+  - `operate.response`: the text content, or the requested tool calls
+    (`{ name, arguments }`) when the model calls tools
+- Full provider payloads remain available via the
+  `beforeEachModelRequest` / `afterEachModelResponse` hooks and LLM
+  Observability spans
+
+### Progress Events
+
+- New `onProgress` option on `operate()` — a single callback receiving
+  lightweight, serializable progress events, suitable for forwarding to
+  websockets, queues, or UI updates
+- Event types (`LlmProgressEventType`): `start`, `model_request`,
+  `model_response`, `tool_call`, `tool_result`, `tool_error`, `retry`, `done`
+- Event fields: `content`, `error`, `maxTurns`, `model`, `provider`, `tool`,
+  `toolCalls`, `turn` (1-indexed), `usage`
+- Errors thrown by the callback are logged at warn and never interrupt the
+  loop
+- New exports: `LlmProgressEventType` (enum), `LlmProgressEvent`,
+  `LlmProgressCallback`, `LlmProgressToolCall` (types)
+- `stream()` is unchanged — its chunks already communicate progress
+
+## Migration
+
+No changes required. Consumers who relied on debug-level `operate.request` /
+`operate.response` payload logging should switch to the
+`beforeEachModelRequest` / `afterEachModelResponse` hooks or set
+`LOG_LEVEL=trace` for the summarized vars.

--- a/packages/mcp/release-notes/logger/1.2.19.md
+++ b/packages/mcp/release-notes/logger/1.2.19.md
@@ -1,0 +1,43 @@
+---
+version: 1.2.19
+date: 2026-07-04
+summary: Serialization limits with rational defaults — maxEntryBytes 256KB on by default, maxStringLength/maxDepth opt-in, log.config() runtime overrides (issue #410)
+---
+
+## Changes
+
+- **Entries are capped at 256KB by default** (`maxEntryBytes: 262144`) — the
+  CloudWatch Logs event limit that fronts Datadog in Lambda (Datadog's own
+  per-log cap is 1MB). Oversized payloads previously flooded the pipeline or
+  were cut arbitrarily mid-JSON; now they truncate deliberately (issue #410)
+- Entry truncation degrades gracefully: the top-level attributes of `data`
+  are truncated **largest-first**, each preserving a 72-character preview
+  plus a visible marker — `data:application/pdf;base64,JVBERi0xLjcK…
+  [truncated 612,340 chars]` — until the entry fits. Only if every attribute
+  is truncated and the entry is still oversized does `data` collapse to
+  `[truncated N bytes]`
+- New opt-in limits:
+  - `maxStringLength` — truncate each string field beyond N characters with
+    the same marker style
+  - `maxDepth` — replace objects/arrays nested beyond N levels with
+    `[Object]` / `[Array(n)]` (like `util.inspect`)
+- Configuration, in precedence order:
+  1. Constructor options — `new Logger({ maxEntryBytes, maxDepth,
+     maxStringLength })` / `createLogger` loggers pass through
+  2. `log.config({ maxStringLength: 1024 })` — runtime override, propagates
+     to derived loggers (`lib`, `with`, `flag`) and persists across `init()`
+  3. Env vars — `LOG_MAX_ENTRY_BYTES`, `LOG_MAX_STRING`, `LOG_MAX_DEPTH`;
+     set `0`/`false`/`none`/`off` to disable a limit
+- Pass `false` for any option to disable it (`log.config({ maxEntryBytes:
+  false })` restores unlimited entries)
+- Applied at serialization time only — the caller's object is never mutated.
+  Circular references are handled (`[Circular]`); class instances (Error,
+  Date) are not traversed so their serialization is unchanged
+- New type exports: `SerializationLimitOptions`, `SerializationLimits`
+
+## Migration
+
+No changes required for typical logging. Entries over 256KB — which were
+already lossy in CloudWatch — now truncate deliberately with visible
+markers. To restore unlimited output, set `LOG_MAX_ENTRY_BYTES=false` or
+call `log.config({ maxEntryBytes: false })`.

--- a/packages/mcp/release-notes/mcp/0.8.91.md
+++ b/packages/mcp/release-notes/mcp/0.8.91.md
@@ -1,10 +1,13 @@
 ---
 version: 0.8.91
 date: 2026-07-04
-summary: Document operate() progress events (onProgress) in the llm skill
+summary: Document operate() progress events (onProgress) in the llm skill and serialization limits in the logs skill
 ---
 
 ## Changes
 
 - `skill("llm")` documents the new `onProgress` progress-event callback on
   `operate()` shipped in `@jaypie/llm@1.3.7`
+- `skill("logs")` documents the serialization limits (`maxEntryBytes` 256KB
+  default, `maxStringLength`, `maxDepth`, `log.config()`, `LOG_MAX_*` env
+  vars) shipped in `@jaypie/logger@1.2.19`

--- a/packages/mcp/release-notes/mcp/0.8.91.md
+++ b/packages/mcp/release-notes/mcp/0.8.91.md
@@ -1,0 +1,10 @@
+---
+version: 0.8.91
+date: 2026-07-04
+summary: Document operate() progress events (onProgress) in the llm skill
+---
+
+## Changes
+
+- `skill("llm")` documents the new `onProgress` progress-event callback on
+  `operate()` shipped in `@jaypie/llm@1.3.7`

--- a/packages/mcp/release-notes/testkit/1.2.51.md
+++ b/packages/mcp/release-notes/testkit/1.2.51.md
@@ -1,7 +1,7 @@
 ---
 version: 1.2.51
 date: 2026-07-04
-summary: Mirror @jaypie/llm LlmProgressEventType export in the mock namespace
+summary: Mirror @jaypie/llm LlmProgressEventType export; mock log.config() from @jaypie/logger
 ---
 
 ## Changes
@@ -9,3 +9,5 @@ summary: Mirror @jaypie/llm LlmProgressEventType export in the mock namespace
 - `@jaypie/testkit/mock` re-exports `LlmProgressEventType` alongside the
   existing `LlmMessageRole`, `LlmMessageType`, and `LlmStreamChunkType`
   mocks, matching `@jaypie/llm@1.3.7`
+- `mockLogFactory` / `spyLog` mock the new `log.config()` method from
+  `@jaypie/logger@1.2.19`

--- a/packages/mcp/release-notes/testkit/1.2.51.md
+++ b/packages/mcp/release-notes/testkit/1.2.51.md
@@ -1,0 +1,11 @@
+---
+version: 1.2.51
+date: 2026-07-04
+summary: Mirror @jaypie/llm LlmProgressEventType export in the mock namespace
+---
+
+## Changes
+
+- `@jaypie/testkit/mock` re-exports `LlmProgressEventType` alongside the
+  existing `LlmMessageRole`, `LlmMessageType`, and `LlmStreamChunkType`
+  mocks, matching `@jaypie/llm@1.3.7`

--- a/packages/mcp/skills/llm.md
+++ b/packages/mcp/skills/llm.md
@@ -316,6 +316,28 @@ const response = await Llm.operate(input, {
 });
 ```
 
+## Progress Events
+
+For progress reporting (UI updates, websockets, queue notifications), prefer `onProgress` over wiring individual hooks. It receives lightweight, serializable events as the loop runs:
+
+```typescript
+import { LlmProgressEventType } from "@jaypie/llm";
+
+const response = await Llm.operate(input, {
+  model: "gpt-5.1",
+  tools: toolkit,
+  onProgress: (event) => {
+    // event.type: start, model_request, model_response,
+    //             tool_call, tool_result, tool_error, retry, done
+    websocket.send(JSON.stringify(event));
+  },
+});
+```
+
+Event fields (all optional except `type`): `content` (text or structured output on `model_response`/`done`), `error` (`tool_error`/`retry`), `maxTurns`/`model`/`provider` (`start`), `tool` (`{ name, arguments }`), `toolCalls` (tools requested on `model_response`), `turn` (1-indexed), `usage` (per-turn on `model_response`, cumulative on `done`).
+
+Errors thrown by the callback are logged and never interrupt the loop. Hooks remain the right choice when you need the full provider request/response payloads. `stream()` communicates progress through its chunks; `onProgress` applies to `operate()`.
+
 ## Fallback Providers
 
 Configure a chain of fallback providers that automatically retry failed calls when the primary provider fails:

--- a/packages/mcp/skills/llm.md
+++ b/packages/mcp/skills/llm.md
@@ -334,7 +334,18 @@ const response = await Llm.operate(input, {
 });
 ```
 
-Event fields (all optional except `type`): `content` (text or structured output on `model_response`/`done`), `error` (`tool_error`/`retry`), `maxTurns`/`model`/`provider` (`start`), `tool` (`{ name, arguments }`), `toolCalls` (tools requested on `model_response`), `turn` (1-indexed), `usage` (per-turn on `model_response`, cumulative on `done`).
+Fields carried by each event (`turn` is 1-indexed):
+
+| Event | Fields |
+|-------|--------|
+| `start` | `model`, `provider`, `maxTurns` |
+| `model_request` | `turn`, `model` |
+| `model_response` | `turn`, `content` (text, if any), `toolCalls` (`[{ name, arguments }]`, if any), `usage` (this turn) |
+| `tool_call` | `turn`, `tool: { name, arguments }` — fires before the tool runs; `arguments` is the JSON string |
+| `tool_result` | `turn`, `tool: { name }` — the result value is deliberately omitted (it can be arbitrarily large); use the `afterEachTool` hook to receive it |
+| `tool_error` | `turn`, `tool: { name }`, `error` (message string) |
+| `retry` | `turn`, `error` (message string) |
+| `done` | `turn` (total turns used), `content` (final text or structured output), `usage` (cumulative) |
 
 Errors thrown by the callback are logged and never interrupt the loop. Hooks remain the right choice when you need the full provider request/response payloads. `stream()` communicates progress through its chunks; `onProgress` applies to `operate()`.
 

--- a/packages/mcp/skills/logs.md
+++ b/packages/mcp/skills/logs.md
@@ -110,6 +110,39 @@ const logger = new Logger({ format: "json", level: "debug", levelField: "status"
 logger.info("test"); // { "message": "test", "status": "info" }
 ```
 
+## Serialization Limits
+
+Entries are capped at 256KB by default (`maxEntryBytes: 262144` — the CloudWatch Logs event limit that fronts Datadog in Lambda). Oversized entries truncate the top-level attributes of `data` largest-first, each keeping a 72-character preview plus a visible marker:
+
+```
+data:application/pdf;base64,JVBERi0xLjcK… [truncated 612,340 chars]
+```
+
+Two more limits are available, off by default:
+
+- `maxStringLength` — truncate each string field beyond N characters
+- `maxDepth` — replace objects/arrays nested beyond N levels with `[Object]` / `[Array(n)]`
+
+Configure via env vars (`0`/`false` disables a limit):
+
+```bash
+LOG_MAX_ENTRY_BYTES=1048576   # Raise entry cap to 1MB (Datadog direct)
+LOG_MAX_ENTRY_BYTES=false     # Unlimited entries
+LOG_MAX_STRING=16384          # Truncate strings beyond 16KB
+LOG_MAX_DEPTH=8               # Collapse nesting beyond 8 levels
+```
+
+Or at runtime with `log.config()` — propagates to derived loggers (`lib`, `with`, `flag`) and persists across `init()`:
+
+```typescript
+import { log } from "jaypie";
+
+log.config({ maxStringLength: 1024 });
+log.config({ maxEntryBytes: false }); // false disables a limit
+```
+
+Limits apply at serialization time only — the caller's object is never mutated.
+
 ## Lambda Logging
 
 Lambda handlers automatically add context:

--- a/packages/testkit/package.json
+++ b/packages/testkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/testkit",
-  "version": "1.2.50",
+  "version": "1.2.51",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"

--- a/packages/testkit/src/mock/llm.ts
+++ b/packages/testkit/src/mock/llm.ts
@@ -113,6 +113,12 @@ export const LlmMessageRole = createMockWrappedObject(original.LlmMessageRole, {
 export const LlmMessageType = createMockWrappedObject(original.LlmMessageType, {
   isClass: true,
 });
+export const LlmProgressEventType = createMockWrappedObject(
+  original.LlmProgressEventType,
+  {
+    isClass: true,
+  },
+);
 export const LlmStreamChunkType = createMockWrappedObject(
   original.LlmStreamChunkType,
   {

--- a/packages/testkit/src/mock/tildeskill.ts
+++ b/packages/testkit/src/mock/tildeskill.ts
@@ -64,6 +64,5 @@ export const createSkillService = createMockFunction(() => {
 });
 export const createMarkdownStore = createMockFunction(() => createMockStore());
 export const createMemoryStore = createMockFunction(
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   (_initial?: SkillRecord[]) => createMockStore(),
 );

--- a/packages/testkit/src/mockLog.module.ts
+++ b/packages/testkit/src/mockLog.module.ts
@@ -5,6 +5,7 @@ import { LogMock } from "./types/jaypie-testkit";
 export function mockLogFactory(): LogMock {
   // Create skeleton of mock objects
   const mock = {
+    config: vi.fn(),
     debug: vi.fn(),
     error: vi.fn(),
     fatal: vi.fn(),
@@ -32,6 +33,7 @@ export function mockLogFactory(): LogMock {
   mock.warn.var = mock.var;
 
   // Have modules return correct objects
+  mock.config.mockReturnValue(null);
   mock.flag.mockReturnValue(mock);
   mock.init.mockReturnValue(null);
   mock.lib.mockReturnValue(mock);
@@ -42,6 +44,7 @@ export function mockLogFactory(): LogMock {
 
   // Pin mocks to the module
   mock.mock = {
+    config: mock.config,
     debug: mock.debug,
     error: mock.error,
     fatal: mock.fatal,
@@ -64,6 +67,7 @@ export function mockLogFactory(): LogMock {
 }
 
 const LOG_METHOD_NAMES = [
+  "config",
   "debug",
   "error",
   "fatal",

--- a/packages/testkit/src/types/jaypie-testkit.d.ts
+++ b/packages/testkit/src/types/jaypie-testkit.d.ts
@@ -33,6 +33,7 @@ export interface MockLogMethod extends Mock {
 }
 
 export interface LogMock extends Log {
+  config: Mock;
   debug: MockLogMethod;
   error: MockLogMethod;
   fatal: MockLogMethod;
@@ -41,6 +42,7 @@ export interface LogMock extends Log {
   init: Mock;
   lib: Mock;
   mock: {
+    config: Mock;
     debug: MockLogMethod;
     error: MockLogMethod;
     fatal: MockLogMethod;

--- a/workspaces/documentation/src/content/docs/docs/core/logging.md
+++ b/workspaces/documentation/src/content/docs/docs/core/logging.md
@@ -220,10 +220,15 @@ log.init(); // Clears tags, resets state
 |----------|--------|---------|
 | `LOG_LEVEL` | trace, debug, info, warn, error, fatal | info |
 | `LOG_FORMAT` | json, text | json |
+| `LOG_MAX_ENTRY_BYTES` | bytes; `false` disables | 262144 (256KB) |
+| `LOG_MAX_STRING` | characters; `false` disables | off |
+| `LOG_MAX_DEPTH` | levels; `false` disables | off |
 
 ```bash
 LOG_LEVEL=debug npm start
 ```
+
+Oversized entries truncate deliberately with visible markers (`… [truncated 612,340 chars]`) so payloads fit the log pipeline — see [Serialization Limits](/docs/packages/logger/#serialization-limits) for details and `log.config()` runtime overrides.
 
 ## Function Prefix Convention
 

--- a/workspaces/documentation/src/content/docs/docs/guides/llm-integration.md
+++ b/workspaces/documentation/src/content/docs/docs/guides/llm-integration.md
@@ -332,25 +332,59 @@ const response = await Llm.operate(
 
 ### Lifecycle Hooks
 
+Seven hooks fire through the operate loop, each receiving the full provider request/response payloads:
+
 ```typescript
 const response = await Llm.operate(prompt, {
   model: "claude-sonnet-4",
   hooks: {
-    beforeCall: (params) => {
+    beforeEachModelRequest: ({ providerRequest }) => {
       log.trace("[llm] calling model");
-      log.var({ model: params.model });
     },
-    afterCall: (response) => {
+    afterEachModelResponse: ({ content, usage }) => {
       log.trace("[llm] response received");
-      log.var({ tokens: response.usage?.totalTokens });
+      log.var({ tokens: usage[usage.length - 1]?.total });
     },
-    onError: (error) => {
-      log.error("[llm] call failed");
+    beforeEachTool: ({ toolName, args }) => {
+      log.trace(`[llm] calling ${toolName}`);
+    },
+    afterEachTool: ({ result, toolName }) => {
+      log.trace(`[llm] ${toolName} returned`);
+    },
+    onToolError: ({ error, toolName }) => {
+      log.warn(`[llm] ${toolName} failed`);
       log.var({ error: error.message });
+    },
+    onRetryableModelError: ({ error }) => {
+      log.warn("[llm] model call failed, retrying");
+    },
+    onUnrecoverableModelError: ({ error }) => {
+      log.error("[llm] model call failed");
+      log.var({ error });
     },
   },
 });
 ```
+
+### Progress Events
+
+For progress reporting (UI updates, websockets, queue notifications), prefer a single `onProgress` callback over wiring individual hooks. It receives lightweight, serializable events as the operate loop runs:
+
+```typescript
+const response = await Llm.operate(prompt, {
+  model: "claude-sonnet-4",
+  tools: toolkit,
+  onProgress: (event) => {
+    // event.type: start, model_request, model_response,
+    //             tool_call, tool_result, tool_error, retry, done
+    websocket.send(JSON.stringify(event));
+  },
+});
+```
+
+Event fields (all optional except `type`): `content` (text or structured output on `model_response`/`done`), `error` (`tool_error`/`retry`), `maxTurns`/`model`/`provider` (`start`), `tool` (`{ name, arguments }`), `toolCalls` (tools requested on `model_response`), `turn` (1-indexed), `usage` (per-turn on `model_response`, cumulative on `done`).
+
+Errors thrown by the callback are logged and never interrupt the loop. `stream()` communicates progress through its chunks; `onProgress` applies to `operate()`.
 
 ## Error Handling
 

--- a/workspaces/documentation/src/content/docs/docs/guides/llm-integration.md
+++ b/workspaces/documentation/src/content/docs/docs/guides/llm-integration.md
@@ -382,7 +382,18 @@ const response = await Llm.operate(prompt, {
 });
 ```
 
-Event fields (all optional except `type`): `content` (text or structured output on `model_response`/`done`), `error` (`tool_error`/`retry`), `maxTurns`/`model`/`provider` (`start`), `tool` (`{ name, arguments }`), `toolCalls` (tools requested on `model_response`), `turn` (1-indexed), `usage` (per-turn on `model_response`, cumulative on `done`).
+Fields carried by each event (`turn` is 1-indexed):
+
+| Event | Fields |
+|-------|--------|
+| `start` | `model`, `provider`, `maxTurns` |
+| `model_request` | `turn`, `model` |
+| `model_response` | `turn`, `content` (text, if any), `toolCalls` (`[{ name, arguments }]`, if any), `usage` (this turn) |
+| `tool_call` | `turn`, `tool: { name, arguments }` — fires before the tool runs; `arguments` is the JSON string |
+| `tool_result` | `turn`, `tool: { name }` — the result value is deliberately omitted (it can be arbitrarily large); use the `afterEachTool` hook to receive it |
+| `tool_error` | `turn`, `tool: { name }`, `error` (message string) |
+| `retry` | `turn`, `error` (message string) |
+| `done` | `turn` (total turns used), `content` (final text or structured output), `usage` (cumulative) |
 
 Errors thrown by the callback are logged and never interrupt the loop. `stream()` communicates progress through its chunks; `onProgress` applies to `operate()`.
 

--- a/workspaces/documentation/src/content/docs/docs/packages/llm.md
+++ b/workspaces/documentation/src/content/docs/docs/packages/llm.md
@@ -320,26 +320,59 @@ const response = await Llm.operate("Describe this", {
 
 ## Hooks
 
-Lifecycle callbacks for logging and metrics.
+Lifecycle callbacks with full provider request/response payloads.
 
 ```typescript
 const response = await Llm.operate(prompt, {
   model: "claude-sonnet-4",
   hooks: {
-    beforeCall: (params) => {
-      log.trace("[llm] calling");
-      log.var({ model: params.model });
+    beforeEachModelRequest: ({ providerRequest }) => {
+      log.trace("[llm] calling model");
     },
-    afterCall: (response) => {
-      log.trace("[llm] complete");
-      log.var({ tokens: response.usage?.totalTokens });
+    afterEachModelResponse: ({ content, usage }) => {
+      log.trace("[llm] response received");
+      log.var({ tokens: usage[usage.length - 1]?.total });
     },
-    onError: (error) => {
-      log.error("[llm] failed");
+    beforeEachTool: ({ toolName, args }) => {
+      log.trace(`[llm] calling ${toolName}`);
+    },
+    afterEachTool: ({ result, toolName }) => {
+      log.trace(`[llm] ${toolName} returned`);
+    },
+    onToolError: ({ error, toolName }) => {
+      log.warn(`[llm] ${toolName} failed`);
+      log.var({ error: error.message });
+    },
+    onRetryableModelError: ({ error }) => {
+      log.warn("[llm] model call failed, retrying");
+    },
+    onUnrecoverableModelError: ({ error }) => {
+      log.error("[llm] model call failed");
+      log.var({ error });
     },
   },
 });
 ```
+
+## Progress Events
+
+For progress reporting (UI updates, websockets, queue notifications), prefer a single `onProgress` callback over wiring individual hooks. It receives lightweight, serializable events as the operate loop runs:
+
+```typescript
+const response = await Llm.operate(prompt, {
+  model: "claude-sonnet-4",
+  tools: toolkit,
+  onProgress: (event) => {
+    // event.type: start, model_request, model_response,
+    //             tool_call, tool_result, tool_error, retry, done
+    websocket.send(JSON.stringify(event));
+  },
+});
+```
+
+Event fields (all optional except `type`): `content` (text or structured output on `model_response`/`done`), `error` (`tool_error`/`retry`), `maxTurns`/`model`/`provider` (`start`), `tool` (`{ name, arguments }`), `toolCalls` (tools requested on `model_response`), `turn` (1-indexed), `usage` (per-turn on `model_response`, cumulative on `done`).
+
+Errors thrown by the callback are logged and never interrupt the loop. `stream()` communicates progress through its chunks; `onProgress` applies to `operate()`.
 
 ## Express Integration
 

--- a/workspaces/documentation/src/content/docs/docs/packages/llm.md
+++ b/workspaces/documentation/src/content/docs/docs/packages/llm.md
@@ -370,7 +370,18 @@ const response = await Llm.operate(prompt, {
 });
 ```
 
-Event fields (all optional except `type`): `content` (text or structured output on `model_response`/`done`), `error` (`tool_error`/`retry`), `maxTurns`/`model`/`provider` (`start`), `tool` (`{ name, arguments }`), `toolCalls` (tools requested on `model_response`), `turn` (1-indexed), `usage` (per-turn on `model_response`, cumulative on `done`).
+Fields carried by each event (`turn` is 1-indexed):
+
+| Event | Fields |
+|-------|--------|
+| `start` | `model`, `provider`, `maxTurns` |
+| `model_request` | `turn`, `model` |
+| `model_response` | `turn`, `content` (text, if any), `toolCalls` (`[{ name, arguments }]`, if any), `usage` (this turn) |
+| `tool_call` | `turn`, `tool: { name, arguments }` — fires before the tool runs; `arguments` is the JSON string |
+| `tool_result` | `turn`, `tool: { name }` — the result value is deliberately omitted (it can be arbitrarily large); use the `afterEachTool` hook to receive it |
+| `tool_error` | `turn`, `tool: { name }`, `error` (message string) |
+| `retry` | `turn`, `error` (message string) |
+| `done` | `turn` (total turns used), `content` (final text or structured output), `usage` (cumulative) |
 
 Errors thrown by the callback are logged and never interrupt the loop. `stream()` communicates progress through its chunks; `onProgress` applies to `operate()`.
 

--- a/workspaces/documentation/src/content/docs/docs/packages/logger.md
+++ b/workspaces/documentation/src/content/docs/docs/packages/logger.md
@@ -158,10 +158,34 @@ Handles top-level `authorization` keys and nested `headers.authorization`. Origi
 |----------|--------|---------|
 | `LOG_LEVEL` | trace, debug, info, warn, error, fatal | info |
 | `LOG_FORMAT` | json, text | json |
+| `LOG_MAX_ENTRY_BYTES` | bytes; `false` disables | 262144 (256KB) |
+| `LOG_MAX_STRING` | characters; `false` disables | off |
+| `LOG_MAX_DEPTH` | levels; `false` disables | off |
 
 ```bash
 LOG_LEVEL=debug npm start
 ```
+
+## Serialization Limits
+
+Entries are capped at 256KB by default — the CloudWatch Logs event limit that fronts Datadog in Lambda. Oversized entries truncate the top-level attributes of `data` largest-first, each keeping a 72-character preview plus a visible marker:
+
+```
+data:application/pdf;base64,JVBERi0xLjcK… [truncated 612,340 chars]
+```
+
+Two more limits are available, off by default: `maxStringLength` (truncate each string field beyond N characters) and `maxDepth` (replace objects nested beyond N levels with `[Object]` / `[Array(n)]`).
+
+Override at runtime with `log.config()` — it propagates to derived loggers and persists across `init()`:
+
+```typescript
+import { log } from "jaypie";
+
+log.config({ maxStringLength: 1024 });
+log.config({ maxEntryBytes: false }); // false disables a limit
+```
+
+Limits apply at serialization time only; the logged object is never mutated.
 
 ## JSON Output
 


### PR DESCRIPTION
## Summary

Three related changes reducing LLM payload noise end to end:

### `@jaypie/llm` 1.3.7 — quiet operate logging + `onProgress`
- All `operate.*` log vars emit at **trace**; `operate.request` / `operate.response` log draconian subsets (text or tool calls) instead of full provider payloads that re-logged the conversation history every turn
- New `onProgress` callback on `operate()` — lightweight, serializable progress events (`start`, `model_request`, `model_response`, `tool_call`, `tool_result`, `tool_error`, `retry`, `done`) suitable for websockets/queues/UI; callback errors never interrupt the loop
- New exports: `LlmProgressEventType`, `LlmProgressEvent`, `LlmProgressCallback`, `LlmProgressToolCall`

### `@jaypie/logger` 1.2.19 — serialization limits (closes #410)
- **`maxEntryBytes` on by default at 256KB** (CloudWatch event limit fronting Datadog); oversized entries truncate `data` attributes largest-first, each keeping a 72-char preview + `… [truncated 612,340 chars]` marker, collapsing to a byte-count marker only as a last resort
- `maxStringLength` / `maxDepth` opt-in; overrides via constructor options, runtime `log.config()` (propagates to derived loggers, persists across `init()`), or `LOG_MAX_ENTRY_BYTES` / `LOG_MAX_STRING` / `LOG_MAX_DEPTH` env vars (`0`/`false` disables)
- Serialization-time only — never mutates the caller's object; circular-safe; class instances untouched

### Docs
- jaypie.net hooks docs documented hooks that never existed (`beforeCall`/`afterCall`/`onError`) — replaced with the real seven; Progress Events sections with per-event field tables added to skill("llm"), package CLAUDE.md, and both web pages; serialization limits documented in skill("logs") and logger pages

### Versions
| Package | Version |
|---------|---------|
| `@jaypie/llm` | 1.3.7 |
| `@jaypie/logger` | 1.2.19 |
| `@jaypie/testkit` | 1.2.51 |
| `@jaypie/mcp` | 0.8.91 |
| `jaypie` | 1.2.61 |

Closes #410

## Test plan
- [x] Full monorepo suite (3,640 tests) green
- [x] 26 new logger limits tests, 4 new onProgress tests
- [x] Typecheck, lint, builds clean; docs site builds (54 pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)