### PR TITLE
feat(express): report route parameters; export JaypieLogger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19069,7 +19069,7 @@
     },
     "packages/express": {
       "name": "@jaypie/express",
-      "version": "1.2.27",
+      "version": "1.2.28",
       "license": "MIT",
       "dependencies": {
         "@jaypie/datadog": "*",
@@ -19965,7 +19965,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.92",
+      "version": "0.8.93",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19935,7 +19935,7 @@
     },
     "packages/logger": {
       "name": "@jaypie/logger",
-      "version": "1.2.19",
+      "version": "1.2.20",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-typescript": "^12.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19765,17 +19765,17 @@
       }
     },
     "packages/jaypie": {
-      "version": "1.2.61",
+      "version": "1.2.62",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "^1.2.10",
         "@jaypie/core": "^1.2.4",
         "@jaypie/datadog": "^1.2.6",
         "@jaypie/errors": "^1.2.3",
-        "@jaypie/express": "^1.2.27",
+        "@jaypie/express": "^1.2.28",
         "@jaypie/kit": "^1.2.12",
         "@jaypie/lambda": "^1.2.11",
-        "@jaypie/logger": "^1.2.19"
+        "@jaypie/logger": "^1.2.20"
       },
       "devDependencies": {
         "@jaypie/types": "^0.1.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20316,7 +20316,7 @@
     },
     "packages/testkit": {
       "name": "@jaypie/testkit",
-      "version": "1.2.51",
+      "version": "1.2.52",
       "license": "MIT",
       "dependencies": {
         "jest-json-schema": "^6.1.0",

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/express",
-  "version": "1.2.27",
+  "version": "1.2.28",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"

--- a/packages/express/src/__tests__/supertest.spec.ts
+++ b/packages/express/src/__tests__/supertest.spec.ts
@@ -358,6 +358,34 @@ describe("Express handler", () => {
           );
         });
 
+        it("Reports route parameters when the route defines them", async () => {
+          const mockFunction = vi.fn(() => ({ ok: true }));
+          const handler = expressHandler(mockFunction, { name: "handler" });
+          const app = express();
+          app.get("/workflows/:id/messages", handler);
+          const id = "123e4567-e89b-12d3-a456-426614174000";
+          await request(app).get(`/workflows/${id}/messages`);
+          expect(log.report).toHaveBeenCalledWith(
+            expect.objectContaining({
+              path: "/workflows/:id/messages",
+              parameters: { id },
+            }),
+          );
+        });
+
+        it("Omits parameters when the route defines none", async () => {
+          const mockFunction = vi.fn(() => ({ ok: true }));
+          const handler = expressHandler(mockFunction, { name: "handler" });
+          const app = express();
+          app.use(handler);
+          await request(app).get("/ping");
+          expect(log.report).toHaveBeenCalledWith(
+            expect.not.objectContaining({
+              parameters: expect.anything(),
+            }),
+          );
+        });
+
         it("Reports contentType and contentLength for POST body", async () => {
           const mockFunction = vi.fn(() => ({ ok: true }));
           const handler = expressHandler(mockFunction, { name: "handler" });

--- a/packages/express/src/expressHandler.ts
+++ b/packages/express/src/expressHandler.ts
@@ -698,14 +698,18 @@ function expressHandler<T>(
     const contentLength = contentLengthHeader ? Number(contentLengthHeader) : 0;
 
     // Add request data to session report
-    logger.report({
+    const reportData: Record<string, unknown> = {
       method: req.method,
       path,
       query,
       contentType,
       contentLength,
       status: String(res.statusCode),
-    });
+    };
+    if (req.params && Object.keys(req.params).length > 0) {
+      reportData.parameters = { ...req.params };
+    }
+    logger.report(reportData);
 
     // Submit metric if Datadog is configured
     if (hasDatadogEnv()) {

--- a/packages/express/src/expressStreamHandler.ts
+++ b/packages/express/src/expressStreamHandler.ts
@@ -428,11 +428,15 @@ function expressStreamHandler(
       );
 
       // Add request data to session report
-      logger.report({
+      const reportData: Record<string, unknown> = {
         method: req.method,
         path,
         status: String(res.statusCode),
-      });
+      };
+      if (req.params && Object.keys(req.params).length > 0) {
+        reportData.parameters = { ...req.params };
+      }
+      logger.report(reportData);
 
       // Submit metric if Datadog is configured
       if (hasDatadogEnv()) {

--- a/packages/jaypie/package.json
+++ b/packages/jaypie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jaypie",
-  "version": "1.2.61",
+  "version": "1.2.62",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"
@@ -41,10 +41,10 @@
     "@jaypie/core": "^1.2.4",
     "@jaypie/datadog": "^1.2.6",
     "@jaypie/errors": "^1.2.3",
-    "@jaypie/express": "^1.2.27",
+    "@jaypie/express": "^1.2.28",
     "@jaypie/kit": "^1.2.12",
     "@jaypie/lambda": "^1.2.11",
-    "@jaypie/logger": "^1.2.19"
+    "@jaypie/logger": "^1.2.20"
   },
   "devDependencies": {
     "@jaypie/types": "^0.1.7",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/logger",
-  "version": "1.2.19",
+  "version": "1.2.20",
   "description": "Logger utilities for Jaypie applications",
   "repository": {
     "type": "git",

--- a/packages/logger/src/JaypieLogger.ts
+++ b/packages/logger/src/JaypieLogger.ts
@@ -27,7 +27,7 @@ function envBoolean(
   );
 }
 
-class JaypieLogger {
+export class JaypieLogger {
   public debug: Logger["debug"];
   public error: Logger["error"];
   public fatal: Logger["fatal"];

--- a/packages/logger/src/JaypieLogger.ts
+++ b/packages/logger/src/JaypieLogger.ts
@@ -260,6 +260,11 @@ class JaypieLogger {
     return logger;
   }
 
+  /**
+   * Merge data into the current session's report. Requires an active
+   * session (started via setup()); logs a warning and is a no-op otherwise.
+   * Warns when overwriting an existing key. Emitted by teardown().
+   */
   public report(data: Record<string, unknown>): void {
     if (!this._sessionActive) {
       this.warn("[logger] report() called without active session");
@@ -273,6 +278,11 @@ class JaypieLogger {
     Object.assign(this._report, data);
   }
 
+  /**
+   * Start a report session: resets warn/error counters and accumulated
+   * report data, applies optional tags. Pair with teardown() to bookend a
+   * request. Handlers call this automatically.
+   */
   public setup(tags?: Record<string, unknown>): void {
     if (this._sessionActive) {
       this.warn("[logger] setup() called while session already active");
@@ -293,6 +303,12 @@ class JaypieLogger {
     Object.assign(this._tags, tags);
   }
 
+  /**
+   * End the current report session: emits log.info.var({ report }) with
+   * accumulated report() data plus { log: { warn, warns, error, errors } }
+   * counts, then resets session state. No-op if no session is active.
+   * Handlers call this automatically.
+   */
   public teardown(): void {
     if (!this._sessionActive) {
       return;

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -20,6 +20,7 @@ export {
   sanitizeAuth,
 };
 export type { SerializationLimitOptions, SerializationLimits } from "./limits";
+export { JaypieLogger } from "./JaypieLogger";
 
 export const log = createLogger();
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.92",
+  "version": "0.8.93",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/express/1.2.28.md
+++ b/packages/mcp/release-notes/express/1.2.28.md
@@ -1,0 +1,12 @@
+---
+version: 1.2.28
+date: 2026-07-04
+summary: Include route parameters in the automatic session report
+---
+
+# @jaypie/express 1.2.28
+
+## Changes
+
+- `expressHandler` and `expressStreamHandler` now include a `parameters` field (mirroring `req.params`) in the automatic `log.report()` call when the matched route defines params, e.g. `path: "/workflows/:id/messages"` now also reports `parameters: { id: "..." }`.
+- `parameters` is omitted entirely when the route has no params.

--- a/packages/mcp/release-notes/jaypie/1.2.62.md
+++ b/packages/mcp/release-notes/jaypie/1.2.62.md
@@ -1,0 +1,14 @@
+---
+version: 1.2.62
+date: 2026-07-04
+summary: Pick up @jaypie/express 1.2.28 (report parameters) and @jaypie/logger 1.2.20 (exported JaypieLogger)
+---
+
+## Changes
+
+- `@jaypie/express` dependency raised to `^1.2.28` — `expressHandler` and
+  `expressStreamHandler` now include a `parameters` field (mirroring
+  `req.params`) in the automatic session report when the matched route
+  defines params
+- `@jaypie/logger` dependency raised to `^1.2.20` — `JaypieLogger` is now a
+  named export, and `report()`/`setup()`/`teardown()` gained TSDoc comments

--- a/packages/mcp/release-notes/logger/1.2.20.md
+++ b/packages/mcp/release-notes/logger/1.2.20.md
@@ -1,0 +1,11 @@
+---
+version: 1.2.20
+date: 2026-07-04
+summary: Export JaypieLogger class and document setup/report/teardown session management
+---
+
+## Changes
+
+- Exported `JaypieLogger` as a named export from `@jaypie/logger` so its class members are visible to API Extractor and appear in generated API docs
+- Added TSDoc comments to `report()`, `setup()`, and `teardown()`
+- Documented the `log.setup()` / `log.report()` / `log.teardown()` session management pattern on jaypie.net (previously only covered in the internal `logs` skill)

--- a/packages/mcp/release-notes/mcp/0.8.93.md
+++ b/packages/mcp/release-notes/mcp/0.8.93.md
@@ -1,0 +1,11 @@
+---
+version: 0.8.93
+date: 2026-07-04
+summary: Document expressHandler/expressStreamHandler automatic parameters field in session report
+---
+
+## Changes
+
+- `skill("express")` documents the automatic `log.report()` session report,
+  including the new `parameters` field (mirrors `req.params`)
+- Release notes for `@jaypie/express` 1.2.28

--- a/packages/mcp/release-notes/testkit/1.2.52.md
+++ b/packages/mcp/release-notes/testkit/1.2.52.md
@@ -1,0 +1,11 @@
+---
+version: 1.2.52
+date: 2026-07-04
+summary: Re-export JaypieLogger from @jaypie/testkit/mock to match @jaypie/logger 1.2.20
+---
+
+## Changes
+
+- `@jaypie/testkit/mock` re-exports `JaypieLogger` alongside the existing
+  `Logger`, `FORMAT`, `LEVEL`, `redactAuth`, `sanitizeAuth` mocks, matching
+  `@jaypie/logger@1.2.20`'s new named export

--- a/packages/mcp/skills/express.md
+++ b/packages/mcp/skills/express.md
@@ -162,6 +162,24 @@ The Lambda adapter provides Express-compatible request properties:
 | `req._lambdaContext` | Original Lambda context |
 | `req._lambdaEvent` | Original Lambda event |
 
+## Session Report
+
+`expressHandler` and `expressStreamHandler` automatically call `log.report()` with request metadata before the session's `log.teardown()` (see `skill("logs")`):
+
+```typescript
+{
+  method: "GET",
+  path: "/workflows/:id/messages", // UUID segments normalized to :id
+  query: "limit=10",
+  contentType: "",
+  contentLength: 0,
+  status: "200",
+  parameters: { id: "123e4567-e89b-12d3-a456-426614174000" }, // req.params, only when non-empty
+}
+```
+
+`parameters` mirrors Express's `req.params` so the original route parameter values survive path normalization for aggregation.
+
 ## CDK Integration
 
 Deploy with `@jaypie/constructs`:

--- a/packages/testkit/package.json
+++ b/packages/testkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/testkit",
-  "version": "1.2.51",
+  "version": "1.2.52",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"

--- a/packages/testkit/src/mock/logger.ts
+++ b/packages/testkit/src/mock/logger.ts
@@ -3,6 +3,7 @@ import { vi } from "vitest";
 import { createMockWrappedFunction } from "./utils";
 import {
   FORMAT,
+  JaypieLogger,
   LEVEL,
   Logger,
   createLogger as originalCreateLogger,
@@ -22,6 +23,6 @@ export const _resetDatadogTransport = vi.fn();
 export const getDatadogTransport = vi.fn().mockReturnValue(null);
 export const isDatadogForwardingEnabled = vi.fn().mockReturnValue(false);
 
-export { FORMAT, LEVEL, Logger, redactAuth, sanitizeAuth };
+export { FORMAT, JaypieLogger, LEVEL, Logger, redactAuth, sanitizeAuth };
 
 export default mockLog;

--- a/workspaces/documentation/src/content/docs/docs/core/logging.md
+++ b/workspaces/documentation/src/content/docs/docs/core/logging.md
@@ -214,6 +214,25 @@ For manual initialization:
 log.init(); // Clears tags, resets state
 ```
 
+## Session Management
+
+Handlers automatically call `log.setup()` and `log.teardown()` to bookend each request. On teardown, a report is emitted as `log.info.var({ report })` containing accumulated data and warn/error counts.
+
+```typescript
+// Manual session (handlers do this automatically)
+log.setup({ handler: "myHandler", invoke: "abc-123" });
+
+// Accumulate report data during the request
+log.report({ userId: "456" });
+log.report({ itemCount: 3 });
+
+// Teardown emits the report with warn/error stats
+log.teardown();
+// => { report: { userId: "456", itemCount: 3, log: { warn: false, warns: 0, error: false, errors: 0 } } }
+```
+
+`log.report()` only accumulates data while a session is active (after `setup()`, before `teardown()`); calling it outside a session logs a warning and is a no-op. Warn and error calls made during the session are counted automatically and included in the final report.
+
 ## Environment Configuration
 
 | Variable | Values | Default |

--- a/workspaces/documentation/src/content/docs/docs/packages/logger.md
+++ b/workspaces/documentation/src/content/docs/docs/packages/logger.md
@@ -38,6 +38,9 @@ npm install @jaypie/logger
 | `log.tag()` | Add context to all logs |
 | `log.with()` | Create child logger |
 | `log.init()` | Reset logger state |
+| `log.setup()` | Start a report session |
+| `log.report()` | Accumulate session report data |
+| `log.teardown()` | Emit session report, end session |
 
 ## Basic Usage
 
@@ -126,6 +129,25 @@ log.init();
 ```
 
 Handlers call `log.init()` automatically.
+
+## Session Management
+
+Handlers automatically call `log.setup()` and `log.teardown()` to bookend each request. On teardown, a report is emitted as `log.info.var({ report })` containing accumulated data and warn/error counts.
+
+```typescript
+// Manual session (handlers do this automatically)
+log.setup({ handler: "myHandler", invoke: "abc-123" });
+
+// Accumulate report data during the request
+log.report({ userId: "456" });
+log.report({ itemCount: 3 });
+
+// Teardown emits the report with warn/error stats
+log.teardown();
+// => { report: { userId: "456", itemCount: 3, log: { warn: false, warns: 0, error: false, errors: 0 } } }
+```
+
+`log.report()` only accumulates data while a session is active; calling it outside a session logs a warning and is a no-op. Warn and error calls made during the session are counted automatically and included in the final report.
 
 ## Function Prefix Convention
 


### PR DESCRIPTION
## Summary
- Document `log.setup()`/`log.report()`/`log.teardown()` session management on jaypie.net (was only in the internal `logs` skill)
- Export `JaypieLogger` as a named export from `@jaypie/logger` so its methods (including `report`/`setup`/`teardown`) surface in the generated API reference; added TSDoc comments
- `expressHandler`/`expressStreamHandler` now include a `parameters` field (mirroring `req.params`) in the automatic session report, so route parameter values survive path normalization (e.g. `path: "/workflows/:id/messages"` + `parameters: { id: "..." }`)
- Version bumps: `@jaypie/logger` 1.2.20, `@jaypie/express` 1.2.28, `@jaypie/testkit` 1.2.52 (mock parity), `@jaypie/mcp` 0.8.93, `jaypie` 1.2.62

## Test plan
- [x] `npm run build/lint/typecheck/test` green for logger, express, testkit, mcp, jaypie
- [x] NPM Check CI passing on branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)