### PR TITLE
feat(dynamodb): conditional updateEntity + transitionEntity (#417); docs(mcp): status vocabulary + ports skill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15008,7 +15008,7 @@
     },
     "packages/dynamodb": {
       "name": "@jaypie/dynamodb",
-      "version": "0.6.5",
+      "version": "0.6.6",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.726.1",
@@ -15503,7 +15503,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.96",
+      "version": "0.8.97",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.3.3",
@@ -15583,7 +15583,7 @@
     },
     "packages/testkit": {
       "name": "@jaypie/testkit",
-      "version": "1.2.53",
+      "version": "1.2.54",
       "license": "MIT",
       "dependencies": {
         "jest-json-schema": "^6.1.0",

--- a/packages/dynamodb/CLAUDE.md
+++ b/packages/dynamodb/CLAUDE.md
@@ -54,7 +54,8 @@ src/
 |--------|-------------|
 | `getEntity({ id })` | Get a single entity by primary key (id only) |
 | `createEntity({ entity })` | Create entity; returns `null` if `id` already exists (conditional write on `attribute_not_exists(id)`) |
-| `updateEntity({ entity })` | Create or replace entity (auto-indexes, auto-timestamps) |
+| `updateEntity({ entity, condition?, names?, values? })` | Create or replace entity (auto-indexes, auto-timestamps). Optional `condition` (a ConditionExpression with `names`/`values` bindings) guards the write; throws `ConflictError` (409) and leaves the item unchanged when the condition fails |
+| `transitionEntity({ id, from?, set })` | Conditionally update by status: reads the entity, merges `set`, writes guarded by `#status = from`; throws `ConflictError` (409) on a race and `NotFoundError` (404) when absent. Validates `from`/`set.status` against the model's `status` vocabulary |
 | `deleteEntity({ id })` | Soft delete (sets `deletedAt`, re-indexes with `#deleted` suffix) |
 | `archiveEntity({ id })` | Archive (sets `archivedAt`, re-indexes with `#archived` suffix) |
 | `destroyEntity({ id })` | Hard delete (permanently removes) |

--- a/packages/dynamodb/package.json
+++ b/packages/dynamodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/dynamodb",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"

--- a/packages/dynamodb/src/__tests__/entities.spec.ts
+++ b/packages/dynamodb/src/__tests__/entities.spec.ts
@@ -16,6 +16,7 @@ import {
   destroyEntity,
   getEntity,
   createEntity,
+  transitionEntity,
   updateEntity,
 } from "../entities.js";
 import type { StorableEntity } from "../types.js";
@@ -31,6 +32,11 @@ beforeAll(() => {
       fabricIndex("type"),
       fabricIndex("xid"),
     ],
+  });
+  registerModel({
+    model: "job",
+    indexes: [fabricIndex()],
+    status: ["running", "complete", "error", "canceled", "expired"],
   });
 });
 
@@ -221,6 +227,138 @@ describe("Entity Operations", () => {
         expiresAt?: unknown;
       };
       expect(result.expiresAt).toBe(expiresAt.toISOString());
+    });
+
+    it("emits no ConditionExpression by default", async () => {
+      await updateEntity({ entity: createTestEntity() });
+      const command = mockSend.mock.calls[0][0];
+      expect(command.input.ConditionExpression).toBeUndefined();
+    });
+
+    it("passes condition, names, and values through to the Put", async () => {
+      await updateEntity({
+        condition: "#status = :from",
+        entity: createTestEntity(),
+        names: { "#status": "status" },
+        values: { ":from": "running" },
+      });
+      const command = mockSend.mock.calls[0][0];
+      expect(command.input.ConditionExpression).toBe("#status = :from");
+      expect(command.input.ExpressionAttributeNames).toEqual({
+        "#status": "status",
+      });
+      expect(command.input.ExpressionAttributeValues).toEqual({
+        ":from": "running",
+      });
+    });
+
+    it("throws a ConflictError when the condition fails", async () => {
+      mockSend.mockRejectedValue(
+        Object.assign(new Error("The conditional request failed"), {
+          name: "ConditionalCheckFailedException",
+        }),
+      );
+      await expect(
+        updateEntity({
+          condition: "attribute_exists(id)",
+          entity: createTestEntity(),
+        }),
+      ).rejects.toMatchObject({ isJaypieError: true, status: 409 });
+    });
+
+    it("propagates errors that are not conditional-check failures", async () => {
+      mockSend.mockRejectedValue(new Error("Throughput exceeded"));
+      await expect(
+        updateEntity({
+          condition: "attribute_exists(id)",
+          entity: createTestEntity(),
+        }),
+      ).rejects.toThrow("Throughput exceeded");
+    });
+  });
+
+  describe("transitionEntity", () => {
+    const runningJob = (): StorableEntity =>
+      ({
+        id: "job-1",
+        model: "job",
+        scope: "@",
+        status: "running",
+      }) as StorableEntity;
+
+    it("guards the write on the current status and merges set", async () => {
+      mockSend.mockResolvedValue({ Item: runningJob() });
+
+      await transitionEntity({
+        from: "running",
+        id: "job-1",
+        set: { status: "complete" },
+      });
+
+      // First send is the GetCommand, second is the conditional PutCommand
+      const put = mockSend.mock.calls[1][0];
+      expect(put.input.ConditionExpression).toBe(
+        "attribute_exists(id) AND #status = :from",
+      );
+      expect(put.input.ExpressionAttributeNames).toEqual({
+        "#status": "status",
+      });
+      expect(put.input.ExpressionAttributeValues).toEqual({
+        ":from": "running",
+      });
+      expect(put.input.Item.status).toBe("complete");
+    });
+
+    it("guards only existence when from is omitted", async () => {
+      mockSend.mockResolvedValue({ Item: runningJob() });
+
+      await transitionEntity({ id: "job-1", set: { status: "complete" } });
+
+      const put = mockSend.mock.calls[1][0];
+      expect(put.input.ConditionExpression).toBe("attribute_exists(id)");
+      expect(put.input.ExpressionAttributeNames).toBeUndefined();
+    });
+
+    it("throws NotFoundError when the entity does not exist", async () => {
+      mockSend.mockResolvedValue({});
+
+      await expect(
+        transitionEntity({
+          from: "running",
+          id: "missing",
+          set: { status: "complete" },
+        }),
+      ).rejects.toMatchObject({ isJaypieError: true, status: 404 });
+    });
+
+    it("throws ConflictError when another writer moved the status", async () => {
+      mockSend
+        .mockResolvedValueOnce({ Item: runningJob() })
+        .mockRejectedValueOnce(
+          Object.assign(new Error("The conditional request failed"), {
+            name: "ConditionalCheckFailedException",
+          }),
+        );
+
+      await expect(
+        transitionEntity({
+          from: "running",
+          id: "job-1",
+          set: { status: "complete" },
+        }),
+      ).rejects.toMatchObject({ isJaypieError: true, status: 409 });
+    });
+
+    it("rejects a status outside the model vocabulary", async () => {
+      mockSend.mockResolvedValue({ Item: runningJob() });
+
+      await expect(
+        transitionEntity({
+          from: "running",
+          id: "job-1",
+          set: { status: "banana" },
+        }),
+      ).rejects.toMatchObject({ isJaypieError: true, status: 400 });
     });
   });
 

--- a/packages/dynamodb/src/__tests__/index.spec.ts
+++ b/packages/dynamodb/src/__tests__/index.spec.ts
@@ -59,6 +59,10 @@ describe("@jaypie/dynamodb exports", () => {
     it("exports destroyEntity", () => {
       expect(dynamodb.destroyEntity).toBeFunction();
     });
+
+    it("exports transitionEntity", () => {
+      expect(dynamodb.transitionEntity).toBeFunction();
+    });
   });
 
   describe("Client Functions", () => {

--- a/packages/dynamodb/src/__tests__/scan.spec.ts
+++ b/packages/dynamodb/src/__tests__/scan.spec.ts
@@ -51,7 +51,7 @@ describe("Scan Utilities", () => {
 
     it("defaults to the initialized table name", async () => {
       send.mockResolvedValueOnce({ Items: [] });
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
       for await (const _ of scanTable()) {
         // drain
       }
@@ -61,7 +61,7 @@ describe("Scan Utilities", () => {
 
     it("scans an explicit table name", async () => {
       send.mockResolvedValueOnce({ Items: [] });
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
       for await (const _ of scanTable({ tableName: "old-table" })) {
         // drain
       }

--- a/packages/dynamodb/src/entities.ts
+++ b/packages/dynamodb/src/entities.ts
@@ -4,8 +4,8 @@ import {
   PutCommand,
   TransactWriteCommand,
 } from "@aws-sdk/lib-dynamodb";
-import { ConflictError } from "@jaypie/errors";
-import { fabricService } from "@jaypie/fabric";
+import { ConflictError, NotFoundError } from "@jaypie/errors";
+import { assertModelStatus, fabricService } from "@jaypie/fabric";
 
 import { getDocClient, getTableName } from "./client.js";
 import { ARCHIVED_SUFFIX, DELETED_SUFFIX } from "./constants.js";
@@ -94,11 +94,24 @@ export async function createEntity({
 /**
  * Update an existing entity.
  * `indexEntity` auto-bumps `updatedAt` — callers never set it manually.
+ *
+ * Pass `condition` to guard the write with a DynamoDB ConditionExpression
+ * (mirroring `transactWriteEntities`), supplying `names`/`values` for any
+ * `#name`/`:value` placeholders. When the condition fails the item is left
+ * unchanged and a `ConflictError` (409) is thrown, giving write-time
+ * enforcement of read-check-then-write invariants. Without `condition` the
+ * write is an unconditional overwrite (last write wins).
  */
 export async function updateEntity({
+  condition,
   entity,
+  names,
+  values,
 }: {
+  condition?: string;
   entity: StorableEntity;
+  names?: Record<string, string>;
+  values?: Record<string, unknown>;
 }): Promise<StorableEntity> {
   const docClient = getDocClient();
   const tableName = getTableName();
@@ -108,11 +121,106 @@ export async function updateEntity({
   const command = new PutCommand({
     Item: updatedEntity,
     TableName: tableName,
+    ...(condition
+      ? {
+          ConditionExpression: condition,
+          ...(names ? { ExpressionAttributeNames: names } : {}),
+          ...(values ? { ExpressionAttributeValues: values } : {}),
+        }
+      : {}),
   });
 
-  await docClient.send(command);
+  try {
+    await docClient.send(command);
+  } catch (error) {
+    if (
+      (error as { name?: string })?.name === "ConditionalCheckFailedException"
+    ) {
+      throw new ConflictError(
+        "The conditional update was rejected because the persisted state no longer matches the condition",
+      );
+    }
+    throw error;
+  }
   return updatedEntity;
 }
+
+const STATUS_FIELD = "status";
+
+/**
+ * Conditionally transition an entity's status, failing closed on a race.
+ *
+ * Reads the entity, merges `set`, and writes it back guarded by a
+ * ConditionExpression so the write commits only when the persisted `status`
+ * still equals `from`. If another writer moved the status inside the window the
+ * write is rejected and a `ConflictError` (409) is thrown, leaving the item
+ * unchanged — write-time enforcement of sticky lifecycle terminals and other
+ * status invariants. Omit `from` to guard only that the entity still exists.
+ *
+ * `from` and any `set.status` are validated against the model's registered
+ * `status` vocabulary (a no-op for free-string models). Throws `NotFoundError`
+ * (404) when the entity does not exist.
+ */
+export const transitionEntity = fabricService({
+  alias: "transitionEntity",
+  description:
+    "Conditionally update an entity only when its persisted status matches `from`, throwing ConflictError on a race",
+  input: {
+    id: {
+      type: String,
+      required: true,
+      description: "Entity id (partition key)",
+    },
+    from: {
+      type: String,
+      required: false,
+      description:
+        "Expected current status; the write is rejected if the persisted status differs",
+    },
+    set: {
+      type: Object,
+      required: true,
+      description: "Fields to merge into the entity (typically the new status)",
+    },
+  },
+  service: async ({
+    from,
+    id,
+    set,
+  }: {
+    from?: string;
+    id: string;
+    set: Record<string, unknown>;
+  }): Promise<StorableEntity> => {
+    const existing = await getEntity({ id });
+    if (!existing) {
+      throw new NotFoundError(`Entity ${id} not found`);
+    }
+
+    if (from !== undefined) {
+      assertModelStatus(existing.model, from);
+    }
+    if (typeof set[STATUS_FIELD] === "string") {
+      assertModelStatus(existing.model, set[STATUS_FIELD]);
+    }
+
+    const merged = { ...existing, ...set, id: existing.id } as StorableEntity;
+
+    if (from === undefined) {
+      return updateEntity({
+        condition: "attribute_exists(id)",
+        entity: merged,
+      });
+    }
+
+    return updateEntity({
+      condition: "attribute_exists(id) AND #status = :from",
+      entity: merged,
+      names: { "#status": STATUS_FIELD },
+      values: { ":from": from },
+    });
+  },
+});
 
 /**
  * Soft delete an entity by setting deletedAt timestamp

--- a/packages/dynamodb/src/index.ts
+++ b/packages/dynamodb/src/index.ts
@@ -24,6 +24,7 @@ export {
   destroyEntity,
   getEntity,
   transactWriteEntities,
+  transitionEntity,
   updateEntity,
 } from "./entities.js";
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.96",
+  "version": "0.8.97",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/dynamodb/0.6.6.md
+++ b/packages/mcp/release-notes/dynamodb/0.6.6.md
@@ -1,0 +1,47 @@
+---
+version: 0.6.6
+date: 2026-07-10
+summary: Conditional updateEntity plus transitionEntity for write-time status guards; ConflictError (409) on a failed condition
+---
+
+## Added
+
+- **Conditional `updateEntity`**. `updateEntity` gained optional `condition`
+  (a DynamoDB `ConditionExpression`) plus `names`/`values` bindings, mirroring
+  `transactWriteEntities` for the single-item case. When the condition fails the
+  item is left unchanged and a `ConflictError` (409, from `@jaypie/errors`) is
+  thrown. Without `condition` the write remains an unconditional overwrite —
+  fully additive.
+
+  ```ts
+  await updateEntity({
+    entity: { ...job, status: "complete" },
+    condition: "#status = :from",
+    names: { "#status": "status" },
+    values: { ":from": "running" },
+  });
+  ```
+
+- **`transitionEntity({ id, from?, set })`**. A purpose-built guardrail for
+  status transitions and the ergonomic surface most consumers want. Reads the
+  entity, merges `set`, and writes it back guarded by `#status = from`, so the
+  write commits only when the persisted status still matches. A concurrent
+  writer racing inside the read→put window fails closed with `ConflictError`
+  (409) — write-time enforcement of sticky lifecycle terminals. Throws
+  `NotFoundError` (404) when the entity does not exist. `from` and any
+  `set.status` are validated against the model's registered `status` vocabulary
+  (a no-op for free-string models). Omit `from` to guard only that the entity
+  still exists.
+
+  ```ts
+  await transitionEntity({
+    id: runId,
+    from: "running",
+    set: { status: "complete" },
+  });
+  ```
+
+  For predicates beyond single-value `from` equality (e.g. "any non-terminal
+  status"), use `updateEntity({ condition })` with your own ConditionExpression.
+
+Issue: [#417](https://github.com/finlaysonstudio/jaypie/issues/417)

--- a/packages/mcp/release-notes/mcp/0.8.97.md
+++ b/packages/mcp/release-notes/mcp/0.8.97.md
@@ -1,0 +1,31 @@
+---
+version: 0.8.97
+date: 2026-07-10
+summary: skill("dynamodb") conditional-writes section extended to updateEntity and transitionEntity; skill("vocabulary") loosens the severity/status stance; new skill("ports")
+---
+
+## Added
+
+- **`skill("ports")`** documents the per-project local port numbering
+  convention: a random two-digit identifier `NN` with role prefixes (`30NN`
+  marketing web, `31NN` app, `80NN` api, `90NN` dynamo, `91NN` dynamo admin),
+  so concurrent projects do not collide locally.
+
+## Changed
+
+- **`skill("dynamodb")`** conditional-writes section reworked from create/transact
+  to cover the full ladder: `createEntity`, `updateEntity({ condition })`,
+  `transitionEntity({ from })`, and `transactWriteEntities`. Adds the
+  sticky-terminal status transition as the worked example and documents the new
+  `@jaypie/dynamodb` 0.6.6 entity-operation signatures.
+- **`skill("vocabulary")`** loosens the log severity stance. The prior wording
+  said log levels are severity, "never `status`." It now keeps the *conceptual*
+  distinction (severity is an emission property; a lifecycle `status` is a
+  position in a model's declared vocabulary) while allowing the *word* `status`
+  for severity — Datadog reserves the field name `status` for log severity and
+  cannot be reconfigured, so serialized logs legitimately emit severity as
+  `status` (`LOG_LEVEL_FIELD=status`). This reconciles the skill with `logs`,
+  `logger/CLAUDE.md`, and the documentation site, which already treat `status`
+  as a valid level field.
+
+Supports [#417](https://github.com/finlaysonstudio/jaypie/issues/417).

--- a/packages/mcp/release-notes/testkit/1.2.54.md
+++ b/packages/mcp/release-notes/testkit/1.2.54.md
@@ -1,0 +1,18 @@
+---
+version: 1.2.54
+date: 2026-07-10
+summary: Mock updateEntity accepts condition/names/values and adds transitionEntity mock
+---
+
+## Changed
+
+- **`updateEntity` mock** now accepts the optional `condition`/`names`/`values`
+  params added in `@jaypie/dynamodb` 0.6.6, matching the new signature.
+
+## Added
+
+- **`transitionEntity` mock**. Defaults to a successful transition returning the
+  merged entity. Simulate a conditional-check failure by overriding:
+  `vi.mocked(transitionEntity).mockRejectedValueOnce(new ConflictError())`.
+
+Supports [#417](https://github.com/finlaysonstudio/jaypie/issues/417).

--- a/packages/mcp/skills/agents.md
+++ b/packages/mcp/skills/agents.md
@@ -34,7 +34,7 @@ Complete stack styles, techniques, and traditions.
 
 Contents: index, releasenotes
 Development: apikey, documentation, errors, llm, logs, mocks, monorepo, repokit, style, subpackages, tests, tools
-Infrastructure: apigateway, aws, cdk, cicd, datadog, dns, dynamodb, express, lambda, migrations, secrets, sqs, streaming, variables, waf, web, websockets
+Infrastructure: apigateway, aws, cdk, cicd, datadog, dns, dynamodb, express, lambda, migrations, ports, secrets, sqs, streaming, variables, waf, web, websockets
 Patterns: api, fabric, handlers, models, services, vocabulary
 Recipes: recipe-api-server
 Meta: issues, jaypie, mcp, skills

--- a/packages/mcp/skills/dynamodb.md
+++ b/packages/mcp/skills/dynamodb.md
@@ -157,6 +157,17 @@ const item = await getEntity({ id: "abc-123" });
 // Update — sets updatedAt, re-indexes
 await updateEntity({ entity: { ...item, name: "Updated Name" } });
 
+// Conditional update — write-time guard; throws ConflictError if it fails
+await updateEntity({
+  entity: { ...item, status: "complete" },
+  condition: "#status = :from",
+  names: { "#status": "status" },
+  values: { ":from": "running" },
+});
+
+// Status transition — reads, guards on `from`, writes; ConflictError on a race
+await transitionEntity({ id: "abc-123", from: "running", set: { status: "complete" } });
+
 // Soft delete — sets deletedAt, re-indexes with #deleted suffix on pk
 await deleteEntity({ id: "abc-123" });
 
@@ -171,17 +182,27 @@ await destroyEntity({ id: "abc-123" });
 |----------|-------------|
 | `createEntity({ entity })` | Create entity; returns `null` if `id` exists (conditional `attribute_not_exists(id)`) |
 | `getEntity({ id })` | Get by primary key (id only) |
-| `updateEntity({ entity })` | Update (sets `updatedAt`, re-indexes) |
+| `updateEntity({ entity, condition?, names?, values? })` | Update (sets `updatedAt`, re-indexes). Pass `condition` (a ConditionExpression, with `names`/`values` bindings) to guard the write; throws `ConflictError` (409) and leaves the item unchanged when the condition fails |
+| `transitionEntity({ id, from?, set })` | Conditionally update by status: reads the entity, merges `set`, writes guarded by `#status = from`; throws `ConflictError` (409) on a race, `NotFoundError` (404) when absent. Validates `from`/`set.status` against the model's `status` vocabulary |
 | `deleteEntity({ id })` | Soft delete (`deletedAt`, `#deleted` suffix on GSI pk) |
 | `archiveEntity({ id })` | Archive (`archivedAt`, `#archived` suffix on GSI pk) |
 | `destroyEntity({ id })` | Hard delete (permanent) |
 | `transactWriteEntities({ entities, conditionalCreate?, condition? })` | Write many entities atomically; `conditionalCreate: true` guards every `Put` with `attribute_not_exists(id)` (`condition` for a custom expression), throwing `ConflictError` (409) when a conditional check fails |
 
-### Atomic Conditional Writes
+### Conditional Writes
 
-Use `conditionalCreate` to write an entity **and** a uniqueness-sentinel row in a single transaction -- both commit or neither does:
+Conditional writes enforce read-check-then-write invariants **at write time**, closing the race a read-then-put opens. Three surfaces, in ascending ergonomics:
+
+- `createEntity` — `attribute_not_exists(id)` (returns `null` on conflict).
+- `updateEntity({ condition })` — the general single-item primitive.
+- `transitionEntity({ from })` — the status-transition guardrail.
+- `transactWriteEntities({ conditionalCreate | condition })` — the multi-item case.
 
 `ConflictError` is thrown from `@jaypie/errors` (re-exported by the `jaypie` umbrella); `@jaypie/dynamodb` does not re-export it.
+
+#### Atomic multi-item create
+
+Use `conditionalCreate` to write an entity **and** a uniqueness-sentinel row in a single transaction -- both commit or neither does:
 
 ```typescript
 import { ConflictError } from "jaypie"; // or "@jaypie/errors"
@@ -199,6 +220,32 @@ try {
   throw error;
 }
 ```
+
+#### Sticky-terminal status transition
+
+Terminal statuses (`complete`/`error`/`canceled`/`expired`) must be sticky: once terminal, no later transition may move the run. `transitionEntity` enforces that at write time -- the write commits only when the persisted status still equals `from`, so a concurrent resume/complete/cancel racing inside the read→put window fails closed:
+
+```typescript
+import { ConflictError } from "jaypie";
+import { transitionEntity } from "@jaypie/dynamodb";
+
+try {
+  // Resume commits only if the run is still "running"; if another writer
+  // already moved it to "canceled", this throws ConflictError, no write.
+  await transitionEntity({
+    id: runId,
+    from: "running",
+    set: { status: "complete", completedAt: new Date().toISOString() },
+  });
+} catch (error) {
+  if (error instanceof ConflictError) {
+    // the run left "running" underneath us -- terminal is sticky, drop the write
+  }
+  throw error;
+}
+```
+
+`from`/`set.status` are validated against the model's registered `status` vocabulary (see `skill("vocabulary")`); a value outside it throws `BadRequestError`. For predicates beyond a single-value `from` equality (e.g. "any non-terminal status"), reach for `updateEntity({ condition })` with your own ConditionExpression.
 
 ### Scope and Hierarchy
 

--- a/packages/mcp/skills/ports.md
+++ b/packages/mcp/skills/ports.md
@@ -1,0 +1,48 @@
+---
+description: Local development port numbering convention
+related: cors, dynamodb, variables
+---
+
+# Ports
+
+A per-project port numbering scheme so multiple Jaypie projects run locally at
+once without colliding inside Docker or on the host.
+
+## Identifier
+
+Pick a random two-digit project identifier `NN` (`00`–`99`). It should be unused
+by any other project running locally. Have the operator confirm or pick `NN` —
+do not assume one.
+
+Every local port is four digits: a role prefix followed by `NN`.
+
+## Map
+
+| Port    | Role                                  |
+|---------|---------------------------------------|
+| `30NN`  | primary marketing web                 |
+| `31NN`  | the app                               |
+| `3XNN`  | additional frontends as needed (docs) |
+| `80NN`  | api                                   |
+| `8XNN`  | additional apis as needed             |
+| `90NN`  | dynamo                                |
+| `91NN`  | dynamo admin                          |
+
+Example, `NN=60`: marketing `3060`, app `3160`, api `8060`, dynamo `9060`,
+dynamo admin `9160`.
+
+## Logic
+
+- `30` derives from `3000`, the conventional frontend dev port
+- `80` derives from `80`/`8080`, the conventional backend port
+- `90` because `80` is already taken by the api tier
+- Fixing the role prefix and varying only `NN` per project keeps concurrent
+  projects from colliding
+
+## See Also
+
+- **`skill("dynamodb")`** — local DynamoDB via docker-compose; point `endpoint`
+  at `90NN` (admin at `91NN`)
+- **`skill("cors")`** — `cors()` auto-allows `localhost:*` in sandbox, so the
+  frontend port is accepted without extra config
+- **`skill("variables")`** — environment variables reference

--- a/packages/mcp/skills/skills.md
+++ b/packages/mcp/skills/skills.md
@@ -17,7 +17,7 @@ Look up skills by alias: `mcp__jaypie__skill(alias)`
 |----------|--------|
 | contents | index, releasenotes |
 | development | apikey, documentation, errors, llm, logs, mocks, monorepo, repokit, style, subpackages, tests, tools |
-| infrastructure | apigateway, aws, cdk, cicd, datadog, dns, dynamodb, express, lambda, migrations, secrets, sqs, streaming, variables, waf, web, websockets |
+| infrastructure | apigateway, aws, cdk, cicd, datadog, dns, dynamodb, express, lambda, migrations, ports, secrets, sqs, streaming, variables, waf, web, websockets |
 | patterns | api, fabric, handlers, models, services, vocabulary |
 | recipes | recipe-api-server |
 | meta | issues, jaypie, mcp, skills |

--- a/packages/mcp/skills/vocabulary.md
+++ b/packages/mcp/skills/vocabulary.md
@@ -44,7 +44,7 @@ Arguably identity, instance, and relation would form a more complete vocabulary.
 - image: tbd, likely urls and references
 - input: request parameters
 - label: shortened, accepted version of name
-- level: severity of a log emission (trace, debug, info, warn, error, fatal); a property of an emission, never a lifecycle `status`
+- level: severity of a log emission (trace, debug, info, warn, error, fatal); a property of an emission, distinct from a lifecycle `status` though Datadog serializes it under the `status` field (see logs skill)
 - links: usually http references
 - message/s: string/s or message object/s
 - metadata: usually immutable, what the entity is
@@ -176,7 +176,7 @@ SEPARATOR = "#";
 
 ## Additional Terminology
 
-The six log levels are **severity**, never `status`. Severity is a property of an emission; `status` is a position in a lifecycle. Because `error` appears in both vocabularies the collision is easy to make — reserve `level` (see Attribute Definitions) for severity and keep it distinct from `status`.
+The six log levels are **severity**. Severity is a property of an emission; a lifecycle `status` is a position in a model's declared vocabulary. They are distinct concepts that share the word `error`, so keep them straight — but the *word* `status` is not off-limits for severity. Jaypie names the property `level`; Datadog reserves the field name `status` for log severity and cannot be reconfigured, so serialized logs legitimately emit severity as `status` (`LOG_LEVEL_FIELD=status`, see logs skill). Reserve the caution for the concepts, not the term.
 
 - debug: logging, operating checkpoint or abnormal condition
 - error: logging, detected an unrecoverable state and exiting (caught error)

--- a/packages/testkit/package.json
+++ b/packages/testkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/testkit",
-  "version": "1.2.53",
+  "version": "1.2.54",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"

--- a/packages/testkit/src/mock/dynamodb.ts
+++ b/packages/testkit/src/mock/dynamodb.ts
@@ -79,9 +79,24 @@ export const createEntity = createMockFunction<
 );
 
 export const updateEntity = createMockFunction<
-  (params: { entity: StorableEntity }) => Promise<StorableEntity>
->(async (params: { entity: StorableEntity }) =>
-  original.indexEntity(params.entity),
+  (params: {
+    condition?: string;
+    entity: StorableEntity;
+    names?: Record<string, string>;
+    values?: Record<string, unknown>;
+  }) => Promise<StorableEntity>
+>(async (params) => original.indexEntity(params.entity));
+
+// Defaults to a successful transition. Simulate a conditional-check failure by
+// overriding: `vi.mocked(transitionEntity).mockRejectedValueOnce(new ConflictError())`.
+export const transitionEntity = createMockFunction<
+  (params: {
+    from?: string;
+    id: string;
+    set: Record<string, unknown>;
+  }) => Promise<StorableEntity>
+>(async ({ id, set }) =>
+  original.indexEntity({ id, ...set } as StorableEntity),
 );
 
 export const deleteEntity = createMockFunction<


### PR DESCRIPTION
## Summary

- **`@jaypie/dynamodb` 0.6.6** — conditional `updateEntity({ condition, names, values })` and a purpose-built `transitionEntity({ id, from?, set })` for write-time status guards. Failed condition → `ConflictError` (409); missing entity → `NotFoundError` (404); `from`/`set.status` validated against the model's status vocabulary.
- **`@jaypie/testkit` 1.2.54** — mocks updated for the new `updateEntity` signature and a `transitionEntity` mock.
- **`@jaypie/mcp` 0.8.97** — `skill("dynamodb")` conditional-writes section extended; `skill("vocabulary")` loosens the severity/status stance (keeps the concept distinction, allows `status` as the log-severity field name since Datadog reserves it); new `skill("ports")` documenting the per-project local port numbering convention.

## Testing

- Full root test suite: 3713 passed, 0 failed
- typecheck + build clean across affected packages
- NPM Check: green

Closes #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)