### PR TITLE
feat(llm): add Fireworks AI provider

### DIFF
--- a/.github/workflows/npm-check.yml
+++ b/.github/workflows/npm-check.yml
@@ -124,6 +124,8 @@ jobs:
             providers: "openai"
           - group: gemini-xai
             providers: "google,xai"
+          - group: fireworks
+            providers: "fireworks"
           - group: openrouter
             providers: "openrouter"
           - group: bedrock
@@ -176,6 +178,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.CICD_ANTHROPIC_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.CICD_GEMINI_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.CICD_OPENAI_API_KEY }}
+          FIREWORKS_API_KEY: ${{ secrets.CICD_FIREWORKS_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.CICD_OPENROUTER_API_KEY }}
           XAI_API_KEY: ${{ secrets.CICD_XAI_API_KEY }}
 

--- a/.github/workflows/npm-deploy.yml
+++ b/.github/workflows/npm-deploy.yml
@@ -197,6 +197,8 @@ jobs:
             providers: "openai"
           - group: gemini-xai
             providers: "google,xai"
+          - group: fireworks
+            providers: "fireworks"
           - group: openrouter
             providers: "openrouter"
           - group: bedrock
@@ -244,5 +246,6 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.CICD_ANTHROPIC_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.CICD_GEMINI_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.CICD_OPENAI_API_KEY }}
+          FIREWORKS_API_KEY: ${{ secrets.CICD_FIREWORKS_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.CICD_OPENROUTER_API_KEY }}
           XAI_API_KEY: ${{ secrets.CICD_XAI_API_KEY }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15264,7 +15264,7 @@
       "license": "MIT"
     },
     "packages/jaypie": {
-      "version": "1.2.63",
+      "version": "1.2.64",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "^1.2.10",
@@ -15289,7 +15289,7 @@
         "typescript-eslint": "^8.46.1"
       },
       "peerDependencies": {
-        "@jaypie/llm": "^1.3.9"
+        "@jaypie/llm": "^1.3.12"
       },
       "peerDependenciesMeta": {
         "@jaypie/llm": {
@@ -15421,7 +15421,7 @@
     },
     "packages/llm": {
       "name": "@jaypie/llm",
-      "version": "1.3.11",
+      "version": "1.3.12",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "*",
@@ -15503,7 +15503,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.99",
+      "version": "0.8.100",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.3.3",
@@ -15583,7 +15583,7 @@
     },
     "packages/testkit": {
       "name": "@jaypie/testkit",
-      "version": "1.2.55",
+      "version": "1.2.56",
       "license": "MIT",
       "dependencies": {
         "jest-json-schema": "^6.1.0",

--- a/packages/jaypie/package.json
+++ b/packages/jaypie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jaypie",
-  "version": "1.2.63",
+  "version": "1.2.64",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"
@@ -59,7 +59,7 @@
     "typescript-eslint": "^8.46.1"
   },
   "peerDependencies": {
-    "@jaypie/llm": "^1.3.9"
+    "@jaypie/llm": "^1.3.12"
   },
   "peerDependenciesMeta": {
     "@jaypie/llm": {

--- a/packages/llm/CLAUDE.md
+++ b/packages/llm/CLAUDE.md
@@ -20,6 +20,7 @@ src/
 │   │   ├── AnthropicAdapter.ts
 │   │   ├── GoogleAdapter.ts
 │   │   ├── OpenAiAdapter.ts
+│   │   ├── FireworksAdapter.ts
 │   │   ├── OpenRouterAdapter.ts
 │   │   ├── XaiAdapter.ts
 │   │   └── ProviderAdapter.interface.ts
@@ -43,6 +44,9 @@ src/
 │   │   └── utils.ts
 │   ├── openai/
 │   │   ├── OpenAiProvider.class.ts
+│   │   └── utils.ts
+│   ├── fireworks/
+│   │   ├── FireworksProvider.class.ts
 │   │   └── utils.ts
 │   ├── openrouter/
 │   │   ├── OpenRouterProvider.class.ts
@@ -118,7 +122,8 @@ five-point relative scale (only the anchored `medium` borrows a provider word).
 Each adapter's `buildRequest` translates it to the provider's native knob via
 `src/util/effort.ts` (OpenAI/Grok `reasoning.effort`, Anthropic
 `output_config.effort`, Gemini 3 `thinkingLevel`, Gemini 2.5 `thinkingBudget`,
-OpenRouter `reasoning.effort`), spreading the scale across the provider's range.
+OpenRouter `reasoning.effort`, Fireworks `reasoning_effort`), spreading the
+scale across the provider's range.
 It is threaded through `OperateRequest` by both loops and is gated per provider
 so unsupported models silently ignore it. Omitting `effort` leaves the provider
 default untouched, so it is safe across a fallback chain. Bedrock is not yet
@@ -462,6 +467,11 @@ HTTP errors shaped to drive `classifyError`):
 - xAI — reuses `OpenAIClient` with `PROVIDER.XAI.BASE_URL` (OpenAI-compatible)
 - Anthropic — `AnthropicClient` (Messages API)
 - Google — `GoogleClient` (Gemini REST)
+- Fireworks — `FireworksClient` (OpenAI-compatible Chat Completions). Images
+  are `image_url` parts (vision models only; non-vision models 4xx). File/PDF
+  inputs are warned and discarded — Fireworks has no `file` part and rejects
+  document `data:` URIs ("Unsupported URL scheme 'data'"; Document Inlining's
+  `#transform=inline` did not engage in live testing 2026-07-19)
 - OpenRouter — `OpenRouterClient` (OpenAI-compatible Chat Completions)
 
 Bedrock is the one provider that keeps an SDK: `@aws-sdk/client-bedrock-runtime`
@@ -478,6 +488,7 @@ when the matching `*_API_KEY` is set and skip otherwise.
 - `OPENAI_API_KEY` - OpenAI API key
 - `ANTHROPIC_API_KEY` - Anthropic API key
 - `GOOGLE_API_KEY` - Google API key
+- `FIREWORKS_API_KEY` - Fireworks API key
 - `OPENROUTER_API_KEY` - OpenRouter API key
 - `XAI_API_KEY` - xAI (Grok) API key
 
@@ -552,7 +563,7 @@ export { JaypieToolkit, toolkit, Toolkit, tools };
 export { extractReasoning, jsonSchemaToNaturalSchema, naturalSchemaToJsonSchema };
 
 // Providers (for direct use)
-export { GoogleProvider, OpenRouterProvider, XaiProvider };
+export { FireworksProvider, GoogleProvider, OpenRouterProvider, XaiProvider };
 // GeminiProvider remains as a deprecated alias of GoogleProvider
 ```
 

--- a/packages/llm/CLAUDE.md
+++ b/packages/llm/CLAUDE.md
@@ -294,6 +294,11 @@ const response = await Llm.operate("Greet the world", {
 - `stop_reason: "refusal"` and `stop_reason: "max_tokens"` are surfaced as text rather than parsed JSON. `provider.send(..., { response })` throws on these; `operate()` surfaces them via `response.content` as a string.
 - A model that rejects `output_config` is cached for the session and transparently retried via the legacy fake-tool emulation. Citations + structured output (a 400 documented as incompatible) and `output_format`-deprecation 400s are **not** retried — those errors propagate so callers can see the real cause.
 
+**Fireworks notes:**
+- Uses the OpenAI-style native `response_format: { type: "json_schema", ... }` for format-only requests.
+- Format **and** tools combined is rejected by the API ("You cannot specify response format and function call at the same time"), so those requests preemptively use the `structured_output` fake-tool emulation (logged at warn) — same approach as Gemini 2.5.
+- A model that 400/422s on `response_format` alone is cached for the session and retried via the emulation path.
+
 **OpenRouter notes:**
 - Uses the OpenAI-style native `response_format: { type: "json_schema", json_schema: { name, schema, strict: true } }`. OpenRouter routes to a backend provider; many but not all backends support this — the SDK accepts the field on every model, and unsupported routes 4xx.
 - `additionalProperties: false` is forced on every object (required for `strict: true`).

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/llm",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "description": "Large language model utilities",
   "repository": {
     "type": "git",

--- a/packages/llm/src/Llm.ts
+++ b/packages/llm/src/Llm.ts
@@ -19,6 +19,7 @@ import {
 import { LlmStreamChunk } from "./types/LlmStreamChunk.interface.js";
 import { AnthropicProvider } from "./providers/anthropic/AnthropicProvider.class.js";
 import { BedrockProvider } from "./providers/bedrock/index.js";
+import { FireworksProvider } from "./providers/fireworks/index.js";
 import { GoogleProvider } from "./providers/google/GoogleProvider.class.js";
 import { OpenAiProvider } from "./providers/openai/index.js";
 import { OpenRouterProvider } from "./providers/openrouter/index.js";
@@ -112,6 +113,10 @@ class Llm implements LlmProvider {
         });
       case PROVIDER.BEDROCK.NAME:
         return new BedrockProvider(model || PROVIDER.BEDROCK.DEFAULT);
+      case PROVIDER.FIREWORKS.NAME:
+        return new FireworksProvider(model || PROVIDER.FIREWORKS.DEFAULT, {
+          apiKey,
+        });
       case PROVIDER.GOOGLE.NAME:
         return new GoogleProvider(model || PROVIDER.GOOGLE.DEFAULT, {
           apiKey,

--- a/packages/llm/src/__tests__/hotModels.ts
+++ b/packages/llm/src/__tests__/hotModels.ts
@@ -27,6 +27,7 @@ export const HOT_MODELS = {
     MODEL.OPUS,
     MODEL.SONNET,
   ]),
+  fireworks: exclude(Object.values(MODEL.FIREWORKS)),
   google: exclude([
     MODEL.GEMINI_FLASH,
     MODEL.GEMINI_FLASH_LITE,

--- a/packages/llm/src/constants.ts
+++ b/packages/llm/src/constants.ts
@@ -24,6 +24,14 @@ export const MODEL = {
   SONNET: "claude-sonnet-5",
   HAIKU: "claude-haiku-4-5",
   MYTHOS: "claude-mythos-5",
+  // Fireworks (serverless open models; ids provided by operator)
+  FIREWORKS: {
+    DEEPSEEK: "accounts/fireworks/models/deepseek-v4-pro",
+    GLM: "accounts/fireworks/models/glm-5p2",
+    KIMI: "accounts/fireworks/models/kimi-k2p7-code",
+    MINIMAX: "accounts/fireworks/models/minimax-m2p7",
+    QWEN: "accounts/fireworks/models/qwen3p7-plus",
+  },
   // Google
   GEMINI_FLASH: "gemini-3.5-flash",
   GEMINI_FLASH_LITE: "gemini-3.1-flash-lite",
@@ -130,6 +138,14 @@ export const PROVIDER = {
       SCHEMA_VERSION: "v2" as const,
     },
   },
+  FIREWORKS: {
+    // https://docs.fireworks.ai/
+    API_KEY: "FIREWORKS_API_KEY" as const,
+    BASE_URL: "https://api.fireworks.ai/inference/v1" as const,
+    DEFAULT: MODEL.FIREWORKS.GLM,
+    MODEL_MATCH_WORDS: ["fireworks"] as const,
+    NAME: "fireworks" as const,
+  },
   /** @deprecated Use PROVIDER.GOOGLE — "Google" is the provider; Gemini is the model family */
   GEMINI: GOOGLE_PROVIDER,
   GOOGLE: GOOGLE_PROVIDER,
@@ -184,6 +200,7 @@ export const PROVIDER = {
 export type LlmProviderName =
   | typeof PROVIDER.ANTHROPIC.NAME
   | typeof PROVIDER.BEDROCK.NAME
+  | typeof PROVIDER.FIREWORKS.NAME
   | typeof PROVIDER.GOOGLE.NAME
   | typeof PROVIDER.OPENAI.NAME
   | typeof PROVIDER.OPENROUTER.NAME

--- a/packages/llm/src/index.ts
+++ b/packages/llm/src/index.ts
@@ -67,6 +67,7 @@ export {
 
 // Providers
 export { BedrockProvider } from "./providers/bedrock/index.js";
+export { FireworksProvider } from "./providers/fireworks/index.js";
 /** @deprecated Use GoogleProvider — "Google" is the provider; Gemini is the model family */
 export { GoogleProvider as GeminiProvider } from "./providers/google/index.js";
 export { GoogleProvider } from "./providers/google/index.js";

--- a/packages/llm/src/operate/adapters/FireworksAdapter.ts
+++ b/packages/llm/src/operate/adapters/FireworksAdapter.ts
@@ -160,7 +160,7 @@ function isStructuredOutputUnsupportedError(error: unknown): boolean {
     (m): m is string => typeof m === "string",
   );
   return messages.some((m) =>
-    /response_format|json[_ ]schema|structured[_ ]output/i.test(m),
+    /response[_ ]format|json[_ ]schema|structured[_ ]output/i.test(m),
   );
 }
 
@@ -389,16 +389,24 @@ export class FireworksAdapter extends BaseProviderAdapter {
       fireworksRequest.user = request.user;
     }
 
+    // Fireworks rejects `response_format` combined with `tools` ("You cannot
+    // specify response format and function call at the same time"), so a
+    // request with both preemptively uses the structured_output tool
+    // emulation — same approach as Gemini 2.5.
+    const hasCallerTools = Boolean(request.tools?.length);
     const useFallbackStructuredOutput =
       Boolean(request.format) &&
-      !this.supportsStructuredOutput(fireworksRequest.model);
+      (hasCallerTools ||
+        !this.supportsStructuredOutput(fireworksRequest.model));
 
     const allTools: ProviderToolDefinition[] = request.tools
       ? [...request.tools]
       : [];
     if (useFallbackStructuredOutput && request.format) {
       log.warn(
-        `[FireworksAdapter] Using legacy structured_output tool fallback for model ${fireworksRequest.model}; native response_format previously rejected for this model.`,
+        hasCallerTools
+          ? `[FireworksAdapter] Fireworks does not support response_format combined with tools; using structured_output tool emulation for model ${fireworksRequest.model}.`
+          : `[FireworksAdapter] Using legacy structured_output tool fallback for model ${fireworksRequest.model}; native response_format previously rejected for this model.`,
       );
       allTools.push({
         name: STRUCTURED_OUTPUT_TOOL_NAME,

--- a/packages/llm/src/operate/adapters/FireworksAdapter.ts
+++ b/packages/llm/src/operate/adapters/FireworksAdapter.ts
@@ -1,0 +1,1212 @@
+import { log } from "@jaypie/logger";
+import { JsonObject, NaturalSchema } from "@jaypie/types";
+import { z } from "zod/v4";
+
+import { PROVIDER } from "../../constants.js";
+import { paperedEffortMessage, toFireworksEffort } from "../../util/effort.js";
+import { Toolkit } from "../../tools/Toolkit.class.js";
+import {
+  LlmHistory,
+  LlmInputContent,
+  LlmMessageRole,
+  LlmMessageType,
+  LlmOperateOptions,
+  LlmOutputMessage,
+  LlmUsageItem,
+} from "../../types/LlmProvider.interface.js";
+import {
+  LlmStreamChunk,
+  LlmStreamChunkType,
+} from "../../types/LlmStreamChunk.interface.js";
+import { isJsonSchema, naturalZodSchema } from "../../util/index.js";
+import {
+  ClassifiedError,
+  ErrorCategory,
+  OperateRequest,
+  ParsedResponse,
+  ProviderToolDefinition,
+  StandardToolCall,
+  StandardToolResult,
+} from "../types.js";
+import { isTransientNetworkError } from "../retry/isTransientNetworkError.js";
+import { classifyProviderError } from "../../util/classifyProviderError.js";
+import { FireworksClient } from "../../providers/fireworks/client.js";
+import { BaseProviderAdapter } from "./ProviderAdapter.interface.js";
+
+//
+//
+// Types
+//
+
+interface FireworksMessage {
+  role: "system" | "user" | "assistant" | "tool";
+  content?: string | FireworksContentPart[] | null;
+  toolCalls?: FireworksToolCall[];
+  toolCallId?: string;
+}
+
+interface FireworksToolCall {
+  id: string;
+  type: "function";
+  function: {
+    name: string;
+    arguments: string;
+  };
+}
+
+interface FireworksResponseMessage {
+  role: "assistant";
+  content?: string | null;
+  toolCalls?: FireworksToolCall[];
+  refusal?: string | null;
+  reasoning?: string | null;
+  reasoning_content?: string | null;
+}
+
+interface FireworksChoice {
+  index: number;
+  message: FireworksResponseMessage;
+  finishReason: string | null;
+  finish_reason?: string | null;
+}
+
+interface FireworksUsage {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  total_tokens?: number;
+  completionTokensDetails?: {
+    reasoningTokens?: number;
+  };
+}
+
+interface FireworksResponse {
+  id: string;
+  object: string;
+  created: number;
+  model: string;
+  choices: FireworksChoice[];
+  usage?: FireworksUsage;
+}
+
+interface FireworksTool {
+  type: "function";
+  function: {
+    name: string;
+    description: string;
+    parameters: JsonObject;
+  };
+}
+
+interface FireworksJsonSchemaConfig {
+  name: string;
+  description?: string;
+  schema: JsonObject;
+  strict?: boolean;
+}
+
+type FireworksResponseFormat =
+  | { type: "json_schema"; json_schema: FireworksJsonSchemaConfig }
+  | { type: "json_object" }
+  | { type: "text" };
+
+interface FireworksRequest {
+  model: string;
+  messages: FireworksMessage[];
+  tools?: FireworksTool[];
+  tool_choice?: "auto" | "none" | "required";
+  response_format?: FireworksResponseFormat;
+  reasoning_effort?: string;
+  user?: string;
+}
+
+/**
+ * Fireworks responses we annotate at receive time so downstream stateless
+ * methods (`hasStructuredOutput`, `extractStructuredOutput`) can tell whether
+ * the request asked for native structured output without re-threading the
+ * request.
+ */
+type AnnotatedFireworksResponse = FireworksResponse & {
+  __jaypieStructuredOutput?: boolean;
+};
+
+//
+//
+// Constants
+//
+
+const STRUCTURED_OUTPUT_TOOL_NAME = "structured_output";
+
+const STRUCTURED_OUTPUT_SCHEMA_NAME = "response";
+
+/**
+ * Detect 4xx errors that indicate the model itself does not support
+ * `response_format: json_schema`. We only trigger the fake-tool fallback when
+ * the failure is plausibly a capability gap, not a generic 400.
+ */
+function isStructuredOutputUnsupportedError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const err = error as {
+    status?: number;
+    statusCode?: number;
+    message?: string;
+    error?: { message?: string };
+  };
+  const status = err.status ?? err.statusCode;
+  if (status !== 400 && status !== 422) return false;
+  const messages = [err.message, err.error?.message].filter(
+    (m): m is string => typeof m === "string",
+  );
+  return messages.some((m) =>
+    /response_format|json[_ ]schema|structured[_ ]output/i.test(m),
+  );
+}
+
+function isTemperatureDeprecationError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const err = error as {
+    status?: number;
+    statusCode?: number;
+    message?: string;
+    error?: { message?: string };
+  };
+  const status = err.status ?? err.statusCode;
+  if (status !== 400) return false;
+  const messages = [err.message, err.error?.message].filter(
+    (m): m is string => typeof m === "string",
+  );
+  return messages.some((m) => m.toLowerCase().includes("temperature"));
+}
+
+/**
+ * Fireworks content part types. Fireworks follows the OpenAI Chat Completions
+ * multimodal schema for `image_url` parts (URL or base64 data URI). There is
+ * no OpenAI-style `file` part, and the API rejects `data:` URIs for documents
+ * ("Unsupported URL scheme 'data'"), so file inputs cannot be delivered.
+ */
+type FireworksContentPart =
+  | { type: "text"; text: string }
+  | { type: "image_url"; imageUrl: { url: string } };
+
+/**
+ * Convert standardized content items to Fireworks format. Images become
+ * `image_url` parts (vision models only; non-vision models 4xx — a
+ * model-capability mismatch surfaced by the call). File inputs are warned
+ * and discarded: Fireworks has no `file` part and rejects document `data:`
+ * URIs outright, so there is no wire shape that can carry them.
+ */
+function convertContentToFireworks(
+  content: string | LlmInputContent[],
+): string | FireworksContentPart[] {
+  if (typeof content === "string") {
+    return content;
+  }
+
+  const parts: FireworksContentPart[] = [];
+
+  for (const item of content) {
+    if (item.type === LlmMessageType.InputText) {
+      parts.push({ type: "text", text: item.text });
+      continue;
+    }
+
+    if (item.type === LlmMessageType.InputImage) {
+      const url = item.image_url ?? "";
+      if (!url) {
+        log.warn("Fireworks image content missing image_url; image discarded");
+        continue;
+      }
+      parts.push({ type: "image_url", imageUrl: { url } });
+      continue;
+    }
+
+    if (item.type === LlmMessageType.InputFile) {
+      log.warn(
+        { filename: item.filename },
+        "Fireworks does not support file inputs (no file part; document data: URIs rejected); file discarded",
+      );
+      continue;
+    }
+
+    // Unknown type - warn and skip
+    log.warn({ item }, "Unknown content type for Fireworks; discarded");
+  }
+
+  // If no parts remain, return empty string to avoid empty array
+  if (parts.length === 0) {
+    return "";
+  }
+
+  return parts;
+}
+
+/**
+ * Convert internal content parts to the OpenAI-compatible wire shape. The
+ * internal representation uses camelCase keys (`imageUrl`); the REST API wants
+ * snake_case (`image_url`).
+ */
+function contentToWire(
+  content: string | FireworksContentPart[] | null | undefined,
+): unknown {
+  if (
+    content === null ||
+    content === undefined ||
+    typeof content === "string"
+  ) {
+    return content;
+  }
+  return content.map((part) => {
+    if (part.type === "image_url") {
+      return { type: "image_url", image_url: part.imageUrl };
+    }
+    return part;
+  });
+}
+
+/**
+ * Serialize an internal message to the OpenAI-compatible wire shape, mapping
+ * camelCase tool fields (`toolCalls`, `toolCallId`) to snake_case. Tool-call
+ * objects are already wire-shaped (`{ id, type, function: { name, arguments } }`).
+ */
+function messageToWire(message: FireworksMessage): Record<string, unknown> {
+  const wire: Record<string, unknown> = { role: message.role };
+  if (message.content !== undefined) {
+    wire.content = contentToWire(message.content);
+  }
+  if (message.toolCalls) {
+    wire.tool_calls = message.toolCalls;
+  }
+  if (message.toolCallId) {
+    wire.tool_call_id = message.toolCallId;
+  }
+  return wire;
+}
+
+// Fireworks error types based on HTTP status codes
+const RETRYABLE_STATUS_CODES = [408, 500, 502, 503, 524, 529];
+const RATE_LIMIT_STATUS_CODE = 429;
+
+/**
+ * Walk the JSON schema and force `additionalProperties: false` on every
+ * object node. Required by the OpenAI-style json_schema response_format when
+ * `strict: true`.
+ */
+function enforceAdditionalPropertiesFalse(schema: JsonObject): void {
+  const stack: JsonObject[] = [schema];
+  while (stack.length > 0) {
+    const node = stack.pop() as JsonObject;
+    if (node.type === "object") {
+      node.additionalProperties = false;
+    }
+    for (const value of Object.values(node)) {
+      if (Array.isArray(value)) {
+        for (const entry of value) {
+          if (entry && typeof entry === "object" && !Array.isArray(entry)) {
+            stack.push(entry as JsonObject);
+          }
+        }
+      } else if (value && typeof value === "object") {
+        stack.push(value as JsonObject);
+      }
+    }
+  }
+}
+
+//
+//
+// Main
+//
+
+/**
+ * FireworksAdapter implements the ProviderAdapter interface for Fireworks AI's
+ * OpenAI-compatible Chat Completions API. It handles request building,
+ * response parsing, and error classification specific to Fireworks.
+ */
+export class FireworksAdapter extends BaseProviderAdapter {
+  readonly name = PROVIDER.FIREWORKS.NAME;
+  readonly defaultModel = PROVIDER.FIREWORKS.DEFAULT;
+
+  // Session-level cache of models observed to reject native
+  // `response_format: json_schema`. When a model is in this set, buildRequest
+  // engages the legacy fake-tool path instead of native structured output.
+  private runtimeNoStructuredOutputModels = new Set<string>();
+
+  rememberModelRejectsStructuredOutput(model: string): void {
+    this.runtimeNoStructuredOutputModels.add(model);
+  }
+
+  clearRuntimeNoStructuredOutputModels(): void {
+    this.runtimeNoStructuredOutputModels.clear();
+  }
+
+  private supportsStructuredOutput(model: string): boolean {
+    return !this.runtimeNoStructuredOutputModels.has(model);
+  }
+
+  // Session-level cache of models observed to reject `temperature`. Populated
+  // by executeRequest on 400 errors so repeat calls skip the param.
+  private runtimeNoTemperatureModels = new Set<string>();
+
+  rememberModelRejectsTemperature(model: string): void {
+    this.runtimeNoTemperatureModels.add(model);
+  }
+
+  clearRuntimeNoTemperatureModels(): void {
+    this.runtimeNoTemperatureModels.clear();
+  }
+
+  private supportsTemperature(model: string): boolean {
+    return !this.runtimeNoTemperatureModels.has(model);
+  }
+
+  //
+  // Request Building
+  //
+
+  buildRequest(request: OperateRequest): FireworksRequest {
+    // Convert messages to Fireworks format (OpenAI-compatible)
+    const messages: FireworksMessage[] = this.convertMessagesToFireworks(
+      request.messages,
+      request.system,
+    );
+
+    // Append instructions to last message if provided
+    if (request.instructions && messages.length > 0) {
+      const lastMsg = messages[messages.length - 1];
+      if (lastMsg.content && typeof lastMsg.content === "string") {
+        lastMsg.content = lastMsg.content + "\n\n" + request.instructions;
+      }
+    }
+
+    const fireworksRequest: FireworksRequest = {
+      model: request.model || this.defaultModel,
+      messages,
+    };
+
+    if (request.user) {
+      fireworksRequest.user = request.user;
+    }
+
+    const useFallbackStructuredOutput =
+      Boolean(request.format) &&
+      !this.supportsStructuredOutput(fireworksRequest.model);
+
+    const allTools: ProviderToolDefinition[] = request.tools
+      ? [...request.tools]
+      : [];
+    if (useFallbackStructuredOutput && request.format) {
+      log.warn(
+        `[FireworksAdapter] Using legacy structured_output tool fallback for model ${fireworksRequest.model}; native response_format previously rejected for this model.`,
+      );
+      allTools.push({
+        name: STRUCTURED_OUTPUT_TOOL_NAME,
+        description:
+          "REQUIRED: You MUST call this tool to provide your final response. " +
+          "After gathering all necessary information (including results from other tools), " +
+          "call this tool with the structured data to complete the request.",
+        parameters: request.format,
+      });
+    }
+
+    if (allTools.length > 0) {
+      fireworksRequest.tools = allTools.map((tool) => ({
+        type: "function" as const,
+        function: {
+          name: tool.name,
+          description: tool.description,
+          parameters: tool.parameters,
+        },
+      }));
+
+      // Use "auto" for tool_choice - not all Fireworks models support "required"
+      // The structured_output tool prompt already emphasizes it must be called
+      fireworksRequest.tool_choice = "auto";
+    }
+
+    // Native structured output: send schema as `response_format`. The legacy
+    // tool-emulation path is engaged only as a runtime fallback for models the
+    // API has flagged as not supporting native json_schema.
+    if (request.format && !useFallbackStructuredOutput) {
+      fireworksRequest.response_format = {
+        type: "json_schema",
+        json_schema: {
+          name: STRUCTURED_OUTPUT_SCHEMA_NAME,
+          schema: request.format,
+          strict: true,
+        },
+      };
+    }
+
+    if (request.providerOptions) {
+      Object.assign(fireworksRequest, request.providerOptions);
+    }
+
+    // Normalized reasoning effort -> reasoning_effort. Fireworks accepts the
+    // param on every model and no-ops where unsupported, so no per-model
+    // gating. First-class effort wins over providerOptions.
+    if (request.effort) {
+      const mapping = toFireworksEffort(request.effort);
+      if (mapping.papered) {
+        log.debug(
+          paperedEffortMessage({
+            model: fireworksRequest.model,
+            provider: this.name,
+            requested: request.effort,
+            value: mapping.value,
+          }),
+        );
+      }
+      fireworksRequest.reasoning_effort = mapping.value as string;
+    }
+
+    // First-class temperature takes precedence over providerOptions
+    if (request.temperature !== undefined) {
+      (fireworksRequest as unknown as Record<string, unknown>).temperature =
+        request.temperature;
+    }
+
+    // Strip temperature for models the runtime has cached as rejecting it
+    const requestRecord = fireworksRequest as unknown as Record<
+      string,
+      unknown
+    >;
+    if (
+      requestRecord.temperature !== undefined &&
+      !this.supportsTemperature(fireworksRequest.model)
+    ) {
+      delete requestRecord.temperature;
+    }
+
+    return fireworksRequest;
+  }
+
+  formatTools(
+    toolkit: Toolkit,
+    // outputSchema is part of the interface contract but Fireworks uses native
+    // `response_format` (set in buildRequest); the legacy fake-tool injection
+    // happens in buildRequest only as a runtime fallback.
+
+    _outputSchema?: JsonObject,
+  ): ProviderToolDefinition[] {
+    return toolkit.tools.map((tool) => ({
+      name: tool.name,
+      description: tool.description,
+      parameters: tool.parameters as JsonObject,
+    }));
+  }
+
+  formatOutputSchema(
+    schema: JsonObject | NaturalSchema | z.ZodType,
+  ): JsonObject {
+    let jsonSchema: JsonObject;
+
+    // Check if schema is already a JsonObject — either the OpenAI-style
+    // `{ type: "json_schema", ... }` envelope or a bare `{ type: "object", properties }` node
+    if (
+      (typeof schema === "object" &&
+        schema !== null &&
+        !Array.isArray(schema) &&
+        (schema as JsonObject).type === "json_schema") ||
+      isJsonSchema(schema)
+    ) {
+      jsonSchema = structuredClone(schema) as JsonObject;
+      jsonSchema.type = "object"; // Normalize type
+    } else {
+      // Convert NaturalSchema to JSON schema through Zod. Re-spread into a
+      // plain object to drop Zod v4's non-enumerable `~standard` marker.
+      const zodSchema =
+        schema instanceof z.ZodType
+          ? schema
+          : naturalZodSchema(schema as NaturalSchema);
+      jsonSchema = { ...(z.toJSONSchema(zodSchema) as JsonObject) };
+    }
+
+    // Remove $schema property (can cause issues with some providers)
+    if (jsonSchema.$schema) {
+      delete jsonSchema.$schema;
+    }
+
+    // Strict json_schema response_format requires additionalProperties: false
+    // on every object.
+    enforceAdditionalPropertiesFalse(jsonSchema);
+
+    return jsonSchema;
+  }
+
+  //
+  // API Execution
+  //
+
+  async executeRequest(
+    client: unknown,
+    request: unknown,
+    signal?: AbortSignal,
+  ): Promise<FireworksResponse> {
+    const fireworks = client as FireworksClient;
+    const fireworksRequest = request as FireworksRequest;
+    const wantsStructuredOutput = Boolean(fireworksRequest.response_format);
+
+    try {
+      const response = (await fireworks.chatCompletion(
+        this.toWireBody(fireworksRequest),
+        signal ? { signal } : undefined,
+      )) as unknown as AnnotatedFireworksResponse;
+      if (wantsStructuredOutput) {
+        response.__jaypieStructuredOutput = true;
+      }
+      return response;
+    } catch (error) {
+      if (signal?.aborted) return undefined as unknown as FireworksResponse;
+
+      // If the model rejected `temperature`, cache it and retry without the param.
+      const requestRecord = fireworksRequest as unknown as Record<
+        string,
+        unknown
+      >;
+      if (
+        requestRecord.temperature !== undefined &&
+        isTemperatureDeprecationError(error)
+      ) {
+        this.rememberModelRejectsTemperature(fireworksRequest.model);
+        const retryRequest = { ...fireworksRequest } as FireworksRequest;
+        delete (retryRequest as unknown as Record<string, unknown>).temperature;
+        const response = (await fireworks.chatCompletion(
+          this.toWireBody(retryRequest),
+          signal ? { signal } : undefined,
+        )) as unknown as AnnotatedFireworksResponse;
+        if (wantsStructuredOutput) {
+          response.__jaypieStructuredOutput = true;
+        }
+        return response;
+      }
+
+      // If the model rejected `response_format`, cache it and retry with the
+      // legacy fake-tool emulation path.
+      if (wantsStructuredOutput && isStructuredOutputUnsupportedError(error)) {
+        const model = fireworksRequest.model;
+        this.rememberModelRejectsStructuredOutput(model);
+        log.warn(
+          `[FireworksAdapter] Model ${model} rejected native response_format; falling back to legacy structured_output tool emulation.`,
+        );
+        const fallbackRequest =
+          this.toFallbackStructuredOutputRequest(fireworksRequest);
+        return (await fireworks.chatCompletion(
+          this.toWireBody(fallbackRequest),
+          signal ? { signal } : undefined,
+        )) as unknown as FireworksResponse;
+      }
+
+      throw error;
+    }
+  }
+
+  /**
+   * Serialize the internal request into the OpenAI-compatible wire body for
+   * Fireworks' Chat Completions endpoint. Top-level fields (model, tools,
+   * tool_choice, response_format, reasoning_effort, user, temperature, and any
+   * providerOptions) are already wire-shaped (snake_case); only messages carry
+   * camelCase tool fields that must become snake_case on the wire.
+   */
+  private toWireBody(
+    fireworksRequest: FireworksRequest,
+  ): Record<string, unknown> {
+    return {
+      ...fireworksRequest,
+      messages: fireworksRequest.messages.map(messageToWire),
+    };
+  }
+
+  /**
+   * Rebuild a structured-output request without `response_format`, swapping in
+   * the legacy fake-tool emulation. Used as a runtime fallback when a model
+   * rejects native json_schema.
+   */
+  private toFallbackStructuredOutputRequest(
+    request: FireworksRequest,
+  ): FireworksRequest {
+    if (
+      !request.response_format ||
+      request.response_format.type !== "json_schema"
+    ) {
+      return request;
+    }
+    const { response_format, ...rest } = request;
+    const fallbackRequest: FireworksRequest = { ...rest };
+    const schema = response_format.json_schema.schema;
+    const fakeTool: FireworksTool = {
+      type: "function" as const,
+      function: {
+        name: STRUCTURED_OUTPUT_TOOL_NAME,
+        description:
+          "REQUIRED: You MUST call this tool to provide your final response. " +
+          "After gathering all necessary information (including results from other tools), " +
+          "call this tool with the structured data to complete the request.",
+        parameters: schema,
+      },
+    };
+    fallbackRequest.tools = [...(fallbackRequest.tools ?? []), fakeTool];
+    fallbackRequest.tool_choice = "auto";
+    return fallbackRequest;
+  }
+
+  async *executeStreamRequest(
+    client: unknown,
+    request: unknown,
+    signal?: AbortSignal,
+  ): AsyncIterable<LlmStreamChunk> {
+    const fireworks = client as FireworksClient;
+    const fireworksRequest = request as FireworksRequest;
+
+    // streamChatCompletion adds `stream: true` + `stream_options.include_usage`
+    // and yields decoded SSE chunks in OpenAI-compatible (snake_case) shape.
+    const stream = fireworks.streamChatCompletion(
+      this.toWireBody(fireworksRequest),
+      signal ? { signal } : undefined,
+    ) as AsyncIterable<unknown>;
+
+    // Track current tool call being built
+    let currentToolCall: {
+      id: string;
+      name: string;
+      arguments: string;
+    } | null = null;
+
+    // Track usage for final chunk
+    let inputTokens = 0;
+    let outputTokens = 0;
+    const model = fireworksRequest.model || this.defaultModel;
+
+    for await (const chunk of stream) {
+      // Handle different chunk types from Fireworks (OpenAI-compatible format)
+      interface StreamChunk {
+        choices?: Array<{
+          delta?: {
+            content?: string;
+            // Reasoning deltas arrive on reasoning_content; kept out of the
+            // text stream so `content` remains the final answer only.
+            reasoning_content?: string;
+            tool_calls?: Array<{
+              id?: string;
+              function?: { name?: string; arguments?: string };
+            }>;
+          };
+          finish_reason?: string;
+        }>;
+        usage?: {
+          prompt_tokens?: number;
+          completion_tokens?: number;
+          promptTokens?: number;
+          completionTokens?: number;
+        };
+      }
+      const typedChunk = chunk as StreamChunk;
+      const choices = typedChunk.choices;
+
+      if (choices && choices.length > 0) {
+        const delta = choices[0].delta;
+
+        // Handle text content
+        if (delta?.content) {
+          yield {
+            type: LlmStreamChunkType.Text,
+            content: delta.content,
+          };
+        }
+
+        // Handle tool calls
+        if (delta?.tool_calls && delta.tool_calls.length > 0) {
+          for (const toolCallDelta of delta.tool_calls) {
+            if (toolCallDelta.id) {
+              // New tool call starting
+              if (currentToolCall) {
+                // Emit the previous tool call
+                yield {
+                  type: LlmStreamChunkType.ToolCall,
+                  toolCall: {
+                    id: currentToolCall.id,
+                    name: currentToolCall.name,
+                    arguments: currentToolCall.arguments,
+                  },
+                };
+              }
+              currentToolCall = {
+                id: toolCallDelta.id,
+                name: toolCallDelta.function?.name || "",
+                arguments: toolCallDelta.function?.arguments || "",
+              };
+            } else if (currentToolCall) {
+              // Continuing existing tool call
+              if (toolCallDelta.function?.name) {
+                currentToolCall.name += toolCallDelta.function.name;
+              }
+              if (toolCallDelta.function?.arguments) {
+                currentToolCall.arguments += toolCallDelta.function.arguments;
+              }
+            }
+          }
+        }
+
+        // Check for finish reason
+        if (choices[0].finish_reason) {
+          // Emit any pending tool call
+          if (currentToolCall) {
+            yield {
+              type: LlmStreamChunkType.ToolCall,
+              toolCall: {
+                id: currentToolCall.id,
+                name: currentToolCall.name,
+                arguments: currentToolCall.arguments,
+              },
+            };
+            currentToolCall = null;
+          }
+        }
+      }
+
+      // Extract usage if present (usually in the final chunk)
+      if (typedChunk.usage) {
+        inputTokens =
+          typedChunk.usage.prompt_tokens || typedChunk.usage.promptTokens || 0;
+        outputTokens =
+          typedChunk.usage.completion_tokens ||
+          typedChunk.usage.completionTokens ||
+          0;
+      }
+    }
+
+    // Emit done chunk with final usage
+    yield {
+      type: LlmStreamChunkType.Done,
+      usage: [
+        {
+          input: inputTokens,
+          output: outputTokens,
+          reasoning: 0,
+          total: inputTokens + outputTokens,
+          provider: this.name,
+          model,
+        },
+      ],
+    };
+  }
+
+  //
+  // Response Parsing
+  //
+
+  parseResponse(
+    response: unknown,
+    _options?: LlmOperateOptions,
+  ): ParsedResponse {
+    const fireworksResponse = response as FireworksResponse;
+    const choice = fireworksResponse.choices[0];
+
+    const content = this.extractContent(fireworksResponse);
+    const hasToolCalls = this.hasToolCalls(fireworksResponse);
+
+    const stopReason =
+      choice?.finishReason ?? choice?.finish_reason ?? undefined;
+
+    return {
+      content,
+      hasToolCalls,
+      stopReason,
+      usage: this.extractUsage(fireworksResponse, fireworksResponse.model),
+      raw: fireworksResponse,
+    };
+  }
+
+  extractToolCalls(response: unknown): StandardToolCall[] {
+    const fireworksResponse = response as FireworksResponse;
+    const toolCalls: StandardToolCall[] = [];
+    const choice = fireworksResponse.choices[0];
+
+    if (!choice?.message?.toolCalls) {
+      return toolCalls;
+    }
+
+    for (const toolCall of choice.message.toolCalls) {
+      toolCalls.push({
+        callId: toolCall.id,
+        name: toolCall.function.name,
+        arguments: toolCall.function.arguments,
+        raw: toolCall,
+      });
+    }
+
+    return toolCalls;
+  }
+
+  extractUsage(response: unknown, model: string): LlmUsageItem {
+    const fireworksResponse = response as FireworksResponse;
+
+    if (!fireworksResponse.usage) {
+      return {
+        input: 0,
+        output: 0,
+        reasoning: 0,
+        total: 0,
+        provider: this.name,
+        model,
+      };
+    }
+
+    const usage = fireworksResponse.usage;
+    return {
+      input: usage.promptTokens || usage.prompt_tokens || 0,
+      output: usage.completionTokens || usage.completion_tokens || 0,
+      reasoning: usage.completionTokensDetails?.reasoningTokens || 0,
+      total: usage.totalTokens || usage.total_tokens || 0,
+      provider: this.name,
+      model,
+    };
+  }
+
+  //
+  // Tool Result Handling
+  //
+
+  formatToolResult(
+    toolCall: StandardToolCall,
+    result: StandardToolResult,
+  ): FireworksMessage {
+    return {
+      role: "tool",
+      toolCallId: toolCall.callId,
+      content: result.output,
+    };
+  }
+
+  appendToolResult(
+    request: unknown,
+    toolCall: StandardToolCall,
+    result: StandardToolResult,
+  ): FireworksRequest {
+    const fireworksRequest = request as FireworksRequest;
+    const toolCallRaw = toolCall.raw as FireworksToolCall;
+
+    // Add assistant message with the tool call
+    fireworksRequest.messages.push({
+      role: "assistant",
+      content: null,
+      toolCalls: [toolCallRaw],
+    });
+
+    // Add tool result message
+    fireworksRequest.messages.push(this.formatToolResult(toolCall, result));
+
+    return fireworksRequest;
+  }
+
+  //
+  // History Management
+  //
+
+  responseToHistoryItems(response: unknown): LlmHistory {
+    const fireworksResponse = response as FireworksResponse;
+    const historyItems: LlmHistory = [];
+    const choice = fireworksResponse.choices[0];
+
+    if (!choice?.message) {
+      return historyItems;
+    }
+
+    // Check if this is a tool use response
+    if (choice.message.toolCalls && choice.message.toolCalls.length > 0) {
+      // Don't add to history yet - will be added after tool execution
+      return historyItems;
+    }
+
+    // Extract text content for non-tool responses
+    if (choice.message.content) {
+      const historyItem: LlmOutputMessage & { reasoning?: string } = {
+        content: choice.message.content,
+        role: LlmMessageRole.Assistant,
+        type: LlmMessageType.Message,
+      };
+
+      // Preserve reasoning if present. Fireworks reasoning models return it in
+      // reasoning_content; some routes use reasoning.
+      const reasoning =
+        choice.message.reasoning_content ?? choice.message.reasoning;
+      if (reasoning) {
+        historyItem.reasoning = reasoning;
+      }
+
+      historyItems.push(historyItem as LlmOutputMessage);
+    }
+
+    return historyItems;
+  }
+
+  //
+  // Error Classification
+  //
+
+  classifyError(error: unknown): ClassifiedError {
+    // Shared first pass: retryable structured-output timeouts (#422),
+    // quota exhaustion, and billing failures classify the same across providers.
+    const shared = classifyProviderError(error);
+    if (shared) return shared;
+
+    // Check if error has a status code (HTTP error)
+    const errorWithStatus = error as { status?: number; statusCode?: number };
+    const statusCode = errorWithStatus.status || errorWithStatus.statusCode;
+
+    if (statusCode) {
+      // Rate limit error
+      if (statusCode === RATE_LIMIT_STATUS_CODE) {
+        return {
+          error,
+          category: ErrorCategory.RateLimit,
+          shouldRetry: false,
+          suggestedDelayMs: 60000,
+        };
+      }
+
+      // Retryable errors (server errors, timeouts, etc.)
+      if (RETRYABLE_STATUS_CODES.includes(statusCode)) {
+        return {
+          error,
+          category: ErrorCategory.Retryable,
+          shouldRetry: true,
+        };
+      }
+
+      // Client errors (4xx except 429) are unrecoverable
+      if (statusCode >= 400 && statusCode < 500) {
+        return {
+          error,
+          category: ErrorCategory.Unrecoverable,
+          shouldRetry: false,
+        };
+      }
+    }
+
+    // Check error message for rate limit indicators
+    const errorMessage =
+      error instanceof Error ? error.message.toLowerCase() : "";
+    if (
+      errorMessage.includes("rate limit") ||
+      errorMessage.includes("too many requests")
+    ) {
+      return {
+        error,
+        category: ErrorCategory.RateLimit,
+        shouldRetry: false,
+        suggestedDelayMs: 60000,
+      };
+    }
+
+    // Check for transient network errors (ECONNRESET, etc.)
+    if (isTransientNetworkError(error)) {
+      return {
+        error,
+        category: ErrorCategory.Retryable,
+        shouldRetry: true,
+      };
+    }
+
+    // Unknown error - treat as potentially retryable
+    return {
+      error,
+      category: ErrorCategory.Unknown,
+      shouldRetry: true,
+    };
+  }
+
+  //
+  // Provider-Specific Features
+  //
+
+  isComplete(response: unknown): boolean {
+    const fireworksResponse = response as FireworksResponse;
+    const choice = fireworksResponse.choices[0];
+
+    // Complete if no tool calls
+    if (!choice?.message?.toolCalls?.length) {
+      return true;
+    }
+
+    return false;
+  }
+
+  override hasStructuredOutput(response: unknown): boolean {
+    const fireworksResponse = response as AnnotatedFireworksResponse;
+
+    // Native path: executeRequest annotates the response when we sent
+    // `response_format`, so we can detect intent statelessly.
+    if (fireworksResponse.__jaypieStructuredOutput) {
+      return this.extractStructuredOutput(response) !== undefined;
+    }
+
+    // Fallback path: legacy fake-tool emulation, kept for models that the
+    // runtime has cached as not supporting native `response_format`.
+    const choice = fireworksResponse.choices[0];
+
+    if (!choice?.message?.toolCalls?.length) {
+      return false;
+    }
+
+    // Check if the last tool call is structured_output
+    const lastToolCall =
+      choice.message.toolCalls[choice.message.toolCalls.length - 1];
+    return lastToolCall?.function?.name === STRUCTURED_OUTPUT_TOOL_NAME;
+  }
+
+  override extractStructuredOutput(response: unknown): JsonObject | undefined {
+    const fireworksResponse = response as AnnotatedFireworksResponse;
+
+    if (fireworksResponse.__jaypieStructuredOutput) {
+      const choice = fireworksResponse.choices[0];
+      const content = choice?.message?.content;
+      if (typeof content !== "string" || content.length === 0) {
+        return undefined;
+      }
+      try {
+        return JSON.parse(content) as JsonObject;
+      } catch {
+        return undefined;
+      }
+    }
+
+    // Fallback path: legacy fake-tool emulation
+    const choice = fireworksResponse.choices[0];
+
+    if (!choice?.message?.toolCalls?.length) {
+      return undefined;
+    }
+
+    const lastToolCall =
+      choice.message.toolCalls[choice.message.toolCalls.length - 1];
+    if (lastToolCall?.function?.name === STRUCTURED_OUTPUT_TOOL_NAME) {
+      try {
+        return JSON.parse(lastToolCall.function.arguments) as JsonObject;
+      } catch {
+        return undefined;
+      }
+    }
+
+    return undefined;
+  }
+
+  //
+  // Private Helpers
+  //
+
+  private hasToolCalls(response: FireworksResponse): boolean {
+    const choice = response.choices[0];
+    return (choice?.message?.toolCalls?.length ?? 0) > 0;
+  }
+
+  private extractContent(
+    response: FireworksResponse,
+  ): string | JsonObject | undefined {
+    // Check for structured output first
+    if (this.hasStructuredOutput(response)) {
+      return this.extractStructuredOutput(response);
+    }
+
+    const choice = response.choices[0];
+    return choice?.message?.content ?? undefined;
+  }
+
+  private convertMessagesToFireworks(
+    messages: LlmHistory,
+    system?: string,
+  ): FireworksMessage[] {
+    const fireworksMessages: FireworksMessage[] = [];
+
+    // Add system message if provided
+    if (system) {
+      fireworksMessages.push({
+        role: "system",
+        content: system,
+      });
+    }
+
+    for (const msg of messages) {
+      const message = msg as unknown as Record<string, unknown>;
+
+      // Handle different message types
+      if (message.role === "system") {
+        fireworksMessages.push({
+          role: "system",
+          content: message.content as string,
+        });
+      } else if (message.role === "user") {
+        fireworksMessages.push({
+          role: "user",
+          content: convertContentToFireworks(
+            message.content as string | LlmInputContent[],
+          ),
+        });
+      } else if (message.role === "assistant") {
+        const assistantMsg: FireworksMessage = {
+          role: "assistant",
+          content: (message.content as string) || null,
+        };
+
+        // Include toolCalls if present (check both camelCase and snake_case for compatibility)
+        if (message.toolCalls) {
+          assistantMsg.toolCalls = message.toolCalls as FireworksToolCall[];
+        } else if (message.tool_calls) {
+          assistantMsg.toolCalls = message.tool_calls as FireworksToolCall[];
+        }
+
+        fireworksMessages.push(assistantMsg);
+      } else if (message.role === "tool") {
+        fireworksMessages.push({
+          role: "tool",
+          toolCallId:
+            (message.toolCallId as string) || (message.tool_call_id as string),
+          content: message.content as string,
+        });
+      } else if (message.type === LlmMessageType.Message) {
+        // Handle internal message format
+        const role = (message.role as string)?.toLowerCase();
+        if (role === "assistant") {
+          fireworksMessages.push({
+            role: "assistant",
+            content: message.content as string,
+          });
+        } else {
+          fireworksMessages.push({
+            role: "user",
+            content: convertContentToFireworks(
+              message.content as string | LlmInputContent[],
+            ),
+          });
+        }
+      } else if (message.type === LlmMessageType.FunctionCall) {
+        fireworksMessages.push({
+          role: "assistant",
+          content: null,
+          toolCalls: [
+            {
+              id: message.call_id as string,
+              type: "function" as const,
+              function: {
+                name: message.name as string,
+                arguments: (message.arguments as string) || "{}",
+              },
+            },
+          ],
+        });
+      } else if (message.type === LlmMessageType.FunctionCallOutput) {
+        fireworksMessages.push({
+          role: "tool",
+          toolCallId: message.call_id as string,
+          content: (message.output as string) || "",
+        });
+      }
+    }
+
+    return fireworksMessages;
+  }
+}
+
+// Export singleton instance
+export const fireworksAdapter = new FireworksAdapter();

--- a/packages/llm/src/operate/adapters/__tests__/FireworksAdapter.spec.ts
+++ b/packages/llm/src/operate/adapters/__tests__/FireworksAdapter.spec.ts
@@ -1,0 +1,1696 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { log } from "@jaypie/logger";
+
+import { FireworksAdapter, fireworksAdapter } from "../FireworksAdapter.js";
+import { PROVIDER } from "../../../constants.js";
+import { Toolkit } from "../../../tools/Toolkit.class.js";
+import { ErrorCategory, OperateRequest } from "../../types.js";
+import {
+  LlmMessageRole,
+  LlmMessageType,
+} from "../../../types/LlmProvider.interface.js";
+import { LlmStreamChunkType } from "../../../types/LlmStreamChunk.interface.js";
+
+//
+//
+// Mock
+//
+
+vi.mock("zod/v4", () => ({
+  z: {
+    ZodType: class ZodType {},
+    toJSONSchema: vi.fn(() => ({ type: "object", properties: {} })),
+  },
+}));
+
+//
+//
+// Tests
+//
+
+describe("FireworksAdapter", () => {
+  // Base Cases
+  describe("Base Cases", () => {
+    it("exports FireworksAdapter class", () => {
+      expect(FireworksAdapter).toBeDefined();
+      expect(typeof FireworksAdapter).toBe("function");
+    });
+
+    it("exports fireworksAdapter singleton", () => {
+      expect(fireworksAdapter).toBeDefined();
+      expect(fireworksAdapter).toBeInstanceOf(FireworksAdapter);
+    });
+
+    it("has correct name", () => {
+      expect(fireworksAdapter.name).toBe(PROVIDER.FIREWORKS.NAME);
+    });
+
+    it("has correct default model", () => {
+      expect(fireworksAdapter.defaultModel).toBe(PROVIDER.FIREWORKS.DEFAULT);
+    });
+  });
+
+  // Happy Paths
+  describe("Happy Paths", () => {
+    describe("buildRequest", () => {
+      it("builds basic request", () => {
+        const request: OperateRequest = {
+          model: PROVIDER.FIREWORKS.DEFAULT,
+          messages: [
+            {
+              content: "Hello",
+              role: LlmMessageRole.User,
+              type: LlmMessageType.Message,
+            },
+          ],
+        };
+
+        const result = fireworksAdapter.buildRequest(request);
+
+        expect(result.model).toBe(PROVIDER.FIREWORKS.DEFAULT);
+        expect(result.messages).toHaveLength(1);
+      });
+
+      it("includes system message when provided", () => {
+        const request: OperateRequest = {
+          model: PROVIDER.FIREWORKS.DEFAULT,
+          messages: [
+            {
+              content: "Hello",
+              role: LlmMessageRole.User,
+              type: LlmMessageType.Message,
+            },
+          ],
+          system: "You are helpful",
+        };
+
+        const result = fireworksAdapter.buildRequest(request);
+
+        expect(result.messages[0].role).toBe("system");
+        expect(result.messages[0].content).toBe("You are helpful");
+      });
+
+      it("appends instructions to last message", () => {
+        const request: OperateRequest = {
+          model: PROVIDER.FIREWORKS.DEFAULT,
+          messages: [
+            {
+              content: "Hello",
+              role: LlmMessageRole.User,
+              type: LlmMessageType.Message,
+            },
+          ],
+          instructions: "Be concise",
+        };
+
+        const result = fireworksAdapter.buildRequest(request);
+
+        expect(result.messages[0].content).toContain("Hello");
+        expect(result.messages[0].content).toContain("Be concise");
+      });
+
+      it("includes tools when provided", () => {
+        const request: OperateRequest = {
+          model: PROVIDER.FIREWORKS.DEFAULT,
+          messages: [],
+          tools: [
+            {
+              name: "test_tool",
+              description: "A test tool",
+              parameters: { type: "object" },
+            },
+          ],
+        };
+
+        const result = fireworksAdapter.buildRequest(request);
+
+        expect(result.tools).toHaveLength(1);
+        expect(result.tools![0].type).toBe("function");
+        expect(result.tools![0].function.name).toBe("test_tool");
+        expect(result.tool_choice).toBe("auto");
+      });
+
+      it("includes user when provided", () => {
+        const request: OperateRequest = {
+          model: PROVIDER.FIREWORKS.DEFAULT,
+          messages: [],
+          user: "user-123",
+        };
+
+        const result = fireworksAdapter.buildRequest(request);
+
+        expect(result.user).toBe("user-123");
+      });
+
+      it("handles FunctionCall messages from StreamLoop", () => {
+        const request: OperateRequest = {
+          model: PROVIDER.FIREWORKS.DEFAULT,
+          messages: [
+            {
+              role: LlmMessageRole.User,
+              content: "List items",
+              type: LlmMessageType.Message,
+            },
+            // This is how StreamLoop adds tool calls to history
+            {
+              type: LlmMessageType.FunctionCall,
+              name: "list_items",
+              arguments: "{}",
+              call_id: "call_123",
+              id: "call_123",
+            } as any,
+          ],
+        };
+
+        const result = fireworksAdapter.buildRequest(request);
+
+        expect(result.messages).toHaveLength(2);
+        expect(result.messages[0].role).toBe("user");
+        expect(result.messages[1].role).toBe("assistant");
+        expect(result.messages[1].toolCalls).toEqual([
+          {
+            id: "call_123",
+            type: "function",
+            function: {
+              name: "list_items",
+              arguments: "{}",
+            },
+          },
+        ]);
+      });
+
+      it("handles FunctionCallOutput messages from StreamLoop", () => {
+        const request: OperateRequest = {
+          model: PROVIDER.FIREWORKS.DEFAULT,
+          messages: [
+            {
+              role: LlmMessageRole.User,
+              content: "List items",
+              type: LlmMessageType.Message,
+            },
+            {
+              type: LlmMessageType.FunctionCall,
+              name: "list_items",
+              arguments: "{}",
+              call_id: "call_123",
+              id: "call_123",
+            } as any,
+            // This is how StreamLoop adds tool results to history
+            {
+              type: LlmMessageType.FunctionCallOutput,
+              output: '{"items":[{"id":"1"}]}',
+              call_id: "call_123",
+              name: "list_items",
+            } as any,
+          ],
+        };
+
+        const result = fireworksAdapter.buildRequest(request);
+
+        expect(result.messages).toHaveLength(3);
+        expect(result.messages[2].role).toBe("tool");
+        expect(result.messages[2].toolCallId).toBe("call_123");
+        expect(result.messages[2].content).toBe('{"items":[{"id":"1"}]}');
+      });
+
+      it("emits response_format json_schema when format is provided", () => {
+        const adapter = new FireworksAdapter();
+        const schema = {
+          type: "object",
+          properties: { name: { type: "string" } },
+        };
+        const request: OperateRequest = {
+          model: PROVIDER.FIREWORKS.DEFAULT,
+          messages: [
+            {
+              content: "Hello",
+              role: LlmMessageRole.User,
+              type: LlmMessageType.Message,
+            },
+          ],
+          format: schema,
+        };
+
+        const result = adapter.buildRequest(request);
+
+        expect(result.response_format).toEqual({
+          type: "json_schema",
+          json_schema: {
+            name: "response",
+            schema,
+            strict: true,
+          },
+        });
+        expect(result.tools).toBeUndefined();
+      });
+
+      it("does not emit response_format when format is absent", () => {
+        const request: OperateRequest = {
+          model: PROVIDER.FIREWORKS.DEFAULT,
+          messages: [
+            {
+              content: "Hello",
+              role: LlmMessageRole.User,
+              type: LlmMessageType.Message,
+            },
+          ],
+        };
+
+        const result = fireworksAdapter.buildRequest(request);
+
+        expect(result.response_format).toBeUndefined();
+      });
+
+      it("uses legacy structured_output tool when model is cached as unsupported", () => {
+        const adapter = new FireworksAdapter();
+        adapter.rememberModelRejectsStructuredOutput(
+          PROVIDER.FIREWORKS.DEFAULT,
+        );
+        const schema = {
+          type: "object",
+          properties: { name: { type: "string" } },
+        };
+        const request: OperateRequest = {
+          model: PROVIDER.FIREWORKS.DEFAULT,
+          messages: [
+            {
+              content: "Hello",
+              role: LlmMessageRole.User,
+              type: LlmMessageType.Message,
+            },
+          ],
+          format: schema,
+        };
+
+        const result = adapter.buildRequest(request);
+
+        expect(result.response_format).toBeUndefined();
+        expect(result.tools).toBeDefined();
+        expect(
+          result.tools!.some((t) => t.function.name === "structured_output"),
+        ).toBe(true);
+        expect(result.tool_choice).toBe("auto");
+      });
+    });
+
+    describe("parseResponse", () => {
+      it("parses response with text content", () => {
+        const response = {
+          id: "resp-123",
+          model: PROVIDER.FIREWORKS.DEFAULT,
+          choices: [
+            {
+              index: 0,
+              message: {
+                role: "assistant",
+                content: "Hello there!",
+              },
+              finishReason: "stop",
+            },
+          ],
+          usage: {
+            promptTokens: 10,
+            completionTokens: 20,
+            totalTokens: 30,
+          },
+        };
+
+        const result = fireworksAdapter.parseResponse(response);
+
+        expect(result.content).toBe("Hello there!");
+        expect(result.hasToolCalls).toBe(false);
+        expect(result.stopReason).toBe("stop");
+      });
+
+      it("detects tool use", () => {
+        const response = {
+          id: "resp-123",
+          model: PROVIDER.FIREWORKS.DEFAULT,
+          choices: [
+            {
+              index: 0,
+              message: {
+                role: "assistant",
+                content: null,
+                toolCalls: [
+                  {
+                    id: "call-123",
+                    type: "function",
+                    function: { name: "test", arguments: "{}" },
+                  },
+                ],
+              },
+              finishReason: "toolCalls",
+            },
+          ],
+          usage: {
+            promptTokens: 10,
+            completionTokens: 20,
+            totalTokens: 30,
+          },
+        };
+
+        const result = fireworksAdapter.parseResponse(response);
+
+        expect(result.hasToolCalls).toBe(true);
+      });
+    });
+
+    describe("extractToolCalls", () => {
+      it("extracts tool calls from response", () => {
+        const response = {
+          id: "resp-123",
+          model: PROVIDER.FIREWORKS.DEFAULT,
+          choices: [
+            {
+              index: 0,
+              message: {
+                role: "assistant",
+                content: null,
+                toolCalls: [
+                  {
+                    id: "call-123",
+                    type: "function",
+                    function: {
+                      name: "test_tool",
+                      arguments: '{"key":"value"}',
+                    },
+                  },
+                ],
+              },
+              finishReason: "toolCalls",
+            },
+          ],
+        };
+
+        const result = fireworksAdapter.extractToolCalls(response);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].name).toBe("test_tool");
+        expect(result[0].callId).toBe("call-123");
+        expect(result[0].arguments).toBe('{"key":"value"}');
+      });
+
+      it("returns empty array when no tool calls", () => {
+        const response = {
+          id: "resp-123",
+          model: PROVIDER.FIREWORKS.DEFAULT,
+          choices: [
+            {
+              index: 0,
+              message: {
+                role: "assistant",
+                content: "Hello",
+              },
+              finishReason: "stop",
+            },
+          ],
+        };
+
+        const result = fireworksAdapter.extractToolCalls(response);
+
+        expect(result).toHaveLength(0);
+      });
+    });
+
+    describe("extractUsage", () => {
+      it("extracts usage from camelCase response", () => {
+        const response = {
+          usage: {
+            promptTokens: 100,
+            completionTokens: 200,
+            totalTokens: 300,
+          },
+        };
+
+        const result = fireworksAdapter.extractUsage(
+          response,
+          PROVIDER.FIREWORKS.DEFAULT,
+        );
+
+        expect(result.input).toBe(100);
+        expect(result.output).toBe(200);
+        expect(result.total).toBe(300);
+        expect(result.reasoning).toBe(0);
+        expect(result.provider).toBe(PROVIDER.FIREWORKS.NAME);
+        expect(result.model).toBe(PROVIDER.FIREWORKS.DEFAULT);
+      });
+
+      it("extracts usage from snake_case response", () => {
+        const response = {
+          usage: {
+            prompt_tokens: 11,
+            completion_tokens: 22,
+            total_tokens: 33,
+          },
+        };
+
+        const result = fireworksAdapter.extractUsage(
+          response,
+          PROVIDER.FIREWORKS.DEFAULT,
+        );
+
+        expect(result.input).toBe(11);
+        expect(result.output).toBe(22);
+        expect(result.total).toBe(33);
+      });
+
+      it("extracts reasoning tokens from completionTokensDetails", () => {
+        const response = {
+          usage: {
+            promptTokens: 10,
+            completionTokens: 20,
+            totalTokens: 30,
+            completionTokensDetails: { reasoningTokens: 7 },
+          },
+        };
+
+        const result = fireworksAdapter.extractUsage(
+          response,
+          PROVIDER.FIREWORKS.DEFAULT,
+        );
+
+        expect(result.reasoning).toBe(7);
+      });
+
+      it("returns zeros when usage is missing", () => {
+        const response = {};
+
+        const result = fireworksAdapter.extractUsage(
+          response,
+          PROVIDER.FIREWORKS.DEFAULT,
+        );
+
+        expect(result.input).toBe(0);
+        expect(result.output).toBe(0);
+        expect(result.total).toBe(0);
+      });
+    });
+  });
+
+  // Features
+  describe("Features", () => {
+    describe("Effort", () => {
+      it("sets top-level reasoning_effort translating the neutral scale", () => {
+        const result = fireworksAdapter.buildRequest({
+          model: PROVIDER.FIREWORKS.DEFAULT,
+          messages: [
+            {
+              content: "Hello",
+              role: LlmMessageRole.User,
+              type: LlmMessageType.Message,
+            },
+          ],
+          effort: "medium",
+        } as OperateRequest);
+
+        expect(result.reasoning_effort).toBe("medium");
+        expect(
+          (result as unknown as Record<string, unknown>).reasoning,
+        ).toBeUndefined();
+      });
+
+      it("papers highest onto high and logs at debug", () => {
+        const debug = vi.spyOn(log, "debug").mockImplementation(() => {});
+        const result = fireworksAdapter.buildRequest({
+          model: PROVIDER.FIREWORKS.DEFAULT,
+          messages: [],
+          effort: "highest",
+        } as OperateRequest);
+
+        expect(result.reasoning_effort).toBe("high");
+        expect(debug).toHaveBeenCalledTimes(1);
+        expect(debug.mock.calls[0][0]).toContain("highest");
+        vi.restoreAllMocks();
+      });
+
+      it("papers lowest onto low", () => {
+        const result = fireworksAdapter.buildRequest({
+          model: PROVIDER.FIREWORKS.DEFAULT,
+          messages: [],
+          effort: "lowest",
+        } as OperateRequest);
+
+        expect(result.reasoning_effort).toBe("low");
+      });
+
+      it("omits reasoning_effort when effort is absent", () => {
+        const result = fireworksAdapter.buildRequest({
+          model: PROVIDER.FIREWORKS.DEFAULT,
+          messages: [],
+        });
+
+        expect(result.reasoning_effort).toBeUndefined();
+      });
+    });
+
+    describe("Content Conversion", () => {
+      it("converts input text and image content", () => {
+        const request: OperateRequest = {
+          model: PROVIDER.FIREWORKS.DEFAULT,
+          messages: [
+            {
+              role: LlmMessageRole.User,
+              type: LlmMessageType.Message,
+              content: [
+                { type: LlmMessageType.InputText, text: "What is this?" },
+                {
+                  type: LlmMessageType.InputImage,
+                  image_url: "https://example.com/cat.png",
+                },
+              ],
+            } as any,
+          ],
+        };
+
+        const result = fireworksAdapter.buildRequest(request);
+
+        expect(result.messages[0].content).toEqual([
+          { type: "text", text: "What is this?" },
+          {
+            type: "image_url",
+            imageUrl: { url: "https://example.com/cat.png" },
+          },
+        ]);
+      });
+
+      it("warns and drops input files (unsupported by Fireworks)", () => {
+        const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
+        const request: OperateRequest = {
+          model: PROVIDER.FIREWORKS.DEFAULT,
+          messages: [
+            {
+              role: LlmMessageRole.User,
+              type: LlmMessageType.Message,
+              content: [
+                { type: LlmMessageType.InputText, text: "Read this" },
+                {
+                  type: LlmMessageType.InputFile,
+                  filename: "doc.pdf",
+                  file_data: "data:application/pdf;base64,AAAA",
+                },
+              ],
+            } as any,
+          ],
+        };
+
+        const result = fireworksAdapter.buildRequest(request);
+
+        expect(result.messages[0].content).toEqual([
+          { type: "text", text: "Read this" },
+        ]);
+        expect(warn).toHaveBeenCalled();
+        vi.restoreAllMocks();
+      });
+
+      it("warns and drops image content missing image_url", () => {
+        const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
+        const request: OperateRequest = {
+          model: PROVIDER.FIREWORKS.DEFAULT,
+          messages: [
+            {
+              role: LlmMessageRole.User,
+              type: LlmMessageType.Message,
+              content: [{ type: LlmMessageType.InputImage }],
+            } as any,
+          ],
+        };
+
+        const result = fireworksAdapter.buildRequest(request);
+
+        expect(result.messages[0].content).toBe("");
+        expect(warn).toHaveBeenCalled();
+        vi.restoreAllMocks();
+      });
+    });
+
+    describe("formatTools", () => {
+      it("formats toolkit to provider definitions", () => {
+        const toolkit = new Toolkit([
+          {
+            name: "test",
+            description: "Test tool",
+            parameters: { type: "object" },
+            type: "function",
+            call: vi.fn(),
+          },
+        ]);
+
+        const result = fireworksAdapter.formatTools(toolkit);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].name).toBe("test");
+        expect(result[0].description).toBe("Test tool");
+      });
+
+      it("does not inject a structured_output tool when schema provided", () => {
+        // Native response_format replaces the fake-tool injection.
+        // The legacy fake tool is only added in buildRequest as a fallback.
+        const toolkit = new Toolkit([
+          {
+            name: "test",
+            description: "Test tool",
+            parameters: { type: "object" },
+            type: "function",
+            call: vi.fn(),
+          },
+        ]);
+        const schema = {
+          type: "object",
+          properties: { name: { type: "string" } },
+        };
+
+        const result = fireworksAdapter.formatTools(toolkit, schema);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].name).toBe("test");
+        expect(result.some((t) => t.name === "structured_output")).toBe(false);
+      });
+    });
+
+    describe("formatToolResult", () => {
+      it("formats tool result correctly", () => {
+        const toolCall = {
+          callId: "call-123",
+          name: "test_tool",
+          arguments: "{}",
+          raw: {},
+        };
+        const result = {
+          callId: "call-123",
+          output: '{"result": "success"}',
+          success: true,
+        };
+
+        const formatted = fireworksAdapter.formatToolResult(toolCall, result);
+
+        expect(formatted.toolCallId).toBe("call-123");
+        expect(formatted.content).toBe('{"result": "success"}');
+        expect(formatted.role).toBe("tool");
+      });
+    });
+
+    describe("appendToolResult", () => {
+      it("appends assistant message and tool result", () => {
+        const request = {
+          model: PROVIDER.FIREWORKS.DEFAULT,
+          messages: [{ role: "user", content: "Hello" }],
+        };
+        const toolCall = {
+          callId: "call-123",
+          name: "test_tool",
+          arguments: "{}",
+          raw: {
+            id: "call-123",
+            type: "function",
+            function: { name: "test_tool", arguments: "{}" },
+          },
+        };
+        const result = {
+          callId: "call-123",
+          output: '{"result": "success"}',
+          success: true,
+        };
+
+        const updated = fireworksAdapter.appendToolResult(
+          request,
+          toolCall,
+          result,
+        );
+
+        expect(updated.messages).toHaveLength(3);
+        expect(updated.messages[1].role).toBe("assistant");
+        expect(updated.messages[1].toolCalls).toBeDefined();
+        expect(updated.messages[2].role).toBe("tool");
+        expect(updated.messages[2].toolCallId).toBe("call-123");
+      });
+    });
+
+    describe("isComplete", () => {
+      it("returns true when no tool calls", () => {
+        const response = {
+          choices: [
+            {
+              message: {
+                role: "assistant",
+                content: "Done",
+              },
+              finishReason: "stop",
+            },
+          ],
+        };
+
+        expect(fireworksAdapter.isComplete(response)).toBe(true);
+      });
+
+      it("returns false when tool calls present", () => {
+        const response = {
+          choices: [
+            {
+              message: {
+                role: "assistant",
+                content: null,
+                toolCalls: [
+                  {
+                    id: "call-123",
+                    type: "function",
+                    function: { name: "test", arguments: "{}" },
+                  },
+                ],
+              },
+              finishReason: "toolCalls",
+            },
+          ],
+        };
+
+        expect(fireworksAdapter.isComplete(response)).toBe(false);
+      });
+    });
+
+    describe("hasStructuredOutput", () => {
+      it("returns true when native annotation is set with parseable JSON content", () => {
+        const response = {
+          choices: [
+            {
+              message: {
+                role: "assistant",
+                content: '{"name":"John"}',
+              },
+              finishReason: "stop",
+            },
+          ],
+          __jaypieStructuredOutput: true,
+        };
+
+        expect(fireworksAdapter.hasStructuredOutput(response)).toBe(true);
+      });
+
+      it("returns false when native annotation is set but content is not JSON", () => {
+        const response = {
+          choices: [
+            {
+              message: {
+                role: "assistant",
+                content: "I cannot comply with that request.",
+              },
+              finishReason: "stop",
+            },
+          ],
+          __jaypieStructuredOutput: true,
+        };
+
+        expect(fireworksAdapter.hasStructuredOutput(response)).toBe(false);
+      });
+
+      it("returns false when no tool calls", () => {
+        const response = {
+          choices: [
+            {
+              message: {
+                role: "assistant",
+                content: "Hello",
+              },
+              finishReason: "stop",
+            },
+          ],
+        };
+
+        expect(fireworksAdapter.hasStructuredOutput(response)).toBe(false);
+      });
+
+      describe("Fallback Path", () => {
+        it("returns true when structured_output tool is used", () => {
+          const response = {
+            choices: [
+              {
+                message: {
+                  role: "assistant",
+                  content: null,
+                  toolCalls: [
+                    {
+                      id: "call-123",
+                      type: "function",
+                      function: {
+                        name: "structured_output",
+                        arguments: '{"key":"value"}',
+                      },
+                    },
+                  ],
+                },
+                finishReason: "toolCalls",
+              },
+            ],
+          };
+
+          expect(fireworksAdapter.hasStructuredOutput(response)).toBe(true);
+        });
+
+        it("returns false for regular tool use", () => {
+          const response = {
+            choices: [
+              {
+                message: {
+                  role: "assistant",
+                  content: null,
+                  toolCalls: [
+                    {
+                      id: "call-123",
+                      type: "function",
+                      function: { name: "other_tool", arguments: "{}" },
+                    },
+                  ],
+                },
+                finishReason: "toolCalls",
+              },
+            ],
+          };
+
+          expect(fireworksAdapter.hasStructuredOutput(response)).toBe(false);
+        });
+      });
+    });
+
+    describe("extractStructuredOutput", () => {
+      it("parses message content as JSON when native annotation is set", () => {
+        const response = {
+          choices: [
+            {
+              message: {
+                role: "assistant",
+                content: '{"name":"John","age":30}',
+              },
+              finishReason: "stop",
+            },
+          ],
+          __jaypieStructuredOutput: true,
+        };
+
+        const result = fireworksAdapter.extractStructuredOutput(response);
+
+        expect(result).toEqual({ name: "John", age: 30 });
+      });
+
+      it("returns undefined when native content is not parseable JSON", () => {
+        const response = {
+          choices: [
+            {
+              message: {
+                role: "assistant",
+                content: "not valid json",
+              },
+              finishReason: "stop",
+            },
+          ],
+          __jaypieStructuredOutput: true,
+        };
+
+        const result = fireworksAdapter.extractStructuredOutput(response);
+
+        expect(result).toBeUndefined();
+      });
+
+      it("returns undefined when native content is empty", () => {
+        const response = {
+          choices: [
+            {
+              message: {
+                role: "assistant",
+                content: "",
+              },
+              finishReason: "stop",
+            },
+          ],
+          __jaypieStructuredOutput: true,
+        };
+
+        const result = fireworksAdapter.extractStructuredOutput(response);
+
+        expect(result).toBeUndefined();
+      });
+
+      it("returns undefined for non-structured responses", () => {
+        const response = {
+          choices: [
+            {
+              message: {
+                role: "assistant",
+                content: "Hello",
+              },
+              finishReason: "stop",
+            },
+          ],
+        };
+
+        const result = fireworksAdapter.extractStructuredOutput(response);
+
+        expect(result).toBeUndefined();
+      });
+
+      describe("Fallback Path", () => {
+        it("extracts structured output from response", () => {
+          const response = {
+            choices: [
+              {
+                message: {
+                  role: "assistant",
+                  content: null,
+                  toolCalls: [
+                    {
+                      id: "call-123",
+                      type: "function",
+                      function: {
+                        name: "structured_output",
+                        arguments: '{"name":"John","age":30}',
+                      },
+                    },
+                  ],
+                },
+                finishReason: "toolCalls",
+              },
+            ],
+          };
+
+          const result = fireworksAdapter.extractStructuredOutput(response);
+
+          expect(result).toEqual({ name: "John", age: 30 });
+        });
+
+        it("returns undefined for invalid JSON", () => {
+          const response = {
+            choices: [
+              {
+                message: {
+                  role: "assistant",
+                  content: null,
+                  toolCalls: [
+                    {
+                      id: "call-123",
+                      type: "function",
+                      function: {
+                        name: "structured_output",
+                        arguments: "not valid json",
+                      },
+                    },
+                  ],
+                },
+                finishReason: "toolCalls",
+              },
+            ],
+          };
+
+          const result = fireworksAdapter.extractStructuredOutput(response);
+
+          expect(result).toBeUndefined();
+        });
+      });
+    });
+
+    describe("Structured-output fallback", () => {
+      it("retries with fake tool when model rejects native response_format", async () => {
+        const adapter = new FireworksAdapter();
+        const schema = {
+          type: "object",
+          properties: { name: { type: "string" } },
+        };
+        const error = Object.assign(
+          new Error("response_format not supported"),
+          {
+            status: 400,
+          },
+        );
+        const successResponse = {
+          id: "resp-1",
+          object: "chat.completion",
+          created: 0,
+          model: PROVIDER.FIREWORKS.DEFAULT,
+          choices: [
+            {
+              index: 0,
+              message: {
+                role: "assistant" as const,
+                content: null,
+                toolCalls: [
+                  {
+                    id: "call-1",
+                    type: "function" as const,
+                    function: {
+                      name: "structured_output",
+                      arguments: '{"name":"Jane"}',
+                    },
+                  },
+                ],
+              },
+              finishReason: "toolCalls",
+            },
+          ],
+        };
+        const mockSend = vi
+          .fn()
+          .mockRejectedValueOnce(error)
+          .mockResolvedValueOnce(successResponse);
+        const mockClient = { chatCompletion: mockSend };
+        const request: OperateRequest = {
+          model: PROVIDER.FIREWORKS.DEFAULT,
+          messages: [
+            {
+              content: "Hi",
+              role: LlmMessageRole.User,
+              type: LlmMessageType.Message,
+            },
+          ],
+          format: schema,
+        };
+
+        const built = adapter.buildRequest(request);
+        expect(built.response_format).toBeDefined();
+
+        const result = await adapter.executeRequest(mockClient, built);
+
+        expect(mockSend).toHaveBeenCalledTimes(2);
+        const fallbackCallParams = mockSend.mock.calls[1][0];
+        expect(fallbackCallParams.response_format).toBeUndefined();
+        expect(fallbackCallParams.tools).toBeDefined();
+        expect(
+          fallbackCallParams.tools.some(
+            (t: { function: { name: string } }) =>
+              t.function.name === "structured_output",
+          ),
+        ).toBe(true);
+        expect(result).toBe(successResponse);
+      });
+
+      it("caches the model so subsequent calls use the fallback up-front", async () => {
+        const adapter = new FireworksAdapter();
+        adapter.rememberModelRejectsStructuredOutput(
+          PROVIDER.FIREWORKS.DEFAULT,
+        );
+        const schema = {
+          type: "object",
+          properties: { name: { type: "string" } },
+        };
+        const request: OperateRequest = {
+          model: PROVIDER.FIREWORKS.DEFAULT,
+          messages: [],
+          format: schema,
+        };
+
+        const built = adapter.buildRequest(request);
+
+        expect(built.response_format).toBeUndefined();
+        expect(built.tools).toBeDefined();
+        expect(
+          built.tools!.some((t) => t.function.name === "structured_output"),
+        ).toBe(true);
+      });
+
+      it("does not fall back on unrelated 400 errors", async () => {
+        const adapter = new FireworksAdapter();
+        const schema = {
+          type: "object",
+          properties: { name: { type: "string" } },
+        };
+        const error = Object.assign(new Error("invalid api key"), {
+          status: 400,
+        });
+        const mockSend = vi.fn().mockRejectedValue(error);
+        const mockClient = { chatCompletion: mockSend };
+        const request: OperateRequest = {
+          model: PROVIDER.FIREWORKS.DEFAULT,
+          messages: [],
+          format: schema,
+        };
+
+        const built = adapter.buildRequest(request);
+
+        await expect(adapter.executeRequest(mockClient, built)).rejects.toThrow(
+          "invalid api key",
+        );
+        expect(mockSend).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe("Temperature fallback", () => {
+      it("retries without temperature when model rejects it", async () => {
+        const adapter = new FireworksAdapter();
+        const error = Object.assign(
+          new Error("temperature is not supported for this model"),
+          { status: 400 },
+        );
+        const successResponse = {
+          id: "resp-1",
+          choices: [{ message: { role: "assistant", content: "Hi" } }],
+        } as unknown as Awaited<ReturnType<typeof adapter.executeRequest>>;
+        const mockSend = vi
+          .fn()
+          .mockRejectedValueOnce(error)
+          .mockResolvedValueOnce(successResponse);
+        const mockClient = { chatCompletion: mockSend };
+        const request: OperateRequest = {
+          model: PROVIDER.FIREWORKS.DEFAULT,
+          messages: [],
+          temperature: 0.7,
+        };
+
+        const built = adapter.buildRequest(request);
+        expect((built as unknown as Record<string, unknown>).temperature).toBe(
+          0.7,
+        );
+
+        const result = await adapter.executeRequest(mockClient, built);
+
+        expect(mockSend).toHaveBeenCalledTimes(2);
+        const retryParams = mockSend.mock.calls[1][0];
+        expect(retryParams.temperature).toBeUndefined();
+        expect(result).toBe(successResponse);
+      });
+
+      it("strips temperature up-front once the model is cached", () => {
+        const adapter = new FireworksAdapter();
+        adapter.rememberModelRejectsTemperature(PROVIDER.FIREWORKS.DEFAULT);
+        const request: OperateRequest = {
+          model: PROVIDER.FIREWORKS.DEFAULT,
+          messages: [],
+          temperature: 0.7,
+        };
+
+        const built = adapter.buildRequest(request) as unknown as Record<
+          string,
+          unknown
+        >;
+
+        expect(built.temperature).toBeUndefined();
+      });
+    });
+
+    describe("executeStreamRequest", () => {
+      async function collect(iterable: AsyncIterable<unknown>) {
+        const chunks: any[] = [];
+        for await (const chunk of iterable) {
+          chunks.push(chunk);
+        }
+        return chunks;
+      }
+
+      it("yields text chunks from content deltas and a Done chunk with usage", async () => {
+        async function* fakeStream() {
+          yield { choices: [{ delta: { content: "He" } }] };
+          yield { choices: [{ delta: { content: "llo" } }] };
+          yield {
+            choices: [{ delta: {}, finish_reason: "stop" }],
+            usage: { prompt_tokens: 3, completion_tokens: 5 },
+          };
+        }
+        const mockClient = {
+          streamChatCompletion: vi.fn(() => fakeStream()),
+        };
+        const request = {
+          model: PROVIDER.FIREWORKS.DEFAULT,
+          messages: [],
+        };
+
+        const chunks = await collect(
+          fireworksAdapter.executeStreamRequest(mockClient, request),
+        );
+
+        expect(chunks).toHaveLength(3);
+        expect(chunks[0]).toEqual({
+          type: LlmStreamChunkType.Text,
+          content: "He",
+        });
+        expect(chunks[1]).toEqual({
+          type: LlmStreamChunkType.Text,
+          content: "llo",
+        });
+        expect(chunks[2].type).toBe(LlmStreamChunkType.Done);
+        expect(chunks[2].usage).toEqual([
+          {
+            input: 3,
+            output: 5,
+            reasoning: 0,
+            total: 8,
+            provider: PROVIDER.FIREWORKS.NAME,
+            model: PROVIDER.FIREWORKS.DEFAULT,
+          },
+        ]);
+      });
+
+      it("assembles tool-call deltas into a single ToolCall chunk", async () => {
+        async function* fakeStream() {
+          yield {
+            choices: [
+              {
+                delta: {
+                  tool_calls: [
+                    { id: "call-1", function: { name: "test_tool" } },
+                  ],
+                },
+              },
+            ],
+          };
+          yield {
+            choices: [
+              {
+                delta: {
+                  tool_calls: [{ function: { arguments: '{"a"' } }],
+                },
+              },
+            ],
+          };
+          yield {
+            choices: [
+              {
+                delta: {
+                  tool_calls: [{ function: { arguments: ":1}" } }],
+                },
+                finish_reason: "tool_calls",
+              },
+            ],
+          };
+        }
+        const mockClient = {
+          streamChatCompletion: vi.fn(() => fakeStream()),
+        };
+        const request = {
+          model: PROVIDER.FIREWORKS.DEFAULT,
+          messages: [],
+        };
+
+        const chunks = await collect(
+          fireworksAdapter.executeStreamRequest(mockClient, request),
+        );
+
+        const toolCallChunks = chunks.filter(
+          (chunk) => chunk.type === LlmStreamChunkType.ToolCall,
+        );
+        expect(toolCallChunks).toHaveLength(1);
+        expect(toolCallChunks[0].toolCall).toEqual({
+          id: "call-1",
+          name: "test_tool",
+          arguments: '{"a":1}',
+        });
+        expect(chunks[chunks.length - 1].type).toBe(LlmStreamChunkType.Done);
+      });
+    });
+
+    describe("classifyError", () => {
+      it("classifies rate limit error by status code", () => {
+        const error = { status: 429, message: "Too many requests" };
+
+        const result = fireworksAdapter.classifyError(error);
+
+        expect(result.category).toBe(ErrorCategory.RateLimit);
+        expect(result.shouldRetry).toBe(false);
+      });
+
+      it("classifies retryable error by status code", () => {
+        const error = { status: 500, message: "Internal server error" };
+
+        const result = fireworksAdapter.classifyError(error);
+
+        expect(result.category).toBe(ErrorCategory.Retryable);
+        expect(result.shouldRetry).toBe(true);
+      });
+
+      it("classifies 502 as retryable", () => {
+        const error = { status: 502, message: "Bad gateway" };
+
+        const result = fireworksAdapter.classifyError(error);
+
+        expect(result.category).toBe(ErrorCategory.Retryable);
+        expect(result.shouldRetry).toBe(true);
+      });
+
+      it("classifies 503 as retryable", () => {
+        const error = { status: 503, message: "Service unavailable" };
+
+        const result = fireworksAdapter.classifyError(error);
+
+        expect(result.category).toBe(ErrorCategory.Retryable);
+        expect(result.shouldRetry).toBe(true);
+      });
+
+      it("classifies unrecoverable error by status code", () => {
+        const error = { status: 401, message: "Unauthorized" };
+
+        const result = fireworksAdapter.classifyError(error);
+
+        expect(result.category).toBe(ErrorCategory.Unrecoverable);
+        expect(result.shouldRetry).toBe(false);
+      });
+
+      it("classifies 400 as unrecoverable", () => {
+        const error = { status: 400, message: "Bad request" };
+
+        const result = fireworksAdapter.classifyError(error);
+
+        expect(result.category).toBe(ErrorCategory.Unrecoverable);
+        expect(result.shouldRetry).toBe(false);
+      });
+
+      it("classifies rate limit error by message", () => {
+        const error = new Error("Rate limit exceeded");
+
+        const result = fireworksAdapter.classifyError(error);
+
+        expect(result.category).toBe(ErrorCategory.RateLimit);
+        expect(result.shouldRetry).toBe(false);
+      });
+
+      it("classifies transient network errors as retryable", () => {
+        const error = Object.assign(new Error("socket hang up"), {
+          code: "ECONNRESET",
+        });
+
+        const result = fireworksAdapter.classifyError(error);
+
+        expect(result.category).toBe(ErrorCategory.Retryable);
+        expect(result.shouldRetry).toBe(true);
+      });
+
+      it("classifies unknown error as retryable", () => {
+        const error = new Error("Unknown error");
+
+        const result = fireworksAdapter.classifyError(error);
+
+        expect(result.category).toBe(ErrorCategory.Unknown);
+        expect(result.shouldRetry).toBe(true);
+      });
+    });
+
+    describe("responseToHistoryItems", () => {
+      it("returns assistant message for text response", () => {
+        const response = {
+          choices: [
+            {
+              message: {
+                role: "assistant",
+                content: "Hello there!",
+              },
+              finishReason: "stop",
+            },
+          ],
+        };
+
+        const result = fireworksAdapter.responseToHistoryItems(response);
+
+        expect(result).toHaveLength(1);
+        expect((result[0] as { content: string }).content).toBe("Hello there!");
+        expect((result[0] as { role: string }).role).toBe(
+          LlmMessageRole.Assistant,
+        );
+      });
+
+      it("preserves reasoning from reasoning_content", () => {
+        const response = {
+          choices: [
+            {
+              message: {
+                role: "assistant",
+                content: "Answer",
+                reasoning_content: "Thinking it through",
+              },
+              finishReason: "stop",
+            },
+          ],
+        };
+
+        const result = fireworksAdapter.responseToHistoryItems(response);
+
+        expect(result).toHaveLength(1);
+        expect((result[0] as { reasoning?: string }).reasoning).toBe(
+          "Thinking it through",
+        );
+      });
+
+      it("falls back to message.reasoning when reasoning_content absent", () => {
+        const response = {
+          choices: [
+            {
+              message: {
+                role: "assistant",
+                content: "Answer",
+                reasoning: "Alternate reasoning field",
+              },
+              finishReason: "stop",
+            },
+          ],
+        };
+
+        const result = fireworksAdapter.responseToHistoryItems(response);
+
+        expect((result[0] as { reasoning?: string }).reasoning).toBe(
+          "Alternate reasoning field",
+        );
+      });
+
+      it("returns empty array for tool use response", () => {
+        const response = {
+          choices: [
+            {
+              message: {
+                role: "assistant",
+                content: null,
+                toolCalls: [
+                  {
+                    id: "call-123",
+                    type: "function",
+                    function: { name: "test", arguments: "{}" },
+                  },
+                ],
+              },
+              finishReason: "toolCalls",
+            },
+          ],
+        };
+
+        const result = fireworksAdapter.responseToHistoryItems(response);
+
+        expect(result).toHaveLength(0);
+      });
+    });
+  });
+
+  // AbortSignal Support
+  describe("AbortSignal Support", () => {
+    describe("executeRequest", () => {
+      it("passes signal to client call when provided", async () => {
+        const mockSend = vi.fn().mockResolvedValue({
+          id: "resp-1",
+          choices: [{ message: { role: "assistant", content: "Hi" } }],
+        });
+        const mockClient = { chatCompletion: mockSend };
+        const request = {
+          model: PROVIDER.FIREWORKS.DEFAULT,
+          messages: [{ role: "user", content: "Hello" }],
+        };
+        const controller = new AbortController();
+
+        await fireworksAdapter.executeRequest(
+          mockClient,
+          request,
+          controller.signal,
+        );
+
+        expect(mockSend).toHaveBeenCalledTimes(1);
+        const [, options] = mockSend.mock.calls[0];
+        expect(options).toEqual({ signal: controller.signal });
+      });
+
+      it("suppresses errors after signal is aborted", async () => {
+        const controller = new AbortController();
+        controller.abort("retry");
+
+        const mockSend = vi.fn().mockRejectedValue(new TypeError("terminated"));
+        const mockClient = { chatCompletion: mockSend };
+        const request = {
+          model: PROVIDER.FIREWORKS.DEFAULT,
+          messages: [{ role: "user", content: "Hello" }],
+        };
+
+        const result = await fireworksAdapter.executeRequest(
+          mockClient,
+          request,
+          controller.signal,
+        );
+
+        expect(result).toBeUndefined();
+      });
+
+      it("throws errors when signal is not aborted", async () => {
+        const controller = new AbortController();
+
+        const mockSend = vi.fn().mockRejectedValue(new Error("real error"));
+        const mockClient = { chatCompletion: mockSend };
+        const request = {
+          model: PROVIDER.FIREWORKS.DEFAULT,
+          messages: [{ role: "user", content: "Hello" }],
+        };
+
+        await expect(
+          fireworksAdapter.executeRequest(
+            mockClient,
+            request,
+            controller.signal,
+          ),
+        ).rejects.toThrow("real error");
+      });
+
+      it("does not pass options when no signal provided", async () => {
+        const mockSend = vi.fn().mockResolvedValue({
+          id: "resp-1",
+          choices: [{ message: { role: "assistant", content: "Hi" } }],
+        });
+        const mockClient = { chatCompletion: mockSend };
+        const request = {
+          model: PROVIDER.FIREWORKS.DEFAULT,
+          messages: [{ role: "user", content: "Hello" }],
+        };
+
+        await fireworksAdapter.executeRequest(mockClient, request);
+
+        expect(mockSend).toHaveBeenCalledTimes(1);
+        const [, options] = mockSend.mock.calls[0];
+        expect(options).toBeUndefined();
+      });
+    });
+  });
+
+  // Specific Scenarios
+  describe("Specific Scenarios", () => {
+    it("uses default model when not specified", () => {
+      const request: OperateRequest = {
+        model: "",
+        messages: [],
+      };
+
+      const result = fireworksAdapter.buildRequest(request);
+
+      expect(result.model).toBe(PROVIDER.FIREWORKS.DEFAULT);
+    });
+
+    it("sets temperature on request when provided", () => {
+      const request: OperateRequest = {
+        model: PROVIDER.FIREWORKS.DEFAULT,
+        messages: [
+          {
+            content: "Hello",
+            role: LlmMessageRole.User,
+            type: LlmMessageType.Message,
+          },
+        ],
+        temperature: 0.7,
+      };
+
+      const result = fireworksAdapter.buildRequest(
+        request,
+      ) as unknown as Record<string, unknown>;
+
+      expect(result.temperature).toBe(0.7);
+    });
+
+    it("temperature takes precedence over providerOptions", () => {
+      const request: OperateRequest = {
+        model: PROVIDER.FIREWORKS.DEFAULT,
+        messages: [],
+        providerOptions: { temperature: 0.3 },
+        temperature: 0.9,
+      };
+
+      const result = fireworksAdapter.buildRequest(
+        request,
+      ) as unknown as Record<string, unknown>;
+
+      expect(result.temperature).toBe(0.9);
+    });
+
+    it("does not set temperature when not provided", () => {
+      const request: OperateRequest = {
+        model: PROVIDER.FIREWORKS.DEFAULT,
+        messages: [],
+      };
+
+      const result = fireworksAdapter.buildRequest(
+        request,
+      ) as unknown as Record<string, unknown>;
+
+      expect(result.temperature).toBeUndefined();
+    });
+
+    it("sets tool_choice to auto", () => {
+      const request: OperateRequest = {
+        model: PROVIDER.FIREWORKS.DEFAULT,
+        messages: [],
+        tools: [
+          {
+            name: "structured_output",
+            description: "Structured output",
+            parameters: { type: "object" },
+          },
+        ],
+      };
+
+      const result = fireworksAdapter.buildRequest(request);
+
+      expect(result.tool_choice).toBe("auto");
+    });
+
+    it("handles multiple tool calls in a single response", () => {
+      const response = {
+        choices: [
+          {
+            message: {
+              role: "assistant",
+              content: null,
+              toolCalls: [
+                {
+                  id: "call-1",
+                  type: "function",
+                  function: { name: "tool_1", arguments: '{"a":1}' },
+                },
+                {
+                  id: "call-2",
+                  type: "function",
+                  function: { name: "tool_2", arguments: '{"b":2}' },
+                },
+              ],
+            },
+            finishReason: "toolCalls",
+          },
+        ],
+      };
+
+      const result = fireworksAdapter.extractToolCalls(response);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].name).toBe("tool_1");
+      expect(result[1].name).toBe("tool_2");
+    });
+
+    it("converts messages with different roles correctly", () => {
+      const request: OperateRequest = {
+        model: PROVIDER.FIREWORKS.DEFAULT,
+        messages: [
+          {
+            content: "System prompt",
+            role: "system" as any,
+          },
+          {
+            content: "User message",
+            role: "user" as any,
+          },
+          {
+            content: "Assistant response",
+            role: "assistant" as any,
+          },
+        ],
+      };
+
+      const result = fireworksAdapter.buildRequest(request);
+
+      expect(result.messages[0].role).toBe("system");
+      expect(result.messages[1].role).toBe("user");
+      expect(result.messages[2].role).toBe("assistant");
+    });
+  });
+});

--- a/packages/llm/src/operate/adapters/__tests__/FireworksAdapter.spec.ts
+++ b/packages/llm/src/operate/adapters/__tests__/FireworksAdapter.spec.ts
@@ -292,6 +292,43 @@ describe("FireworksAdapter", () => {
         ).toBe(true);
         expect(result.tool_choice).toBe("auto");
       });
+
+      it("uses structured_output tool emulation when format and tools are combined", () => {
+        const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
+        const adapter = new FireworksAdapter();
+        const schema = {
+          type: "object",
+          properties: { name: { type: "string" } },
+        };
+        const request: OperateRequest = {
+          model: PROVIDER.FIREWORKS.DEFAULT,
+          messages: [
+            {
+              content: "Hello",
+              role: LlmMessageRole.User,
+              type: LlmMessageType.Message,
+            },
+          ],
+          format: schema,
+          tools: [
+            {
+              name: "roll",
+              description: "Roll dice",
+              parameters: { type: "object" },
+            },
+          ],
+        };
+
+        const result = adapter.buildRequest(request);
+
+        // Fireworks rejects response_format combined with tools
+        expect(result.response_format).toBeUndefined();
+        expect(result.tools).toHaveLength(2);
+        expect(result.tools![0].function.name).toBe("roll");
+        expect(result.tools![1].function.name).toBe("structured_output");
+        expect(warn).toHaveBeenCalled();
+        vi.restoreAllMocks();
+      });
     });
 
     describe("parseResponse", () => {

--- a/packages/llm/src/operate/adapters/__tests__/effort.spec.ts
+++ b/packages/llm/src/operate/adapters/__tests__/effort.spec.ts
@@ -9,6 +9,7 @@ import {
 } from "../../../types/LlmProvider.interface.js";
 import {
   toAnthropicEffort,
+  toFireworksEffort,
   toGeminiThinkingBudget,
   toGeminiThinkingLevel,
   toOpenAiEffort,
@@ -146,6 +147,29 @@ describe("effort mapping util", () => {
       expect(value).toBeLessThanOrEqual(24576);
       expect(value).toBeGreaterThanOrEqual(512);
     }
+  });
+
+  it("Fireworks collapses ends onto low..high", () => {
+    expect(toFireworksEffort(EFFORT.LOWEST)).toEqual({
+      papered: true,
+      value: "low",
+    });
+    expect(toFireworksEffort(EFFORT.LOW)).toEqual({
+      papered: false,
+      value: "low",
+    });
+    expect(toFireworksEffort(EFFORT.MEDIUM)).toEqual({
+      papered: false,
+      value: "medium",
+    });
+    expect(toFireworksEffort(EFFORT.HIGH)).toEqual({
+      papered: false,
+      value: "high",
+    });
+    expect(toFireworksEffort(EFFORT.HIGHEST)).toEqual({
+      papered: true,
+      value: "high",
+    });
   });
 
   it("OpenRouter spans minimal..xhigh without papering", () => {

--- a/packages/llm/src/operate/adapters/index.ts
+++ b/packages/llm/src/operate/adapters/index.ts
@@ -3,6 +3,7 @@ export type { ProviderAdapter } from "./ProviderAdapter.interface.js";
 
 export { AnthropicAdapter, anthropicAdapter } from "./AnthropicAdapter.js";
 export { BedrockAdapter, bedrockAdapter } from "./BedrockAdapter.js";
+export { FireworksAdapter, fireworksAdapter } from "./FireworksAdapter.js";
 export { GoogleAdapter, googleAdapter } from "./GoogleAdapter.js";
 export { OpenAiAdapter, openAiAdapter } from "./OpenAiAdapter.js";
 export { OpenRouterAdapter, openRouterAdapter } from "./OpenRouterAdapter.js";

--- a/packages/llm/src/operate/index.ts
+++ b/packages/llm/src/operate/index.ts
@@ -5,6 +5,8 @@ export {
   BaseProviderAdapter,
   BedrockAdapter,
   bedrockAdapter,
+  FireworksAdapter,
+  fireworksAdapter,
   GoogleAdapter,
   googleAdapter,
   OpenAiAdapter,

--- a/packages/llm/src/providers/fireworks/FireworksProvider.class.ts
+++ b/packages/llm/src/providers/fireworks/FireworksProvider.class.ts
@@ -1,0 +1,163 @@
+import { JsonObject } from "@jaypie/types";
+import type { FireworksClient } from "./client.js";
+import {
+  createOperateLoop,
+  createStreamLoop,
+  fireworksAdapter,
+  OperateLoop,
+  StreamLoop,
+} from "../../operate/index.js";
+import {
+  LlmHistory,
+  LlmInputMessage,
+  LlmMessageOptions,
+  LlmOperateOptions,
+  LlmOperateResponse,
+  LlmProvider,
+  LlmHistoryItem,
+} from "../../types/LlmProvider.interface.js";
+import { LlmStreamChunk } from "../../types/LlmStreamChunk.interface.js";
+import {
+  getDefaultModel,
+  getLogger,
+  initializeClient,
+  prepareMessages,
+} from "./utils.js";
+
+export class FireworksProvider implements LlmProvider {
+  private model: string;
+  private _client?: FireworksClient;
+  private _operateLoop?: OperateLoop;
+  private _streamLoop?: StreamLoop;
+  private apiKey?: string;
+  private log = getLogger();
+  private conversationHistory: LlmHistoryItem[] = [];
+
+  constructor(
+    model: string = getDefaultModel(),
+    { apiKey }: { apiKey?: string } = {},
+  ) {
+    this.model = model;
+    this.apiKey = apiKey;
+  }
+
+  private async getClient(): Promise<FireworksClient> {
+    if (this._client) {
+      return this._client;
+    }
+
+    this._client = await initializeClient({ apiKey: this.apiKey });
+    return this._client;
+  }
+
+  private async getOperateLoop(): Promise<OperateLoop> {
+    if (this._operateLoop) {
+      return this._operateLoop;
+    }
+
+    const client = await this.getClient();
+    this._operateLoop = createOperateLoop({
+      adapter: fireworksAdapter,
+      client,
+    });
+    return this._operateLoop;
+  }
+
+  private async getStreamLoop(): Promise<StreamLoop> {
+    if (this._streamLoop) {
+      return this._streamLoop;
+    }
+
+    const client = await this.getClient();
+    this._streamLoop = createStreamLoop({
+      adapter: fireworksAdapter,
+      client,
+    });
+    return this._streamLoop;
+  }
+
+  async send(
+    message: string,
+    options?: LlmMessageOptions,
+  ): Promise<string | JsonObject> {
+    const client = await this.getClient();
+    const messages = prepareMessages(message, options);
+    const modelToUse = options?.model || this.model;
+
+    // OpenAI-compatible Chat Completions body; messages are already wire-shaped.
+    const response = await client.chatCompletion({
+      model: modelToUse,
+      messages,
+    });
+
+    const choices = response.choices as
+      Array<{ message?: { content?: unknown } }> | undefined;
+    const rawContent = choices?.[0]?.message?.content;
+    // Extract text content - content could be string or array of content items
+    const content =
+      typeof rawContent === "string"
+        ? rawContent
+        : Array.isArray(rawContent)
+          ? rawContent
+              .filter((item) => item.type === "text")
+              .map((item) => (item as { text: string }).text)
+              .join("")
+          : "";
+
+    this.log.trace(`Assistant reply: ${content?.length || 0} characters`);
+
+    // If structured output was requested, try to parse the response
+    if (options?.response && content) {
+      try {
+        return JSON.parse(content);
+      } catch {
+        return content || "";
+      }
+    }
+
+    return content || "";
+  }
+
+  async operate(
+    input: string | LlmHistory | LlmInputMessage,
+    options: LlmOperateOptions = {},
+  ): Promise<LlmOperateResponse> {
+    const operateLoop = await this.getOperateLoop();
+    const mergedOptions = { ...options, model: options.model ?? this.model };
+
+    // Create a merged history including both the tracked history and any explicitly provided history
+    if (this.conversationHistory.length > 0) {
+      mergedOptions.history = options.history
+        ? [...this.conversationHistory, ...options.history]
+        : [...this.conversationHistory];
+    }
+
+    // Execute operate loop
+    const response = await operateLoop.execute(input, mergedOptions);
+
+    // Update conversation history with the new history from the response
+    if (response.history && response.history.length > 0) {
+      this.conversationHistory = response.history;
+    }
+
+    return response;
+  }
+
+  async *stream(
+    input: string | LlmHistory | LlmInputMessage,
+    options: LlmOperateOptions = {},
+  ): AsyncIterable<LlmStreamChunk> {
+    const streamLoop = await this.getStreamLoop();
+    const mergedOptions = { ...options, model: options.model ?? this.model };
+
+    // Create a merged history including both the tracked history and any explicitly provided history
+    if (this.conversationHistory.length > 0) {
+      mergedOptions.history = options.history
+        ? [...this.conversationHistory, ...options.history]
+        : [...this.conversationHistory];
+    }
+
+    // Execute stream loop
+    yield* streamLoop.execute(input, mergedOptions);
+  }
+}

--- a/packages/llm/src/providers/fireworks/__tests__/FireworksProvider.spec.ts
+++ b/packages/llm/src/providers/fireworks/__tests__/FireworksProvider.spec.ts
@@ -1,0 +1,196 @@
+import { getEnvSecret } from "@jaypie/aws";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { FireworksProvider } from "../FireworksProvider.class";
+import { FireworksClient } from "../client.js";
+import { PROVIDER } from "../../../constants.js";
+
+// Mock the Fireworks client
+vi.mock("../client.js");
+
+// Mock the OperateLoop for conversation history tests
+vi.mock("../../../operate/index.js", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...(actual as object),
+    createOperateLoop: vi.fn(() => ({
+      execute: vi.fn(),
+    })),
+  };
+});
+
+vi.mock("@jaypie/aws", async () => {
+  const actual = await vi.importActual("@jaypie/aws");
+  const module = {
+    ...actual,
+    getEnvSecret: vi.fn(() => "MOCK_VALUE"),
+  };
+  return module;
+});
+
+describe("FireworksProvider", () => {
+  beforeEach(() => {
+    vi.mocked(FireworksClient).mockImplementation(
+      class {
+        chatCompletion = vi.fn();
+      } as any,
+    );
+    vi.mocked(getEnvSecret).mockResolvedValue("test-fireworks-key");
+  });
+
+  describe("Base Cases", () => {
+    it("is a Class", () => {
+      expect(FireworksProvider).toBeFunction();
+    });
+
+    it("Works", () => {
+      const provider = new FireworksProvider();
+      expect(provider).toBeInstanceOf(FireworksProvider);
+    });
+
+    it("defaults to Fireworks default model", () => {
+      const provider = new FireworksProvider();
+      expect(provider["model"]).toBe(PROVIDER.FIREWORKS.DEFAULT);
+    });
+
+    it("accepts a custom model", () => {
+      const provider = new FireworksProvider(
+        "accounts/fireworks/models/kimi-k2p7-code",
+      );
+      expect(provider["model"]).toBe(
+        "accounts/fireworks/models/kimi-k2p7-code",
+      );
+    });
+  });
+
+  describe("Error Conditions", () => {
+    beforeEach(() => {
+      vi.mocked(getEnvSecret).mockResolvedValue(null as unknown as string);
+    });
+
+    it("throws ConfigurationError when API key is missing", async () => {
+      const provider = new FireworksProvider();
+      expect(async () => provider.send("test")).toThrowConfigurationError();
+    });
+  });
+
+  describe("Happy Paths", () => {
+    beforeEach(() => {
+      vi.mocked(getEnvSecret).mockResolvedValue("test-fireworks-key");
+    });
+
+    it("sends messages using the Fireworks client", async () => {
+      const mockResponse = {
+        choices: [{ message: { content: "test response from fireworks" } }],
+      };
+
+      const mockChatCompletion = vi.fn().mockResolvedValue(mockResponse);
+      vi.mocked(FireworksClient).mockImplementation(
+        class {
+          chatCompletion = mockChatCompletion;
+        } as any,
+      );
+
+      const provider = new FireworksProvider();
+      const response = await provider.send("test message");
+
+      expect(response).toBe("test response from fireworks");
+      expect(mockChatCompletion).toHaveBeenCalledWith({
+        model: PROVIDER.FIREWORKS.DEFAULT,
+        messages: [{ role: "user", content: "test message" }],
+      });
+    });
+
+    it("initializes the Fireworks client with the resolved API key", async () => {
+      const mockChatCompletion = vi.fn().mockResolvedValue({
+        choices: [{ message: { content: "response" } }],
+      });
+      vi.mocked(FireworksClient).mockImplementation(
+        class {
+          chatCompletion = mockChatCompletion;
+        } as any,
+      );
+
+      const provider = new FireworksProvider();
+      await provider.send("test");
+
+      expect(FireworksClient).toHaveBeenCalledWith({
+        apiKey: "test-fireworks-key",
+      });
+    });
+
+    it("resolves FIREWORKS_API_KEY from environment", async () => {
+      const mockChatCompletion = vi.fn().mockResolvedValue({
+        choices: [{ message: { content: "response" } }],
+      });
+      vi.mocked(FireworksClient).mockImplementation(
+        class {
+          chatCompletion = mockChatCompletion;
+        } as any,
+      );
+
+      const provider = new FireworksProvider();
+      await provider.send("test");
+
+      expect(getEnvSecret).toHaveBeenCalledWith(PROVIDER.FIREWORKS.API_KEY);
+    });
+
+    it("includes a system message when provided", async () => {
+      const mockChatCompletion = vi.fn().mockResolvedValue({
+        choices: [{ message: { content: "response" } }],
+      });
+      vi.mocked(FireworksClient).mockImplementation(
+        class {
+          chatCompletion = mockChatCompletion;
+        } as any,
+      );
+
+      const provider = new FireworksProvider();
+      await provider.send("test", { system: "Be helpful" });
+
+      expect(mockChatCompletion).toHaveBeenCalledWith({
+        model: PROVIDER.FIREWORKS.DEFAULT,
+        messages: [
+          { role: "system", content: "Be helpful" },
+          { role: "user", content: "test" },
+        ],
+      });
+    });
+
+    it("parses JSON content when structured response is requested", async () => {
+      const mockChatCompletion = vi.fn().mockResolvedValue({
+        choices: [{ message: { content: '{"capital":"Paris"}' } }],
+      });
+      vi.mocked(FireworksClient).mockImplementation(
+        class {
+          chatCompletion = mockChatCompletion;
+        } as any,
+      );
+
+      const provider = new FireworksProvider();
+      const response = await provider.send("test", {
+        response: { capital: String },
+      });
+
+      expect(response).toEqual({ capital: "Paris" });
+    });
+
+    it("delegates operate to the operate loop", async () => {
+      const { createOperateLoop } = await import("../../../operate/index.js");
+      const mockExecute = vi.fn().mockResolvedValue({
+        content: "loop response",
+        history: [],
+      });
+      vi.mocked(createOperateLoop).mockReturnValue({
+        execute: mockExecute,
+      } as any);
+
+      const provider = new FireworksProvider();
+      const response = await provider.operate("test input");
+
+      expect(mockExecute).toHaveBeenCalledWith("test input", {
+        model: PROVIDER.FIREWORKS.DEFAULT,
+      });
+      expect(response.content).toBe("loop response");
+    });
+  });
+});

--- a/packages/llm/src/providers/fireworks/__tests__/client.hot.spec.ts
+++ b/packages/llm/src/providers/fireworks/__tests__/client.hot.spec.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import { HOT_MODELS } from "../../../__tests__/hotModels.js";
+import { FireworksClient } from "../client.js";
+import { FireworksProvider } from "../FireworksProvider.class.js";
+
+//
+//
+// Hot tests
+//
+// Live tests against the real Fireworks API. Skipped unless
+// FIREWORKS_API_KEY is set, so CI stays green and `npm test` runs them
+// automatically on machines that have a key.
+//
+//   FIREWORKS_API_KEY=fw-... npm run test -w packages/llm
+//
+
+const apiKey = process.env.FIREWORKS_API_KEY;
+const TIMEOUT = 60_000;
+
+describe.skipIf(!apiKey)("FireworksClient (hot)", () => {
+  describe.each(HOT_MODELS.fireworks)("%s", (MODEL) => {
+    describe("chatCompletion", () => {
+      it(
+        "returns assistant text from the live endpoint",
+        async () => {
+          const client = new FireworksClient({ apiKey: apiKey! });
+          const response = (await client.chatCompletion({
+            model: MODEL,
+            messages: [
+              { role: "user", content: "Reply with the single word: pong" },
+            ],
+          })) as { choices: Array<{ message: { content: string } }> };
+
+          const content = response.choices?.[0]?.message?.content ?? "";
+          expect(content.toLowerCase()).toContain("pong");
+        },
+        TIMEOUT,
+      );
+    });
+
+    describe("streamChatCompletion", () => {
+      it(
+        "streams text deltas and a usage chunk",
+        async () => {
+          const client = new FireworksClient({ apiKey: apiKey! });
+          let text = "";
+          let sawUsage = false;
+          for await (const chunk of client.streamChatCompletion({
+            model: MODEL,
+            messages: [{ role: "user", content: "Count: one two three" }],
+          })) {
+            const typed = chunk as {
+              choices?: Array<{ delta?: { content?: string } }>;
+              usage?: { completion_tokens?: number };
+            };
+            if (typed.choices?.[0]?.delta?.content) {
+              text += typed.choices[0].delta.content;
+            }
+            if (typed.usage) sawUsage = true;
+          }
+
+          expect(text.length).toBeGreaterThan(0);
+          expect(sawUsage).toBe(true);
+        },
+        TIMEOUT,
+      );
+    });
+
+    describe("FireworksProvider.operate", () => {
+      it(
+        "completes a text turn end-to-end",
+        async () => {
+          const provider = new FireworksProvider(MODEL, { apiKey: apiKey! });
+          const response = await provider.operate(
+            "Reply with the single word: pong",
+          );
+          expect(String(response.content).toLowerCase()).toContain("pong");
+        },
+        TIMEOUT,
+      );
+
+      it(
+        "returns structured output via native response_format",
+        async () => {
+          const provider = new FireworksProvider(MODEL, { apiKey: apiKey! });
+          const response = await provider.operate(
+            "Give the capital of France.",
+            {
+              format: { capital: String },
+            },
+          );
+          expect(response.content).toMatchObject({
+            capital: expect.any(String),
+          });
+        },
+        TIMEOUT,
+      );
+    });
+  });
+});

--- a/packages/llm/src/providers/fireworks/__tests__/client.spec.ts
+++ b/packages/llm/src/providers/fireworks/__tests__/client.spec.ts
@@ -1,0 +1,175 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { FireworksClient, FireworksHttpError } from "../client.js";
+
+//
+//
+// Helpers
+//
+
+function jsonResponse(
+  body: unknown,
+  { ok = true, status = 200 } = {},
+): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+/** Build a Response whose body streams the given SSE text in arbitrary slices. */
+function sseResponse(text: string, sliceAt: number[] = []): Response {
+  const encoder = new TextEncoder();
+  const bytes = encoder.encode(text);
+  const bounds = [0, ...sliceAt, bytes.length];
+  let index = 0;
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (index >= bounds.length - 1) {
+        controller.close();
+        return;
+      }
+      controller.enqueue(bytes.slice(bounds[index], bounds[index + 1]));
+      index += 1;
+    },
+  });
+  return { ok: true, status: 200, body } as unknown as Response;
+}
+
+//
+//
+// Tests
+//
+
+describe("FireworksClient", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("Base Cases", () => {
+    it("is a class", () => {
+      expect(FireworksClient).toBeTypeOf("function");
+    });
+  });
+
+  describe("chatCompletion", () => {
+    it("POSTs to the chat completions endpoint with bearer auth", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(jsonResponse({ choices: [] }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new FireworksClient({ apiKey: "fw-test" });
+      await client.chatCompletion({ model: "m", messages: [] });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe(
+        "https://api.fireworks.ai/inference/v1/chat/completions",
+      );
+      expect(init.method).toBe("POST");
+      expect(init.headers.Authorization).toBe("Bearer fw-test");
+      expect(JSON.parse(init.body)).toEqual({ model: "m", messages: [] });
+    });
+
+    it("normalizes snake_case wire fields to camelCase", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        jsonResponse({
+          choices: [
+            {
+              message: {
+                role: "assistant",
+                content: null,
+                tool_calls: [
+                  {
+                    id: "c1",
+                    type: "function",
+                    function: { name: "t", arguments: "{}" },
+                  },
+                ],
+              },
+              finish_reason: "tool_calls",
+            },
+          ],
+          usage: { prompt_tokens: 3, completion_tokens: 5, total_tokens: 8 },
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new FireworksClient({ apiKey: "fw-test" });
+      const response = (await client.chatCompletion({
+        model: "m",
+        messages: [],
+      })) as {
+        choices: Array<{
+          message: { toolCalls: unknown[] };
+          finishReason: string;
+        }>;
+        usage: {
+          promptTokens: number;
+          completionTokens: number;
+          totalTokens: number;
+        };
+      };
+
+      expect(response.choices[0].message.toolCalls).toHaveLength(1);
+      expect(response.choices[0].finishReason).toBe("tool_calls");
+      expect(response.usage.promptTokens).toBe(3);
+      expect(response.usage.completionTokens).toBe(5);
+      expect(response.usage.totalTokens).toBe(8);
+    });
+
+    it("throws FireworksHttpError carrying status and message on non-2xx", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(
+          jsonResponse(
+            { error: { message: "rate limited" } },
+            { ok: false, status: 429 },
+          ),
+        );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new FireworksClient({ apiKey: "fw-test" });
+      await expect(
+        client.chatCompletion({ model: "m", messages: [] }),
+      ).rejects.toMatchObject({
+        status: 429,
+        statusCode: 429,
+        message: "rate limited",
+      });
+      await expect(
+        client.chatCompletion({ model: "m", messages: [] }),
+      ).rejects.toBeInstanceOf(FireworksHttpError);
+    });
+  });
+
+  describe("streamChatCompletion", () => {
+    it("requests usage and yields decoded SSE chunks until [DONE]", async () => {
+      const sse =
+        'data: {"choices":[{"delta":{"content":"He"}}]}\n\n' +
+        'data: {"choices":[{"delta":{"content":"llo"}}]}\n\n' +
+        'data: {"usage":{"prompt_tokens":1,"completion_tokens":2}}\n\n' +
+        "data: [DONE]\n\n";
+      // Split mid-chunk to exercise cross-read buffering.
+      const fetchMock = vi.fn().mockResolvedValue(sseResponse(sse, [20, 55]));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new FireworksClient({ apiKey: "fw-test" });
+      const chunks: unknown[] = [];
+      for await (const chunk of client.streamChatCompletion({
+        model: "m",
+        messages: [],
+      })) {
+        chunks.push(chunk);
+      }
+
+      expect(chunks).toHaveLength(3);
+      const init = fetchMock.mock.calls[0][1];
+      const sentBody = JSON.parse(init.body);
+      expect(sentBody.stream).toBe(true);
+      expect(sentBody.stream_options).toEqual({ include_usage: true });
+    });
+  });
+});

--- a/packages/llm/src/providers/fireworks/client.ts
+++ b/packages/llm/src/providers/fireworks/client.ts
@@ -1,0 +1,174 @@
+import { JsonObject } from "@jaypie/types";
+
+import { PROVIDER } from "../../constants.js";
+import { parseSseStream } from "../../util/sse.js";
+
+//
+//
+// Types
+//
+
+export interface FireworksClientOptions {
+  apiKey: string;
+  baseURL?: string;
+}
+
+export interface ChatCompletionOptions {
+  signal?: AbortSignal;
+}
+
+/**
+ * HTTP error carrying the upstream status and parsed API message. The
+ * FireworksAdapter classifies errors by reading `.status` / `.statusCode` and
+ * `.message` / `.error.message`.
+ */
+export class FireworksHttpError extends Error {
+  readonly status: number;
+  readonly statusCode: number;
+  readonly error?: { message?: string };
+
+  constructor(status: number, message: string, error?: { message?: string }) {
+    super(message);
+    this.name = "FireworksHttpError";
+    this.status = status;
+    this.statusCode = status;
+    this.error = error;
+  }
+}
+
+//
+//
+// Helpers
+//
+
+/**
+ * Normalize the snake_case wire response into the camelCase shape the adapter
+ * readers expect. Only protocol fields are touched — user content (schema
+ * property names, tool argument JSON) is left untouched.
+ */
+function normalizeResponse(json: JsonObject): JsonObject {
+  const choices = json.choices as Array<Record<string, unknown>> | undefined;
+  if (Array.isArray(choices)) {
+    for (const choice of choices) {
+      if (
+        choice.finish_reason !== undefined &&
+        choice.finishReason === undefined
+      ) {
+        choice.finishReason = choice.finish_reason;
+      }
+      const message = choice.message as Record<string, unknown> | undefined;
+      if (
+        message?.tool_calls !== undefined &&
+        message.toolCalls === undefined
+      ) {
+        message.toolCalls = message.tool_calls;
+      }
+    }
+  }
+
+  const usage = json.usage as Record<string, unknown> | undefined;
+  if (usage) {
+    if (usage.promptTokens === undefined)
+      usage.promptTokens = usage.prompt_tokens;
+    if (usage.completionTokens === undefined) {
+      usage.completionTokens = usage.completion_tokens;
+    }
+    if (usage.totalTokens === undefined) usage.totalTokens = usage.total_tokens;
+    const details = usage.completion_tokens_details as
+      { reasoning_tokens?: number } | undefined;
+    if (
+      details?.reasoning_tokens !== undefined &&
+      !usage.completionTokensDetails
+    ) {
+      usage.completionTokensDetails = {
+        reasoningTokens: details.reasoning_tokens,
+      };
+    }
+  }
+
+  return json;
+}
+
+//
+//
+// Main
+//
+
+/**
+ * Minimal `fetch`-based client for Fireworks AI's OpenAI-compatible Chat
+ * Completions endpoint. The adapter only needs a single POST (streaming and
+ * non-streaming), header auth, and HTTP error surfacing.
+ */
+export class FireworksClient {
+  private readonly apiKey: string;
+  private readonly baseURL: string;
+
+  constructor({
+    apiKey,
+    baseURL = PROVIDER.FIREWORKS.BASE_URL,
+  }: FireworksClientOptions) {
+    this.apiKey = apiKey;
+    this.baseURL = baseURL;
+  }
+
+  private headers(): Record<string, string> {
+    return {
+      Authorization: `Bearer ${this.apiKey}`,
+      "Content-Type": "application/json",
+    };
+  }
+
+  private async toError(response: Response): Promise<FireworksHttpError> {
+    let message = `Fireworks request failed with status ${response.status}`;
+    let error: { message?: string } | undefined;
+    try {
+      const body = (await response.json()) as { error?: { message?: string } };
+      if (body?.error?.message) {
+        message = body.error.message;
+        error = body.error;
+      }
+    } catch {
+      // Non-JSON error body; keep the status-based message.
+    }
+    return new FireworksHttpError(response.status, message, error);
+  }
+
+  async chatCompletion(
+    body: Record<string, unknown>,
+    { signal }: ChatCompletionOptions = {},
+  ): Promise<JsonObject> {
+    const response = await fetch(`${this.baseURL}/chat/completions`, {
+      method: "POST",
+      headers: this.headers(),
+      body: JSON.stringify(body),
+      signal,
+    });
+
+    if (!response.ok) throw await this.toError(response);
+
+    const json = (await response.json()) as JsonObject;
+    return normalizeResponse(json);
+  }
+
+  async *streamChatCompletion(
+    body: Record<string, unknown>,
+    { signal }: ChatCompletionOptions = {},
+  ): AsyncIterable<JsonObject> {
+    const response = await fetch(`${this.baseURL}/chat/completions`, {
+      method: "POST",
+      headers: { ...this.headers(), Accept: "text/event-stream" },
+      // OpenAI-style streams only include usage when explicitly requested.
+      body: JSON.stringify({
+        ...body,
+        stream: true,
+        stream_options: { include_usage: true },
+      }),
+      signal,
+    });
+
+    if (!response.ok) throw await this.toError(response);
+    if (!response.body) return;
+
+    yield* parseSseStream(response.body);
+  }
+}

--- a/packages/llm/src/providers/fireworks/index.ts
+++ b/packages/llm/src/providers/fireworks/index.ts
@@ -1,0 +1,2 @@
+export { FireworksProvider } from "./FireworksProvider.class.js";
+export * from "./utils.js";

--- a/packages/llm/src/providers/fireworks/utils.ts
+++ b/packages/llm/src/providers/fireworks/utils.ts
@@ -1,0 +1,93 @@
+import { getEnvSecret } from "@jaypie/aws";
+import { ConfigurationError } from "@jaypie/errors";
+import { JAYPIE, placeholders as replacePlaceholders } from "@jaypie/kit";
+import { createLogger, log as defaultLog } from "@jaypie/logger";
+import { LlmMessageOptions } from "../../types/LlmProvider.interface.js";
+import { PROVIDER } from "../../constants.js";
+import { FireworksClient } from "./client.js";
+
+// Logger
+export const getLogger = (): ReturnType<typeof createLogger> =>
+  defaultLog.lib({ lib: JAYPIE.LIB.LLM });
+
+// Client initialization
+export async function initializeClient({
+  apiKey,
+}: {
+  apiKey?: string;
+} = {}): Promise<FireworksClient> {
+  const logger = getLogger();
+  const resolvedApiKey =
+    apiKey || (await getEnvSecret(PROVIDER.FIREWORKS.API_KEY));
+
+  if (!resolvedApiKey) {
+    throw new ConfigurationError(
+      "The application could not resolve the requested keys",
+    );
+  }
+
+  const client = new FireworksClient({ apiKey: resolvedApiKey });
+  logger.trace("Initialized Fireworks client");
+  return client;
+}
+
+// Get default model from environment or constants
+export function getDefaultModel(): string {
+  return process.env.FIREWORKS_MODEL || PROVIDER.FIREWORKS.DEFAULT;
+}
+
+// Message formatting
+export interface ChatMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+}
+
+export function formatSystemMessage(
+  systemPrompt: string,
+  { data, placeholders }: Pick<LlmMessageOptions, "data" | "placeholders"> = {},
+): ChatMessage {
+  const content =
+    placeholders?.system === false
+      ? systemPrompt
+      : replacePlaceholders(systemPrompt, data);
+
+  return {
+    role: "system" as const,
+    content,
+  };
+}
+
+export function formatUserMessage(
+  message: string,
+  { data, placeholders }: Pick<LlmMessageOptions, "data" | "placeholders"> = {},
+): ChatMessage {
+  const content =
+    placeholders?.message === false
+      ? message
+      : replacePlaceholders(message, data);
+
+  return {
+    role: "user" as const,
+    content,
+  };
+}
+
+export function prepareMessages(
+  message: string,
+  { system, data, placeholders }: LlmMessageOptions = {},
+): ChatMessage[] {
+  const logger = getLogger();
+  const messages: ChatMessage[] = [];
+
+  if (system) {
+    const systemMessage = formatSystemMessage(system, { data, placeholders });
+    messages.push(systemMessage);
+    logger.trace(`System message: ${systemMessage.content?.length} characters`);
+  }
+
+  const userMessage = formatUserMessage(message, { data, placeholders });
+  messages.push(userMessage);
+  logger.trace(`User message: ${userMessage.content?.length} characters`);
+
+  return messages;
+}

--- a/packages/llm/src/util/__tests__/determineModelProvider.spec.ts
+++ b/packages/llm/src/util/__tests__/determineModelProvider.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { DEFAULT, PROVIDER } from "../../constants";
+import { DEFAULT, MODEL, PROVIDER } from "../../constants";
 import { determineModelProvider } from "../determineModelProvider";
 
 describe("determineModelProvider", () => {
@@ -471,6 +471,43 @@ describe("determineModelProvider", () => {
         bedrockModels.forEach((model) => {
           const result = determineModelProvider(model);
           expect(result.provider).toBe(PROVIDER.BEDROCK.NAME);
+          expect(result.model).toBe(model);
+        });
+      });
+    });
+
+    describe("Fireworks Detection", () => {
+      it("Returns default model when provider name 'fireworks' is passed", () => {
+        const result = determineModelProvider(PROVIDER.FIREWORKS.NAME);
+        expect(result).toEqual({
+          model: PROVIDER.FIREWORKS.DEFAULT,
+          provider: PROVIDER.FIREWORKS.NAME,
+        });
+      });
+
+      it("Identifies Fireworks ids containing 'fireworks' despite the slash", () => {
+        const result = determineModelProvider(
+          "accounts/fireworks/models/glm-5p2",
+        );
+        expect(result).toEqual({
+          model: "accounts/fireworks/models/glm-5p2",
+          provider: PROVIDER.FIREWORKS.NAME,
+        });
+      });
+
+      it("Handles fireworks: prefix and strips it", () => {
+        const result = determineModelProvider("fireworks:some/model");
+        expect(result).toEqual({
+          model: "some/model",
+          provider: PROVIDER.FIREWORKS.NAME,
+        });
+      });
+
+      it("Correctly identifies all Fireworks models", () => {
+        const fireworksModels = Object.values(MODEL.FIREWORKS);
+        fireworksModels.forEach((model) => {
+          const result = determineModelProvider(model);
+          expect(result.provider).toBe(PROVIDER.FIREWORKS.NAME);
           expect(result.model).toBe(model);
         });
       });

--- a/packages/llm/src/util/determineModelProvider.ts
+++ b/packages/llm/src/util/determineModelProvider.ts
@@ -20,6 +20,15 @@ export function determineModelProvider(input?: string): {
     };
   }
 
+  // Check for explicit fireworks: prefix
+  if (input.startsWith("fireworks:")) {
+    const model = input.slice("fireworks:".length);
+    return {
+      model,
+      provider: PROVIDER.FIREWORKS.NAME,
+    };
+  }
+
   // Check for explicit bedrock: prefix
   if (input.startsWith("bedrock:")) {
     const model = input.slice("bedrock:".length);
@@ -34,6 +43,12 @@ export function determineModelProvider(input?: string): {
     return {
       model: PROVIDER.BEDROCK.DEFAULT,
       provider: PROVIDER.BEDROCK.NAME,
+    };
+  }
+  if (input === PROVIDER.FIREWORKS.NAME) {
+    return {
+      model: PROVIDER.FIREWORKS.DEFAULT,
+      provider: PROVIDER.FIREWORKS.NAME,
     };
   }
   if (input === PROVIDER.ANTHROPIC.NAME) {
@@ -69,6 +84,19 @@ export function determineModelProvider(input?: string): {
 
   // Exact model ids are classified by the "/" rule and MODEL_MATCH_WORDS below,
   // so no per-provider id catalog is consulted here.
+
+  // Check Fireworks match words before the "/" rule — Fireworks ids contain
+  // "/" (e.g., "accounts/fireworks/models/glm-5p2") and would otherwise route
+  // to OpenRouter
+  const lowerInputEarly = input.toLowerCase();
+  for (const matchWord of PROVIDER.FIREWORKS.MODEL_MATCH_WORDS) {
+    if (lowerInputEarly.includes(matchWord)) {
+      return {
+        model: input,
+        provider: PROVIDER.FIREWORKS.NAME,
+      };
+    }
+  }
 
   // Assume OpenRouter for models containing "/" (e.g., "openai/gpt-4", "anthropic/claude-3-opus")
   // This check must come before match words so that "openai/gpt-4" is not matched by "openai" keyword

--- a/packages/llm/src/util/effort.ts
+++ b/packages/llm/src/util/effort.ts
@@ -159,6 +159,21 @@ export function toGeminiThinkingBudget(
   return { papered: false, value: GEMINI_THINKING_BUDGET[effort] };
 }
 
+// Fireworks `reasoning_effort` — low | medium | high. Accepted on every model
+// (the API no-ops where unsupported). No sub-low or top rung, so `lowest`
+// collapses onto `low` and `highest` onto `high`.
+const FIREWORKS_EFFORT: Record<LlmEffort, LlmEffortMapping> = {
+  [EFFORT.LOWEST]: { papered: true, value: "low" },
+  [EFFORT.LOW]: { papered: false, value: "low" },
+  [EFFORT.MEDIUM]: { papered: false, value: "medium" },
+  [EFFORT.HIGH]: { papered: false, value: "high" },
+  [EFFORT.HIGHEST]: { papered: true, value: "high" },
+};
+
+export function toFireworksEffort(effort: LlmEffort): LlmEffortMapping {
+  return FIREWORKS_EFFORT[effort];
+}
+
 // OpenRouter `reasoning.effort` — accepts the full minimal..xhigh ladder and
 // maps to the routed provider's nearest supported level itself, so nothing is
 // papered here.

--- a/packages/llm/test/models.ts
+++ b/packages/llm/test/models.ts
@@ -66,15 +66,17 @@ function catalogIds(node: unknown = MODEL, out: string[] = []): string[] {
 // Per-model expected-outcome overrides for first-class models. Fireworks has
 // no file/PDF input support (documents cannot be delivered as data: URIs) and
 // only some catalog models are vision-capable (verified live 2026-07-19).
+// Fireworks also rejects response_format combined with tools, so `both`
+// engages the structured_output tool emulation and logs a warn.
 const MATRIX_EXPECT: Record<
   string,
   Partial<Record<Capability, ExpectedOutcome>>
 > = {
-  [MODEL.FIREWORKS.DEEPSEEK]: { pdf: "skip", image: "skip" },
-  [MODEL.FIREWORKS.GLM]: { pdf: "skip", image: "skip" },
-  [MODEL.FIREWORKS.KIMI]: { pdf: "skip" },
-  [MODEL.FIREWORKS.MINIMAX]: { pdf: "skip", image: "skip" },
-  [MODEL.FIREWORKS.QWEN]: { pdf: "skip" },
+  [MODEL.FIREWORKS.DEEPSEEK]: { both: "warn", pdf: "skip", image: "skip" },
+  [MODEL.FIREWORKS.GLM]: { both: "warn", pdf: "skip", image: "skip" },
+  [MODEL.FIREWORKS.KIMI]: { both: "warn", pdf: "skip" },
+  [MODEL.FIREWORKS.MINIMAX]: { both: "warn", pdf: "skip", image: "skip" },
+  [MODEL.FIREWORKS.QWEN]: { both: "warn", pdf: "skip" },
 };
 
 // First-class models under test = the promoted MODEL.* catalog plus each

--- a/packages/llm/test/models.ts
+++ b/packages/llm/test/models.ts
@@ -63,6 +63,20 @@ function catalogIds(node: unknown = MODEL, out: string[] = []): string[] {
   return out;
 }
 
+// Per-model expected-outcome overrides for first-class models. Fireworks has
+// no file/PDF input support (documents cannot be delivered as data: URIs) and
+// only some catalog models are vision-capable (verified live 2026-07-19).
+const MATRIX_EXPECT: Record<
+  string,
+  Partial<Record<Capability, ExpectedOutcome>>
+> = {
+  [MODEL.FIREWORKS.DEEPSEEK]: { pdf: "skip", image: "skip" },
+  [MODEL.FIREWORKS.GLM]: { pdf: "skip", image: "skip" },
+  [MODEL.FIREWORKS.KIMI]: { pdf: "skip" },
+  [MODEL.FIREWORKS.MINIMAX]: { pdf: "skip", image: "skip" },
+  [MODEL.FIREWORKS.QWEN]: { pdf: "skip" },
+};
+
 // First-class models under test = the promoted MODEL.* catalog plus each
 // provider's resolved default, deduped, minus the exclude set. Provider is
 // resolved from the id so the matrix shards correctly by group (APP_GROUP).
@@ -70,6 +84,7 @@ const FIRST_CLASS_MODELS: ModelConfig[] = [
   ...new Set([
     ...catalogIds(),
     PROVIDER.ANTHROPIC.DEFAULT,
+    PROVIDER.FIREWORKS.DEFAULT,
     PROVIDER.GOOGLE.DEFAULT,
     PROVIDER.OPENAI.DEFAULT,
     PROVIDER.OPENROUTER.DEFAULT,
@@ -79,7 +94,12 @@ const FIRST_CLASS_MODELS: ModelConfig[] = [
   .filter((model) => !MATRIX_EXCLUDE.has(model))
   .map((model) => {
     const provider = determineModelProvider(model).provider;
-    return provider ? { model, provider } : { model };
+    const expect = MATRIX_EXPECT[model];
+    return {
+      model,
+      ...(provider ? { provider } : {}),
+      ...(expect ? { expect } : {}),
+    };
   });
 
 // Bedrock (and Bedrock-hosted third-party) models are not in MODEL.* — Bedrock

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.99",
+  "version": "0.8.100",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/jaypie/1.2.64.md
+++ b/packages/mcp/release-notes/jaypie/1.2.64.md
@@ -1,0 +1,9 @@
+---
+version: 1.2.64
+date: 2026-07-18
+summary: Pull @jaypie/llm 1.3.12 (Fireworks AI provider)
+---
+
+## Changes
+
+- Update `@jaypie/llm` to `^1.3.12`, adding the Fireworks AI provider

--- a/packages/mcp/release-notes/llm/1.3.12.md
+++ b/packages/mcp/release-notes/llm/1.3.12.md
@@ -1,0 +1,14 @@
+---
+version: 1.3.12
+date: 2026-07-18
+summary: Add Fireworks AI as a first-class provider
+---
+
+## Changes
+
+- New `fireworks` provider (OpenAI-compatible Chat Completions at `api.fireworks.ai`) with `FireworksProvider`, `FireworksAdapter`, and a minimal fetch-based `FireworksClient`
+- `MODEL.FIREWORKS.*` catalog (DEEPSEEK, GLM, KIMI, MINIMAX, QWEN); `PROVIDER.FIREWORKS.DEFAULT` is GLM
+- Model ids containing "fireworks" (e.g., `accounts/fireworks/models/glm-5p2`) and the `fireworks:` prefix auto-route to the provider
+- Provider-neutral `effort` maps to Fireworks `reasoning_effort` (low/medium/high; ends collapse and log at debug)
+- Structured output via native `response_format` json_schema with runtime fake-tool fallback; streaming with tool execution; images as `image_url` on vision models (QWEN, KIMI); file/PDF inputs are not supported by the Fireworks API and are warned and discarded
+- API key via `FIREWORKS_API_KEY` (supports AWS Secrets Manager)

--- a/packages/mcp/release-notes/llm/1.3.12.md
+++ b/packages/mcp/release-notes/llm/1.3.12.md
@@ -10,5 +10,5 @@ summary: Add Fireworks AI as a first-class provider
 - `MODEL.FIREWORKS.*` catalog (DEEPSEEK, GLM, KIMI, MINIMAX, QWEN); `PROVIDER.FIREWORKS.DEFAULT` is GLM
 - Model ids containing "fireworks" (e.g., `accounts/fireworks/models/glm-5p2`) and the `fireworks:` prefix auto-route to the provider
 - Provider-neutral `effort` maps to Fireworks `reasoning_effort` (low/medium/high; ends collapse and log at debug)
-- Structured output via native `response_format` json_schema with runtime fake-tool fallback; streaming with tool execution; images as `image_url` on vision models (QWEN, KIMI); file/PDF inputs are not supported by the Fireworks API and are warned and discarded
+- Structured output via native `response_format` json_schema with runtime fake-tool fallback; format+tools combined uses the fake-tool emulation preemptively (the API rejects the combination); streaming with tool execution; images as `image_url` on vision models (QWEN, KIMI); file/PDF inputs are not supported by the Fireworks API and are warned and discarded
 - API key via `FIREWORKS_API_KEY` (supports AWS Secrets Manager)

--- a/packages/mcp/release-notes/mcp/0.8.100.md
+++ b/packages/mcp/release-notes/mcp/0.8.100.md
@@ -1,0 +1,9 @@
+---
+version: 0.8.100
+date: 2026-07-18
+summary: Document Fireworks provider in the llm skill
+---
+
+## Changes
+
+- `skill("llm")` documents the Fireworks provider: match keywords, model catalog, `FIREWORKS_API_KEY`, and `reasoning_effort` mapping

--- a/packages/mcp/release-notes/testkit/1.2.56.md
+++ b/packages/mcp/release-notes/testkit/1.2.56.md
@@ -1,0 +1,9 @@
+---
+version: 1.2.56
+date: 2026-07-18
+summary: Mock FireworksProvider from @jaypie/llm
+---
+
+## Changes
+
+- Add `FireworksProvider` mock wrapping the new `@jaypie/llm` export

--- a/packages/mcp/skills/llm.md
+++ b/packages/mcp/skills/llm.md
@@ -24,6 +24,7 @@ console.log(response.content); // "4"
 | OpenAI | "openai", "gpt", "sol", "terra", "luna", /^o\d/ | gpt-5.6-sol |
 | Anthropic | "anthropic", "claude", "fable", "haiku", "mythos", "opus", "sonnet" | claude-sonnet-5 |
 | Google | "google", "gemini" | gemini-3.5-flash |
+| Fireworks | "fireworks" (also matched inside ids like `accounts/fireworks/models/...`) | accounts/fireworks/models/glm-5p2 |
 | OpenRouter | "openrouter" | anthropic/claude-sonnet-5 |
 | xAI | "xai", "grok" | grok-latest |
 | Bedrock | "amazon.nova", "anthropic.claude", "meta.llama", … | amazon.nova-pro-v1:0 |
@@ -33,7 +34,7 @@ The provider name for Gemini models is `"google"` — `"gemini"` is accepted as 
 ### Model Constants
 
 - **`PROVIDER.<name>.DEFAULT`** — the single default model per provider (above), used when no `model` is given.
-- **`LLM.MODEL.*`** — the named model catalog (e.g. `MODEL.SONNET`, `MODEL.SOL`, `MODEL.GEMINI_FLASH`, `MODEL.GROK`), plus `MODEL.OPENROUTER.*` for provider-prefixed routes (`GLM`, `LUNA`, `SONNET`). Pick specific models from here.
+- **`LLM.MODEL.*`** — the named model catalog (e.g. `MODEL.SONNET`, `MODEL.SOL`, `MODEL.GEMINI_FLASH`, `MODEL.GROK`), plus `MODEL.OPENROUTER.*` for provider-prefixed routes (`GLM`, `LUNA`, `SONNET`) and `MODEL.FIREWORKS.*` for Fireworks serverless models (`DEEPSEEK`, `GLM`, `KIMI`, `MINIMAX`, `QWEN`). Pick specific models from here.
 - **Deprecated:** the size-tier map `PROVIDER.<name>.MODEL.{DEFAULT,LARGE,SMALL,TINY}`, the `DEFAULT.MODEL` bundle, and `ALL` are `@deprecated` and retired in 2.0 — use `PROVIDER.*.DEFAULT` for defaults and `MODEL.*` for named models.
 
 ```typescript
@@ -446,6 +447,7 @@ const flash = new Llm(LLM.MODEL.GEMINI_FLASH); // -> google, gemini-3.5-flash
 
 ```bash
 ANTHROPIC_API_KEY   # Required for Anthropic
+FIREWORKS_API_KEY   # Required for Fireworks
 GOOGLE_API_KEY      # Required for Google (Gemini models)
 OPENAI_API_KEY      # Required for OpenAI
 OPENROUTER_API_KEY  # Required for OpenRouter
@@ -623,13 +625,13 @@ await Llm.operate("Solve this step by step", {
 Per-provider translation (`medium`/`high` stay aligned across providers; ends
 collapse where a provider has fewer rungs):
 
-| `effort`  | OpenAI `reasoning.effort` | Anthropic `output_config.effort` | Gemini 3 `thinkingLevel` | Gemini 2.5 `thinkingBudget` | Grok `reasoning_effort` | OpenRouter `reasoning.effort` |
-|-----------|---------------------------|----------------------------------|--------------------------|-----------------------------|-------------------------|-------------------------------|
-| `lowest`  | minimal | low    | MINIMAL | 512   | low    | minimal |
-| `low`     | low     | low    | LOW     | 4096  | low    | low     |
-| `medium`  | medium  | medium | MEDIUM  | 8192  | medium | medium  |
-| `high`    | high    | high   | HIGH    | 16384 | high   | high    |
-| `highest` | xhigh   | max    | HIGH    | 24576 | high   | xhigh   |
+| `effort`  | OpenAI `reasoning.effort` | Anthropic `output_config.effort` | Gemini 3 `thinkingLevel` | Gemini 2.5 `thinkingBudget` | Grok `reasoning_effort` | OpenRouter `reasoning.effort` | Fireworks `reasoning_effort` |
+|-----------|---------------------------|----------------------------------|--------------------------|-----------------------------|-------------------------|-------------------------------|------------------------------|
+| `lowest`  | minimal | low    | MINIMAL | 512   | low    | minimal | low    |
+| `low`     | low     | low    | LOW     | 4096  | low    | low     | low    |
+| `medium`  | medium  | medium | MEDIUM  | 8192  | medium | medium  | medium |
+| `high`    | high    | high   | HIGH    | 16384 | high   | high    | high   |
+| `highest` | xhigh   | max    | HIGH    | 24576 | high   | xhigh   | high   |
 
 When a neutral level has no distinct native rung and collapses onto a neighbor
 (e.g. `highest` → Grok `high`), the adapter logs it at `log.debug` for the
@@ -652,6 +654,8 @@ erroring):
   skipped.
 - **OpenRouter** — always forwarded; OpenRouter maps to the routed model's
   nearest supported level.
+- **Fireworks** — always forwarded (`reasoning_effort`); the API accepts it on
+  every model and no-ops where unsupported.
 - **Bedrock** — not yet wired; `effort` is ignored.
 
 First-class `effort` takes precedence over a raw `providerOptions.reasoning`

--- a/packages/testkit/package.json
+++ b/packages/testkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/testkit",
-  "version": "1.2.55",
+  "version": "1.2.56",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"

--- a/packages/testkit/src/mock/llm.ts
+++ b/packages/testkit/src/mock/llm.ts
@@ -133,6 +133,12 @@ export const BedrockProvider = createMockWrappedObject(
     isClass: true,
   },
 );
+export const FireworksProvider = createMockWrappedObject(
+  original.FireworksProvider,
+  {
+    isClass: true,
+  },
+);
 export const GoogleProvider = createMockWrappedObject(original.GoogleProvider, {
   isClass: true,
 });

--- a/workspaces/documentation/src/content/docs/docs/guides/llm-integration.md
+++ b/workspaces/documentation/src/content/docs/docs/guides/llm-integration.md
@@ -5,7 +5,7 @@ title: "LLM Integration"
 
 **Prerequisites:**
 - `npm install @jaypie/llm`
-- API key for at least one provider (Anthropic, Google, OpenAI, OpenRouter, or xAI)
+- API key for at least one provider (Anthropic, Fireworks, Google, OpenAI, OpenRouter, or xAI)
 
 ## Overview
 
@@ -19,6 +19,7 @@ The `Llm` class handles provider-specific implementations while exposing a consi
 | Provider | Models | Env Variable |
 |----------|--------|--------------|
 | Anthropic | claude-sonnet-4, claude-opus-4, claude-haiku | `ANTHROPIC_API_KEY` |
+| Fireworks | glm, deepseek, kimi, minimax, qwen | `FIREWORKS_API_KEY` |
 | Google | gemini-2.0-flash, gemini-1.5-pro | `GOOGLE_API_KEY` |
 | OpenAI | gpt-4o, gpt-4o-mini, o1-mini, o3-mini | `OPENAI_API_KEY` |
 | OpenRouter | Any supported model | `OPENROUTER_API_KEY` |

--- a/workspaces/documentation/src/content/docs/docs/packages/llm.md
+++ b/workspaces/documentation/src/content/docs/docs/packages/llm.md
@@ -7,7 +7,7 @@ title: "@jaypie/llm"
 
 ## Overview
 
-`@jaypie/llm` provides a unified interface for calling Anthropic, Google, OpenAI, OpenRouter, and xAI models with consistent API patterns.
+`@jaypie/llm` provides a unified interface for calling Anthropic, Fireworks, Google, OpenAI, OpenRouter, and xAI models with consistent API patterns.
 
 ## Installation
 
@@ -30,6 +30,7 @@ npm install @jaypie/llm
 | Provider | Models | Env Variable |
 |----------|--------|--------------|
 | `anthropic` | claude-sonnet-4, claude-opus-4, claude-haiku | `ANTHROPIC_API_KEY` |
+| `fireworks` | glm, deepseek, kimi, minimax, qwen | `FIREWORKS_API_KEY` |
 | `google` | gemini-2.0-flash, gemini-1.5-pro | `GOOGLE_API_KEY` |
 | `openai` | gpt-4o, gpt-4o-mini, o1-mini, o3-mini | `OPENAI_API_KEY` |
 | `openrouter` | Various | `OPENROUTER_API_KEY` |


### PR DESCRIPTION
## Summary

- Add Fireworks AI as a first-class provider in `@jaypie/llm` (OpenAI-compatible Chat Completions at `api.fireworks.ai`): `FireworksProvider`, `FireworksAdapter`, fetch-based `FireworksClient`
- `MODEL.FIREWORKS` catalog (DEEPSEEK, GLM, KIMI, MINIMAX, QWEN); default `accounts/fireworks/models/glm-5p2`
- Routing: `fireworks:` prefix and "fireworks" match word resolved ahead of the OpenRouter `/` rule
- Provider-neutral `effort` maps to `reasoning_effort` (low/medium/high; ends collapse, logged at debug); `reasoning_content` preserved in history
- Native `response_format` json_schema with runtime fake-tool fallback; streaming with automatic tool execution
- Images as `image_url` on vision models (QWEN, KIMI). File/PDF inputs are warned and discarded: the Fireworks API has no file part, rejects document `data:` URIs, and Document Inlining is deprecated platform-wide (verified live 2026-07-19)
- Testkit mocks `FireworksProvider`; CI gains a `fireworks` matrix shard using `CICD_FIREWORKS_API_KEY`
- Versions: llm 1.3.12, testkit 1.2.56, mcp 0.8.100, jaypie 1.2.64 (dep range synced); release notes added

## Testing

- 1135 unit tests pass (llm), 293 (testkit); typecheck, lint, build clean
- 20 live hot tests pass across all five catalog models
- Live smoke: plain, tools, structured output, effort, streaming, image upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XaJ4VEmHYNUMvg4nQoAF5A