### PR TITLE
fix(dynamodb): floor @jaypie/fabric at ^0.3.4 for assertModelStatus

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15008,12 +15008,12 @@
     },
     "packages/dynamodb": {
       "name": "@jaypie/dynamodb",
-      "version": "0.6.6",
+      "version": "0.6.7",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.726.1",
         "@aws-sdk/lib-dynamodb": "^3.726.1",
-        "@jaypie/fabric": "*"
+        "@jaypie/fabric": "^0.3.4"
       },
       "devDependencies": {
         "@rollup/plugin-typescript": "^12.1.2",
@@ -15503,7 +15503,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.97",
+      "version": "0.8.98",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.3.3",

--- a/packages/dynamodb/package.json
+++ b/packages/dynamodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/dynamodb",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"
@@ -49,7 +49,7 @@
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.726.1",
     "@aws-sdk/lib-dynamodb": "^3.726.1",
-    "@jaypie/fabric": "*"
+    "@jaypie/fabric": "^0.3.4"
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^12.1.2",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.97",
+  "version": "0.8.98",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/dynamodb/0.6.7.md
+++ b/packages/mcp/release-notes/dynamodb/0.6.7.md
@@ -1,0 +1,20 @@
+---
+version: 0.6.7
+date: 2026-07-11
+summary: floor @jaypie/fabric at ^0.3.4 so assertModelStatus resolves at install time
+---
+
+## Changes
+
+- Declare `"@jaypie/fabric": "^0.3.4"` (was `"*"`). The runtime imports
+  `assertModelStatus` (added in fabric 0.3.4) for `transitionEntity`, so an
+  unbounded `"*"` let a resolver pick fabric <0.3.4 and fail at module load with
+  `SyntaxError: The requested module '@jaypie/fabric' does not provide an export
+  named 'assertModelStatus'`. `getModelStatus` / `isModelStatus` (same 0.3.4
+  release) shared the exposure.
+
+## Migration
+
+- None. The floor is satisfied by any current install. External consumers on an
+  older hoisted fabric now get a clear install-time resolution error instead of
+  a runtime load failure. Fixes #420.

--- a/packages/mcp/release-notes/mcp/0.8.98.md
+++ b/packages/mcp/release-notes/mcp/0.8.98.md
@@ -1,0 +1,9 @@
+---
+version: 0.8.98
+date: 2026-07-11
+summary: ship the @jaypie/dynamodb 0.6.7 release note
+---
+
+## Changes
+
+- Bundle the `@jaypie/dynamodb` 0.6.7 release note (fabric floored at `^0.3.4`).


### PR DESCRIPTION
## Summary

`@jaypie/dynamodb@0.6.6` imports `assertModelStatus` from `@jaypie/fabric` (added in fabric `0.3.4`, used by `transitionEntity`) but declared the dependency as `"*"`. An unbounded range let a resolver hoist fabric `<0.3.4`, failing at ESM load:

```
SyntaxError: The requested module '@jaypie/fabric' does not provide an export named 'assertModelStatus'
```

`getModelStatus` / `isModelStatus` (same 0.3.4 release) shared the exposure.

## Changes

- `@jaypie/dynamodb` dependency `@jaypie/fabric` `"*"` → `"^0.3.4"`; version `0.6.6` → `0.6.7`
- `@jaypie/mcp` `0.8.97` → `0.8.98` to ship the release note
- Release notes for both

The floor makes the resolver reject an incompatible fabric at install time instead of failing at runtime. Metadata-only; no code changed.

Fixes #420.

🤖 Generated with [Claude Code](https://claude.com/claude-code)