### PR TITLE
feat(llm): surface resolved tool message in hooks and tool_call progress event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19905,7 +19905,7 @@
     },
     "packages/llm": {
       "name": "@jaypie/llm",
-      "version": "1.3.7",
+      "version": "1.3.8",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "*",
@@ -19965,7 +19965,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.91",
+      "version": "0.8.92",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.3.3",

--- a/packages/llm/CLAUDE.md
+++ b/packages/llm/CLAUDE.md
@@ -229,6 +229,12 @@ const response = await Llm.operate("What's the weather in NYC?", {
 });
 ```
 
+Tools may define `message` — a human-readable status line (static string or
+function of the parsed args). The operate/stream loops resolve it once per
+call via `Toolkit.resolveMessage()` and surface it in the Toolkit `log`
+option, the `beforeEachTool`/`afterEachTool`/`onToolError` hooks (as
+`message`), and the `tool_call` progress event (as `tool.message`).
+
 ### Progress Events
 
 `operate()` accepts an `onProgress` callback that receives lightweight,
@@ -255,7 +261,7 @@ Fields carried by each event (`turn` is 1-indexed):
 | `start` | `model`, `provider`, `maxTurns` |
 | `model_request` | `turn`, `model` |
 | `model_response` | `turn`, `content` (text, if any), `toolCalls` (`[{ name, arguments }]`, if any), `usage` (this turn) |
-| `tool_call` | `turn`, `tool: { name, arguments }` — before the tool runs; `arguments` is the JSON string |
+| `tool_call` | `turn`, `tool: { name, arguments, message }` — before the tool runs; `arguments` is the JSON string; `message` is the resolved `LlmTool.message`, when the tool defines one |
 | `tool_result` | `turn`, `tool: { name }` — result value deliberately omitted; use `afterEachTool` to receive it |
 | `tool_error` | `turn`, `tool: { name }`, `error` (message string) |
 | `retry` | `turn`, `error` (message string) |

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/llm",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "Large language model utilities",
   "repository": {
     "type": "git",

--- a/packages/llm/src/operate/OperateLoop.ts
+++ b/packages/llm/src/operate/OperateLoop.ts
@@ -498,10 +498,19 @@ export class OperateLoop {
 
         // Process each tool call
         for (const toolCall of toolCalls) {
+          // Resolved once per call; never throws (undefined when tool has no message)
+          const toolMessage = await state.toolkit!.resolveMessage({
+            arguments: toolCall.arguments,
+            name: toolCall.name,
+          });
           try {
             await emitProgress({
               event: {
-                tool: { arguments: toolCall.arguments, name: toolCall.name },
+                tool: {
+                  arguments: toolCall.arguments,
+                  message: toolMessage,
+                  name: toolCall.name,
+                },
                 turn: state.currentTurn,
                 type: LlmProgressEventType.ToolCall,
               },
@@ -511,6 +520,7 @@ export class OperateLoop {
             // Execute beforeEachTool hook
             await this.hookRunnerInstance.runBeforeTool(context.hooks, {
               args: toolCall.arguments,
+              message: toolMessage,
               toolName: toolCall.name,
             });
 
@@ -521,6 +531,7 @@ export class OperateLoop {
               async () => {
                 const result = await state.toolkit!.call({
                   arguments: toolCall.arguments,
+                  message: toolMessage,
                   name: toolCall.name,
                 });
                 annotateLlmObs({
@@ -544,6 +555,7 @@ export class OperateLoop {
             // Execute afterEachTool hook
             await this.hookRunnerInstance.runAfterTool(context.hooks, {
               args: toolCall.arguments,
+              message: toolMessage,
               result,
               toolName: toolCall.name,
             });
@@ -591,6 +603,7 @@ export class OperateLoop {
             await this.hookRunnerInstance.runOnToolError(context.hooks, {
               args: toolCall.arguments,
               error: error as Error,
+              message: toolMessage,
               toolName: toolCall.name,
             });
 

--- a/packages/llm/src/operate/StreamLoop.ts
+++ b/packages/llm/src/operate/StreamLoop.ts
@@ -465,10 +465,16 @@ export class StreamLoop {
   ): AsyncGenerator<LlmStreamChunk, void> {
     const log = getLogger();
     for (const toolCall of toolCalls) {
+      // Resolved once per call; never throws (undefined when tool has no message)
+      const toolMessage = await state.toolkit!.resolveMessage({
+        arguments: toolCall.arguments,
+        name: toolCall.name,
+      });
       try {
         // Execute beforeEachTool hook
         await this.hookRunnerInstance.runBeforeTool(context.hooks, {
           args: toolCall.arguments,
+          message: toolMessage,
           toolName: toolCall.name,
         });
 
@@ -479,6 +485,7 @@ export class StreamLoop {
           async () => {
             const result = await state.toolkit!.call({
               arguments: toolCall.arguments,
+              message: toolMessage,
               name: toolCall.name,
             });
             annotateLlmObs({
@@ -493,6 +500,7 @@ export class StreamLoop {
         // Execute afterEachTool hook
         await this.hookRunnerInstance.runAfterTool(context.hooks, {
           args: toolCall.arguments,
+          message: toolMessage,
           result,
           toolName: toolCall.name,
         });
@@ -522,6 +530,7 @@ export class StreamLoop {
         await this.hookRunnerInstance.runOnToolError(context.hooks, {
           args: toolCall.arguments,
           error: error as Error,
+          message: toolMessage,
           toolName: toolCall.name,
         });
 

--- a/packages/llm/src/operate/__tests__/OperateLoop.spec.ts
+++ b/packages/llm/src/operate/__tests__/OperateLoop.spec.ts
@@ -490,6 +490,95 @@ describe("OperateLoop", () => {
         expect(beforeToolHook).toHaveBeenCalled();
       });
 
+      it("passes resolved tool message to beforeEachTool and afterEachTool hooks", async () => {
+        const beforeToolHook = vi.fn();
+        const afterToolHook = vi.fn();
+
+        let callCount = 0;
+        mockAdapter.parseResponse = vi.fn((response): ParsedResponse => {
+          callCount++;
+          if (callCount === 1) {
+            return {
+              content: undefined,
+              hasToolCalls: true,
+              stopReason: "tool_use",
+              usage: {
+                input: 10,
+                output: 20,
+                reasoning: 0,
+                total: 30,
+                provider: "mock",
+                model: "mock-model",
+              },
+              raw: response,
+            };
+          }
+          return {
+            content: "Done!",
+            hasToolCalls: false,
+            stopReason: "end_turn",
+            usage: {
+              input: 10,
+              output: 20,
+              reasoning: 0,
+              total: 30,
+              provider: "mock",
+              model: "mock-model",
+            },
+            raw: response,
+          };
+        }) as Mock;
+
+        mockAdapter.extractToolCalls = vi.fn((): StandardToolCall[] => [
+          {
+            callId: "call-123",
+            name: "test_tool",
+            arguments: JSON.stringify({ city: "NYC" }),
+            raw: {},
+          },
+        ]);
+
+        const toolkit = new Toolkit([
+          {
+            name: "test_tool",
+            description: "A test tool",
+            parameters: { type: "object" },
+            type: "function",
+            call: vi.fn(() => "result"),
+            message: ({ city }: { city?: string } = {}) =>
+              `Checking weather in ${city}`,
+          },
+        ]);
+
+        const loop = new OperateLoop({
+          adapter: mockAdapter,
+          client: mockClient,
+        });
+
+        await loop.execute("Call tool", {
+          tools: toolkit,
+          turns: 3,
+          hooks: {
+            afterEachTool: afterToolHook,
+            beforeEachTool: beforeToolHook,
+          },
+        });
+
+        expect(beforeToolHook).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: "Checking weather in NYC",
+            toolName: "test_tool",
+          }),
+        );
+        expect(afterToolHook).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: "Checking weather in NYC",
+            result: "result",
+            toolName: "test_tool",
+          }),
+        );
+      });
+
       it("logs at warn level when tool throws, not error", async () => {
         const { log: mockLog } = await import("@jaypie/logger");
         const mockLogger = {
@@ -648,6 +737,7 @@ describe("OperateLoop", () => {
             parameters: { type: "object" },
             type: "function",
             call: vi.fn(() => "tool result"),
+            message: "Running the test tool",
           },
         ]);
 
@@ -670,6 +760,7 @@ describe("OperateLoop", () => {
         );
         expect(toolCallEvent?.tool).toEqual({
           arguments: "{}",
+          message: "Running the test tool",
           name: "test_tool",
         });
         const toolResultEvent = events.find(

--- a/packages/llm/src/operate/__tests__/StreamLoop.spec.ts
+++ b/packages/llm/src/operate/__tests__/StreamLoop.spec.ts
@@ -1113,6 +1113,91 @@ describe("StreamLoop", () => {
         );
       });
 
+      it("passes resolved tool message to beforeEachTool and afterEachTool hooks", async () => {
+        const beforeToolHook = vi.fn();
+        const afterToolHook = vi.fn();
+        const toolkit = new Toolkit([
+          {
+            name: "test_tool",
+            description: "Test",
+            parameters: { type: "object" },
+            type: "function",
+            call: vi.fn(() => "result"),
+            message: "Streaming tool message",
+          },
+        ]);
+
+        let callCount = 0;
+        mockAdapter.executeStreamRequest = vi.fn(
+          async function* (): AsyncIterable<LlmStreamChunk> {
+            callCount++;
+            if (callCount === 1) {
+              yield {
+                type: LlmStreamChunkType.ToolCall,
+                toolCall: { id: "call-1", name: "test_tool", arguments: "{}" },
+              };
+              yield {
+                type: LlmStreamChunkType.Done,
+                usage: [
+                  {
+                    input: 10,
+                    output: 10,
+                    reasoning: 0,
+                    total: 20,
+                    provider: "mock",
+                    model: "mock-model",
+                  },
+                ],
+              };
+            } else {
+              yield { type: LlmStreamChunkType.Text, content: "Done" };
+              yield {
+                type: LlmStreamChunkType.Done,
+                usage: [
+                  {
+                    input: 10,
+                    output: 10,
+                    reasoning: 0,
+                    total: 20,
+                    provider: "mock",
+                    model: "mock-model",
+                  },
+                ],
+              };
+            }
+          },
+        );
+
+        const loop = new StreamLoop({
+          adapter: mockAdapter,
+          client: mockClient,
+        });
+
+        await collectChunks(
+          loop.execute("Call tool", {
+            tools: toolkit,
+            turns: 3,
+            hooks: {
+              afterEachTool: afterToolHook,
+              beforeEachTool: beforeToolHook,
+            },
+          }),
+        );
+
+        expect(beforeToolHook).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: "Streaming tool message",
+            toolName: "test_tool",
+          }),
+        );
+        expect(afterToolHook).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: "Streaming tool message",
+            toolName: "test_tool",
+          }),
+        );
+      });
+
       it("calls onToolError hook when tool throws", async () => {
         const onToolErrorHook = vi.fn();
         const toolError = new Error("Tool failed!");

--- a/packages/llm/src/operate/hooks/HookRunner.ts
+++ b/packages/llm/src/operate/hooks/HookRunner.ts
@@ -30,11 +30,13 @@ export interface AfterModelResponseContext {
 
 export interface BeforeToolContext {
   args: string;
+  message?: string;
   toolName: string;
 }
 
 export interface AfterToolContext {
   args: string;
+  message?: string;
   result: unknown;
   toolName: string;
 }
@@ -42,6 +44,7 @@ export interface AfterToolContext {
 export interface ToolErrorContext {
   args: string;
   error: Error;
+  message?: string;
   toolName: string;
 }
 

--- a/packages/llm/src/tools/Toolkit.class.ts
+++ b/packages/llm/src/tools/Toolkit.class.ts
@@ -72,12 +72,7 @@ export class Toolkit {
     });
   }
 
-  async call({ name, arguments: args }: { name: string; arguments: string }) {
-    const tool = this._tools.find((t) => t.name === name);
-    if (!tool) {
-      throw new Error(`Tool '${name}' not found`);
-    }
-
+  private parseArgs(args: string) {
     let parsedArgs;
     try {
       parsedArgs = JSON.parse(args);
@@ -87,6 +82,59 @@ export class Toolkit {
     } catch {
       parsedArgs = args;
     }
+    return parsedArgs;
+  }
+
+  /**
+   * Resolve a tool's `message` (static string or function of args) without
+   * calling the tool. Returns undefined when the tool is missing or defines
+   * no message. Never throws; resolution errors log at warn.
+   */
+  async resolveMessage({
+    name,
+    arguments: args,
+  }: {
+    name: string;
+    arguments: string;
+  }): Promise<string | undefined> {
+    const tool = this._tools.find((t) => t.name === name);
+    if (!tool || !tool.message) {
+      return undefined;
+    }
+
+    try {
+      if (typeof tool.message === "string") {
+        return tool.message;
+      }
+      const parsedArgs = this.parseArgs(args);
+      if (typeof tool.message === "function") {
+        return await resolveValue(tool.message(parsedArgs, { name }));
+      }
+      log.warn("[Toolkit] Tool provided unknown message type");
+      return String(tool.message);
+    } catch (error) {
+      log.warn("[Toolkit] Caught error resolving tool message");
+      log.var({ error });
+      return undefined;
+    }
+  }
+
+  async call({
+    name,
+    arguments: args,
+    message: resolvedMessage,
+  }: {
+    name: string;
+    arguments: string;
+    /** Pre-resolved tool message; skips re-resolving `tool.message` for logging */
+    message?: string;
+  }) {
+    const tool = this._tools.find((t) => t.name === name);
+    if (!tool) {
+      throw new Error(`Tool '${name}' not found`);
+    }
+
+    const parsedArgs = this.parseArgs(args);
 
     if (this.log !== false) {
       try {
@@ -94,28 +142,15 @@ export class Toolkit {
           name,
           args: parsedArgs,
         };
-        let message: string;
 
         if (this.explain) {
           context.explanation = parsedArgs.__Explanation;
         }
 
-        if (tool.message) {
-          if (typeof tool.message === "string") {
-            log.trace("[Toolkit] Tool provided string message");
-            message = tool.message;
-          } else if (typeof tool.message === "function") {
-            log.trace("[Toolkit] Tool provided function message");
-            log.trace("[Toolkit] Resolving message result");
-            message = await resolveValue(tool.message(parsedArgs, { name }));
-          } else {
-            log.warn("[Toolkit] Tool provided unknown message type");
-            message = String(tool.message);
-          }
-        } else {
-          log.trace("[Toolkit] Log tool call with default message");
-          message = `${tool.name}:${JSON.stringify(parsedArgs)}`;
-        }
+        const message =
+          resolvedMessage ??
+          (await this.resolveMessage({ arguments: args, name })) ??
+          `${tool.name}:${JSON.stringify(parsedArgs)}`;
 
         if (typeof this.log === "function") {
           log.trace("[Toolkit] Log tool call with custom logger");

--- a/packages/llm/src/tools/__tests__/Toolkit.class.test.ts
+++ b/packages/llm/src/tools/__tests__/Toolkit.class.test.ts
@@ -322,6 +322,101 @@ describe("Toolkit", () => {
         { name: "testTool", args: { testParam: "value" } },
       );
     });
+
+    it("should not re-resolve tool.message when call receives a pre-resolved message", async () => {
+      const messageFn = vi.fn().mockReturnValue("Resolved elsewhere");
+      const toolWithMessage: LlmTool = {
+        ...mockTool,
+        message: messageFn,
+      };
+      const customLogFn = vi.fn();
+      const toolkit = new Toolkit([toolWithMessage], { log: customLogFn });
+      const args = JSON.stringify({ testParam: "value" });
+
+      await toolkit.call({
+        arguments: args,
+        message: "Pre-resolved message",
+        name: "testTool",
+      });
+
+      expect(messageFn).not.toHaveBeenCalled();
+      expect(customLogFn).toHaveBeenCalledWith("Pre-resolved message", {
+        name: "testTool",
+        args: { testParam: "value" },
+      });
+    });
+  });
+
+  describe("resolveMessage", () => {
+    it("resolves a string message", async () => {
+      const toolkit = new Toolkit([{ ...mockTool, message: "Static message" }]);
+      const message = await toolkit.resolveMessage({
+        arguments: "{}",
+        name: "testTool",
+      });
+      expect(message).toBe("Static message");
+    });
+
+    it("resolves a function message with parsed args and context", async () => {
+      const messageFn = vi
+        .fn()
+        .mockImplementation(({ testParam }) => `Working on ${testParam}`);
+      const toolkit = new Toolkit([{ ...mockTool, message: messageFn }]);
+      const message = await toolkit.resolveMessage({
+        arguments: JSON.stringify({ testParam: "value" }),
+        name: "testTool",
+      });
+      expect(message).toBe("Working on value");
+      expect(messageFn).toHaveBeenCalledWith(
+        { testParam: "value" },
+        { name: "testTool" },
+      );
+    });
+
+    it("awaits a function message returning a promise", async () => {
+      const toolkit = new Toolkit([
+        { ...mockTool, message: vi.fn().mockResolvedValue("Async message") },
+      ]);
+      const message = await toolkit.resolveMessage({
+        arguments: "{}",
+        name: "testTool",
+      });
+      expect(message).toBe("Async message");
+    });
+
+    it("returns undefined when the tool has no message", async () => {
+      const toolkit = new Toolkit([mockTool]);
+      const message = await toolkit.resolveMessage({
+        arguments: "{}",
+        name: "testTool",
+      });
+      expect(message).toBeUndefined();
+    });
+
+    it("returns undefined when the tool is not found", async () => {
+      const toolkit = new Toolkit([mockTool]);
+      const message = await toolkit.resolveMessage({
+        arguments: "{}",
+        name: "missingTool",
+      });
+      expect(message).toBeUndefined();
+    });
+
+    it("returns undefined when the message function throws", async () => {
+      const toolkit = new Toolkit([
+        {
+          ...mockTool,
+          message: vi.fn().mockImplementation(() => {
+            throw new Error("Sorpresa!");
+          }),
+        },
+      ]);
+      const message = await toolkit.resolveMessage({
+        arguments: "{}",
+        name: "testTool",
+      });
+      expect(message).toBeUndefined();
+    });
   });
 
   describe("extend", () => {

--- a/packages/llm/src/types/LlmProvider.interface.ts
+++ b/packages/llm/src/types/LlmProvider.interface.ts
@@ -237,6 +237,8 @@ export enum LlmProgressEventType {
 export interface LlmProgressToolCall {
   /** JSON string of arguments (tool_call events only) */
   arguments?: string;
+  /** Resolved `LlmTool.message`, when the tool defines one (tool_call events only) */
+  message?: string;
   /** Tool name */
   name: string;
 }
@@ -299,10 +301,13 @@ export interface LlmOperateOptions {
       result,
       toolName,
       args,
+      message,
     }: {
       result: unknown;
       toolName: string;
       args: string;
+      /** Resolved `LlmTool.message`, when the tool defines one */
+      message?: string;
     }) => unknown | Promise<unknown>;
     beforeEachModelRequest?: ({
       input,
@@ -316,9 +321,12 @@ export interface LlmOperateOptions {
     beforeEachTool?: ({
       toolName,
       args,
+      message,
     }: {
       toolName: string;
       args: string;
+      /** Resolved `LlmTool.message`, when the tool defines one */
+      message?: string;
     }) => unknown | Promise<unknown>;
     onRetryableModelError?: ({
       input,
@@ -335,10 +343,13 @@ export interface LlmOperateOptions {
       error,
       toolName,
       args,
+      message,
     }: {
       error: Error;
       toolName: string;
       args: string;
+      /** Resolved `LlmTool.message`, when the tool defines one */
+      message?: string;
     }) => unknown | Promise<unknown>;
     onUnrecoverableModelError?: ({
       input,

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.91",
+  "version": "0.8.92",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/llm/1.3.8.md
+++ b/packages/mcp/release-notes/llm/1.3.8.md
@@ -1,0 +1,28 @@
+---
+version: 1.3.8
+date: 2026-07-04
+summary: Surface resolved LlmTool.message in tool hooks and the tool_call progress event; add Toolkit.resolveMessage
+---
+
+## Changes
+
+### Tool Messages
+
+- `beforeEachTool`, `afterEachTool`, and `onToolError` hooks receive
+  `message` — the tool's resolved `LlmTool.message` (static string or
+  function of the parsed args), `undefined` when the tool defines none.
+  Applies to both `operate()` and `stream()`
+- The `tool_call` progress event (`onProgress`) carries `tool.message`
+- New public `Toolkit.resolveMessage({ name, arguments })` — resolves a
+  tool's message without calling the tool; returns `undefined` when the
+  tool is missing or defines no message; never throws (resolution errors
+  log at warn)
+- `Toolkit.call({ name, arguments, message })` accepts an optional
+  pre-resolved message so the loops resolve each tool's message exactly
+  once per call (function messages are not invoked twice)
+
+## Migration
+
+No changes required. The Toolkit `log` option remains supported and
+continues to receive the resolved message (or the default
+`name:{args}` line when no message is defined).

--- a/packages/mcp/release-notes/mcp/0.8.92.md
+++ b/packages/mcp/release-notes/mcp/0.8.92.md
@@ -1,0 +1,13 @@
+---
+version: 0.8.92
+date: 2026-07-04
+summary: Document tool messages in the llm skill — hooks message field, tool_call event message, Toolkit.resolveMessage
+---
+
+## Changes
+
+- `skill("llm")` documents Tool Messages: the `LlmTool.message` field, the
+  `message` field on `beforeEachTool`/`afterEachTool`/`onToolError` hook
+  contexts, `tool.message` on the `tool_call` progress event, and
+  `Toolkit.resolveMessage()`
+- Release notes for `@jaypie/llm` 1.3.8

--- a/packages/mcp/skills/llm.md
+++ b/packages/mcp/skills/llm.md
@@ -166,6 +166,30 @@ When enabled:
 - The explanation is stripped before the tool executes (tools receive clean arguments)
 - Useful for debugging and understanding LLM decision-making
 
+### Tool Messages
+
+Tools may define a `message` — a human-readable status line for the call, either a static string or a function of the parsed arguments:
+
+```typescript
+const toolkit = new Toolkit([
+  {
+    name: "get_weather",
+    description: "Get current weather for a city",
+    type: "function",
+    parameters: { type: "object", properties: { city: { type: "string" } } },
+    call: async ({ city }) => ({ temp: 72 }),
+    message: ({ city }) => `Checking weather in ${city}`,
+  },
+]);
+```
+
+The resolved message surfaces in three places during `operate()`/`stream()`:
+- The Toolkit's `log` option: `new Toolkit(tools, { log: (message, { name, args }) => ... })`
+- The `beforeEachTool`, `afterEachTool`, and `onToolError` hooks as `message`
+- The `tool_call` progress event as `tool.message` (`operate()` only)
+
+Resolve one directly with `toolkit.resolveMessage({ name, arguments })` — returns the resolved string, or `undefined` when the tool is missing or defines no message; it never throws.
+
 ## Structured Output
 
 ### Natural Schema
@@ -303,18 +327,20 @@ const response = await Llm.operate(input, {
     afterEachModelResponse: ({ content, usage }) => {
       console.log(`Tokens: ${usage.total}`);
     },
-    beforeEachTool: ({ toolName, args }) => {
-      console.log(`Calling ${toolName} with`, args);
+    beforeEachTool: ({ toolName, args, message }) => {
+      console.log(message ?? `Calling ${toolName} with ${args}`);
     },
-    afterEachTool: ({ result, toolName }) => {
+    afterEachTool: ({ result, toolName, message }) => {
       console.log(`${toolName} returned:`, result);
     },
-    onToolError: ({ error, toolName }) => {
+    onToolError: ({ error, toolName, message }) => {
       console.error(`${toolName} failed:`, error);
     },
   },
 });
 ```
+
+The tool hooks receive `message` — the tool's resolved `LlmTool.message`, when the tool defines one (see Tool Messages).
 
 ## Progress Events
 
@@ -341,7 +367,7 @@ Fields carried by each event (`turn` is 1-indexed):
 | `start` | `model`, `provider`, `maxTurns` |
 | `model_request` | `turn`, `model` |
 | `model_response` | `turn`, `content` (text, if any), `toolCalls` (`[{ name, arguments }]`, if any), `usage` (this turn) |
-| `tool_call` | `turn`, `tool: { name, arguments }` — fires before the tool runs; `arguments` is the JSON string |
+| `tool_call` | `turn`, `tool: { name, arguments, message }` — fires before the tool runs; `arguments` is the JSON string; `message` is the resolved `LlmTool.message`, when the tool defines one |
 | `tool_result` | `turn`, `tool: { name }` — the result value is deliberately omitted (it can be arbitrarily large); use the `afterEachTool` hook to receive it |
 | `tool_error` | `turn`, `tool: { name }`, `error` (message string) |
 | `retry` | `turn`, `error` (message string) |

--- a/workspaces/documentation/src/content/docs/docs/guides/llm-integration.md
+++ b/workspaces/documentation/src/content/docs/docs/guides/llm-integration.md
@@ -345,13 +345,14 @@ const response = await Llm.operate(prompt, {
       log.trace("[llm] response received");
       log.var({ tokens: usage[usage.length - 1]?.total });
     },
-    beforeEachTool: ({ toolName, args }) => {
-      log.trace(`[llm] calling ${toolName}`);
+    beforeEachTool: ({ toolName, args, message }) => {
+      // message is the tool's resolved LlmTool.message, when defined
+      log.trace(message ?? `[llm] calling ${toolName}`);
     },
-    afterEachTool: ({ result, toolName }) => {
+    afterEachTool: ({ result, toolName, message }) => {
       log.trace(`[llm] ${toolName} returned`);
     },
-    onToolError: ({ error, toolName }) => {
+    onToolError: ({ error, toolName, message }) => {
       log.warn(`[llm] ${toolName} failed`);
       log.var({ error: error.message });
     },
@@ -389,7 +390,7 @@ Fields carried by each event (`turn` is 1-indexed):
 | `start` | `model`, `provider`, `maxTurns` |
 | `model_request` | `turn`, `model` |
 | `model_response` | `turn`, `content` (text, if any), `toolCalls` (`[{ name, arguments }]`, if any), `usage` (this turn) |
-| `tool_call` | `turn`, `tool: { name, arguments }` — fires before the tool runs; `arguments` is the JSON string |
+| `tool_call` | `turn`, `tool: { name, arguments, message }` — fires before the tool runs; `arguments` is the JSON string; `message` is the resolved `LlmTool.message`, when the tool defines one |
 | `tool_result` | `turn`, `tool: { name }` — the result value is deliberately omitted (it can be arbitrarily large); use the `afterEachTool` hook to receive it |
 | `tool_error` | `turn`, `tool: { name }`, `error` (message string) |
 | `retry` | `turn`, `error` (message string) |

--- a/workspaces/documentation/src/content/docs/docs/packages/llm.md
+++ b/workspaces/documentation/src/content/docs/docs/packages/llm.md
@@ -333,13 +333,14 @@ const response = await Llm.operate(prompt, {
       log.trace("[llm] response received");
       log.var({ tokens: usage[usage.length - 1]?.total });
     },
-    beforeEachTool: ({ toolName, args }) => {
-      log.trace(`[llm] calling ${toolName}`);
+    beforeEachTool: ({ toolName, args, message }) => {
+      // message is the tool's resolved LlmTool.message, when defined
+      log.trace(message ?? `[llm] calling ${toolName}`);
     },
-    afterEachTool: ({ result, toolName }) => {
+    afterEachTool: ({ result, toolName, message }) => {
       log.trace(`[llm] ${toolName} returned`);
     },
-    onToolError: ({ error, toolName }) => {
+    onToolError: ({ error, toolName, message }) => {
       log.warn(`[llm] ${toolName} failed`);
       log.var({ error: error.message });
     },
@@ -377,7 +378,7 @@ Fields carried by each event (`turn` is 1-indexed):
 | `start` | `model`, `provider`, `maxTurns` |
 | `model_request` | `turn`, `model` |
 | `model_response` | `turn`, `content` (text, if any), `toolCalls` (`[{ name, arguments }]`, if any), `usage` (this turn) |
-| `tool_call` | `turn`, `tool: { name, arguments }` — fires before the tool runs; `arguments` is the JSON string |
+| `tool_call` | `turn`, `tool: { name, arguments, message }` — fires before the tool runs; `arguments` is the JSON string; `message` is the resolved `LlmTool.message`, when the tool defines one |
 | `tool_result` | `turn`, `tool: { name }` — the result value is deliberately omitted (it can be arbitrarily large); use the `afterEachTool` hook to receive it |
 | `tool_error` | `turn`, `tool: { name }`, `error` (message string) |
 | `retry` | `turn`, `error` (message string) |


### PR DESCRIPTION
## Summary

Makes `LlmTool.message` usable while an operate loop is running.

- 🆕 Public `Toolkit.resolveMessage({ name, arguments })` — resolves a tool's `message` (static string, sync or async function of parsed args) without calling the tool; returns `undefined` when the tool is missing or defines no message; never throws
- 🪝 `beforeEachTool`, `afterEachTool`, and `onToolError` hook contexts now carry `message` in both `operate()` and `stream()`
- 📡 The `tool_call` progress event (`onProgress`) carries `tool.message`
- ♻️ Loops resolve each tool's message exactly once per call and pass it into `Toolkit.call({ ..., message })` — function messages are never invoked twice; the Toolkit `log` option reuses the pre-resolved value

## Versions

- `@jaypie/llm` 1.3.7 → 1.3.8
- `@jaypie/mcp` 0.8.91 → 0.8.92 (skill docs + release notes)

## Docs

- `skill("llm")` Tool Messages section; hooks example and event field tables
- jaypie.net: `packages/llm` and `guides/llm-integration` event tables + hook examples
- `packages/llm/CLAUDE.md`

## Tests

- Toolkit: `resolveMessage` specs (string, function, async, missing tool, no message, throwing message) + no-double-resolution spec
- OperateLoop: message in before/after hooks, `tool_call` event `message`
- StreamLoop: message in before/after hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)