### PR TITLE
fix(llm): enforce format contract with JSON salvage and corrective retry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15264,7 +15264,7 @@
       "license": "MIT"
     },
     "packages/jaypie": {
-      "version": "1.2.64",
+      "version": "1.2.65",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "^1.2.10",
@@ -15289,7 +15289,7 @@
         "typescript-eslint": "^8.46.1"
       },
       "peerDependencies": {
-        "@jaypie/llm": "^1.3.12"
+        "@jaypie/llm": "^1.3.13"
       },
       "peerDependenciesMeta": {
         "@jaypie/llm": {
@@ -15421,7 +15421,7 @@
     },
     "packages/llm": {
       "name": "@jaypie/llm",
-      "version": "1.3.12",
+      "version": "1.3.13",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "*",
@@ -15503,7 +15503,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.100",
+      "version": "0.8.101",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.3.3",

--- a/packages/jaypie/package.json
+++ b/packages/jaypie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jaypie",
-  "version": "1.2.64",
+  "version": "1.2.65",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"
@@ -59,7 +59,7 @@
     "typescript-eslint": "^8.46.1"
   },
   "peerDependencies": {
-    "@jaypie/llm": "^1.3.12"
+    "@jaypie/llm": "^1.3.13"
   },
   "peerDependenciesMeta": {
     "@jaypie/llm": {

--- a/packages/llm/CLAUDE.md
+++ b/packages/llm/CLAUDE.md
@@ -298,6 +298,7 @@ const response = await Llm.operate("Greet the world", {
 - Uses the OpenAI-style native `response_format: { type: "json_schema", ... }` for format-only requests.
 - Format **and** tools combined is rejected by the API ("You cannot specify response format and function call at the same time"), so those requests preemptively use the `structured_output` fake-tool emulation (logged at warn) — same approach as Gemini 2.5.
 - A model that 400/422s on `response_format` alone is cached for the session and retried via the emulation path.
+- Emulation compliance is enforced by the operate loop: when a format request completes as prose, the loop first tries to parse the text as JSON (fence-stripped), then takes a corrective turn offering **only** the `structured_output` tool (`OperateRequest.structuredOutputRetry`), looping within the `turns` budget. Adapters opt in via `supportsStructuredOutputRetry`; Fireworks is currently the only one.
 
 **OpenRouter notes:**
 - Uses the OpenAI-style native `response_format: { type: "json_schema", json_schema: { name, schema, strict: true } }`. OpenRouter routes to a backend provider; many but not all backends support this — the SDK accepts the field on every model, and unsupported routes 4xx.

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/llm",
-  "version": "1.3.12",
+  "version": "1.3.13",
   "description": "Large language model utilities",
   "repository": {
     "type": "git",

--- a/packages/llm/src/operate/OperateLoop.ts
+++ b/packages/llm/src/operate/OperateLoop.ts
@@ -93,6 +93,31 @@ function createErrorClassifier(adapter: ProviderAdapter): ErrorClassifier {
   };
 }
 
+/**
+ * Attempt to read a prose response as the structured payload itself: parse the
+ * text (stripping a Markdown code fence if present) and return the object, or
+ * undefined when the text is not a JSON object.
+ */
+function tryParseJsonObject(text: string): JsonObject | undefined {
+  let candidate = text.trim();
+  const fence = candidate.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/);
+  if (fence) {
+    candidate = fence[1].trim();
+  }
+  if (!candidate.startsWith("{")) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(candidate);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as JsonObject;
+    }
+  } catch {
+    // Not JSON; caller falls through to the corrective-turn path.
+  }
+  return undefined;
+}
+
 //
 //
 // Main
@@ -186,6 +211,7 @@ export class OperateLoop {
             messages: state.currentInput,
             model: modelName,
             providerOptions: options.providerOptions,
+            structuredOutputRetry: state.structuredOutputRetry,
             system: options.system,
             temperature: options.temperature,
             tools: state.formattedTools,
@@ -685,6 +711,51 @@ export class OperateLoop {
         }
 
         return true; // Continue to next turn
+      }
+    }
+
+    // Format contract enforcement: the loop is about to complete but the
+    // model answered with prose instead of structured output.
+    if (state.formattedFormat && typeof parsed.content === "string") {
+      // First salvage attempt: the text may be the JSON itself (with or
+      // without a code fence).
+      const salvaged = tryParseJsonObject(parsed.content);
+      if (salvaged) {
+        state.responseBuilder.setContent(
+          this.applyFormatArrayDefaults(salvaged, options),
+        );
+        state.responseBuilder.complete();
+        for (const item of this.adapter.responseToHistoryItems(parsed.raw)) {
+          state.responseBuilder.appendToHistory(item);
+        }
+        return false; // Stop loop
+      }
+
+      // Corrective turn: for adapters whose structured output rides a tool
+      // emulation, take another turn offering only the structured_output tool
+      // and demand it be called. Bounded by maxTurns.
+      if (
+        this.adapter.supportsStructuredOutputRetry &&
+        state.currentTurn < state.maxTurns
+      ) {
+        log.warn(
+          `[operate] Model returned text despite format on turn ${state.currentTurn}; retrying with structured_output tool only`,
+        );
+        for (const item of this.adapter.responseToHistoryItems(parsed.raw)) {
+          state.currentInput.push(item);
+          state.responseBuilder.appendToHistory(item);
+        }
+        const corrective: LlmInputMessage = {
+          content:
+            "You must provide your final answer by calling the structured_output tool " +
+            "with arguments matching the required schema. Do not respond with text.",
+          role: LlmMessageRole.User,
+          type: LlmMessageType.Message,
+        };
+        state.currentInput.push(corrective);
+        state.responseBuilder.appendToHistory(corrective);
+        state.structuredOutputRetry = true;
+        return true; // Continue to corrective turn
       }
     }
 

--- a/packages/llm/src/operate/__tests__/OperateLoop.spec.ts
+++ b/packages/llm/src/operate/__tests__/OperateLoop.spec.ts
@@ -1142,4 +1142,126 @@ describe("OperateLoop", () => {
       expect(libSpy).toHaveBeenCalledWith({ lib: "@jaypie/llm" });
     });
   });
+
+  // Structured output contract enforcement
+  describe("Format Contract Enforcement", () => {
+    const format = {
+      type: "object",
+      properties: { total: { type: "number" } },
+    } as JsonObject;
+
+    it("salvages prose that is itself JSON", async () => {
+      mockAdapter.parseResponse.mockReturnValueOnce({
+        content: '{"total": 21}',
+        hasToolCalls: false,
+        stopReason: "end_turn",
+        raw: {},
+      } as ParsedResponse);
+      const loop = new OperateLoop({
+        adapter: mockAdapter,
+        client: mockClient,
+      });
+
+      const response = await loop.execute("Roll dice", { format });
+
+      expect(response.content).toEqual({ total: 21 });
+      expect(mockAdapter.executeRequest).toHaveBeenCalledTimes(1);
+    });
+
+    it("salvages fenced JSON", async () => {
+      mockAdapter.parseResponse.mockReturnValueOnce({
+        content: '```json\n{"total": 21}\n```',
+        hasToolCalls: false,
+        stopReason: "end_turn",
+        raw: {},
+      } as ParsedResponse);
+      const loop = new OperateLoop({
+        adapter: mockAdapter,
+        client: mockClient,
+      });
+
+      const response = await loop.execute("Roll dice", { format });
+
+      expect(response.content).toEqual({ total: 21 });
+    });
+
+    it("takes a corrective turn when the adapter supports structured output retry", async () => {
+      Object.defineProperty(mockAdapter, "supportsStructuredOutputRetry", {
+        value: true,
+      });
+      mockAdapter.parseResponse
+        .mockReturnValueOnce({
+          content: "You rolled a total of 21!",
+          hasToolCalls: false,
+          stopReason: "end_turn",
+          raw: {},
+        } as ParsedResponse)
+        .mockReturnValueOnce({
+          content: undefined,
+          hasToolCalls: true,
+          stopReason: "tool_calls",
+          raw: {},
+        } as ParsedResponse);
+      mockAdapter.hasStructuredOutput = vi
+        .fn()
+        .mockReturnValueOnce(false)
+        .mockReturnValue(true);
+      mockAdapter.extractStructuredOutput = vi.fn(() => ({ total: 21 }));
+      const loop = new OperateLoop({
+        adapter: mockAdapter,
+        client: mockClient,
+      });
+
+      const response = await loop.execute("Roll dice", { format, turns: 3 });
+
+      expect(response.content).toEqual({ total: 21 });
+      expect(mockAdapter.executeRequest).toHaveBeenCalledTimes(2);
+      // The corrective request is flagged so adapters can restrict tools
+      const secondBuild = mockAdapter.buildRequest.mock.calls[1][0];
+      expect(secondBuild.structuredOutputRetry).toBe(true);
+      // Corrective user message was appended to the conversation
+      const lastMessage = secondBuild.messages[secondBuild.messages.length - 1];
+      expect(lastMessage.role).toBe(LlmMessageRole.User);
+      expect(lastMessage.content).toContain("structured_output");
+    });
+
+    it("returns prose unchanged when the adapter does not support retry", async () => {
+      mockAdapter.parseResponse.mockReturnValueOnce({
+        content: "You rolled a total of 21!",
+        hasToolCalls: false,
+        stopReason: "end_turn",
+        raw: {},
+      } as ParsedResponse);
+      const loop = new OperateLoop({
+        adapter: mockAdapter,
+        client: mockClient,
+      });
+
+      const response = await loop.execute("Roll dice", { format, turns: 3 });
+
+      expect(response.content).toBe("You rolled a total of 21!");
+      expect(mockAdapter.executeRequest).toHaveBeenCalledTimes(1);
+    });
+
+    it("stops retrying at the turn budget", async () => {
+      Object.defineProperty(mockAdapter, "supportsStructuredOutputRetry", {
+        value: true,
+      });
+      mockAdapter.parseResponse.mockReturnValue({
+        content: "Still prose.",
+        hasToolCalls: false,
+        stopReason: "end_turn",
+        raw: {},
+      } as ParsedResponse);
+      const loop = new OperateLoop({
+        adapter: mockAdapter,
+        client: mockClient,
+      });
+
+      const response = await loop.execute("Roll dice", { format, turns: 2 });
+
+      expect(response.content).toBe("Still prose.");
+      expect(mockAdapter.executeRequest).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/packages/llm/src/operate/adapters/FireworksAdapter.ts
+++ b/packages/llm/src/operate/adapters/FireworksAdapter.ts
@@ -328,6 +328,11 @@ export class FireworksAdapter extends BaseProviderAdapter {
   readonly name = PROVIDER.FIREWORKS.NAME;
   readonly defaultModel = PROVIDER.FIREWORKS.DEFAULT;
 
+  // Structured output with tools rides the structured_output tool emulation
+  // (Fireworks rejects response_format + tools), and emulation compliance is
+  // a model decision — opt in to OperateLoop's corrective retry turn.
+  override readonly supportsStructuredOutputRetry = true;
+
   // Session-level cache of models observed to reject native
   // `response_format: json_schema`. When a model is in this set, buildRequest
   // engages the legacy fake-tool path instead of native structured output.
@@ -399,9 +404,11 @@ export class FireworksAdapter extends BaseProviderAdapter {
       (hasCallerTools ||
         !this.supportsStructuredOutput(fireworksRequest.model));
 
-    const allTools: ProviderToolDefinition[] = request.tools
-      ? [...request.tools]
-      : [];
+    // On a corrective retry turn (the model answered a format request with
+    // prose), offer only the structured_output tool so the demanded call is
+    // the sole option.
+    const allTools: ProviderToolDefinition[] =
+      request.tools && !request.structuredOutputRetry ? [...request.tools] : [];
     if (useFallbackStructuredOutput && request.format) {
       log.warn(
         hasCallerTools

--- a/packages/llm/src/operate/adapters/ProviderAdapter.interface.ts
+++ b/packages/llm/src/operate/adapters/ProviderAdapter.interface.ts
@@ -44,6 +44,13 @@ export interface ProviderAdapter {
    */
   readonly defaultModel: string;
 
+  /**
+   * Whether OperateLoop may take a corrective turn when a `format` request
+   * completes with prose instead of structured output (tool-emulation
+   * providers opt in).
+   */
+  readonly supportsStructuredOutputRetry?: boolean;
+
   //
   // Request Building
   //
@@ -283,6 +290,14 @@ export abstract class BaseProviderAdapter implements ProviderAdapter {
   abstract responseToHistoryItems(response: unknown): LlmHistory;
   abstract classifyError(error: unknown): ClassifiedError;
   abstract isComplete(response: unknown): boolean;
+
+  /**
+   * Whether OperateLoop may take a corrective turn when a `format` request
+   * completes with prose instead of structured output. Providers whose
+   * structured output rides a tool emulation (where compliance is a model
+   * decision) opt in; native grammar-constrained providers do not need it.
+   */
+  readonly supportsStructuredOutputRetry: boolean = false;
 
   /**
    * Default implementation checks if error is retryable via classifyError

--- a/packages/llm/src/operate/adapters/__tests__/FireworksAdapter.spec.ts
+++ b/packages/llm/src/operate/adapters/__tests__/FireworksAdapter.spec.ts
@@ -329,6 +329,41 @@ describe("FireworksAdapter", () => {
         expect(warn).toHaveBeenCalled();
         vi.restoreAllMocks();
       });
+
+      it("offers only the structured_output tool on a corrective retry turn", () => {
+        vi.spyOn(log, "warn").mockImplementation(() => {});
+        const adapter = new FireworksAdapter();
+        const schema = {
+          type: "object",
+          properties: { name: { type: "string" } },
+        };
+        const request: OperateRequest = {
+          model: PROVIDER.FIREWORKS.DEFAULT,
+          messages: [
+            {
+              content: "Hello",
+              role: LlmMessageRole.User,
+              type: LlmMessageType.Message,
+            },
+          ],
+          format: schema,
+          structuredOutputRetry: true,
+          tools: [
+            {
+              name: "roll",
+              description: "Roll dice",
+              parameters: { type: "object" },
+            },
+          ],
+        };
+
+        const result = adapter.buildRequest(request);
+
+        expect(result.response_format).toBeUndefined();
+        expect(result.tools).toHaveLength(1);
+        expect(result.tools![0].function.name).toBe("structured_output");
+        vi.restoreAllMocks();
+      });
     });
 
     describe("parseResponse", () => {

--- a/packages/llm/src/operate/types.ts
+++ b/packages/llm/src/operate/types.ts
@@ -99,6 +99,13 @@ export interface OperateRequest {
   stream?: boolean;
   /** Sampling temperature (0-2 for most providers) */
   temperature?: number;
+  /**
+   * Set by OperateLoop on a corrective turn after a format request came back
+   * as prose. Adapters that support the retry (see
+   * `ProviderAdapter.supportsStructuredOutputRetry`) should offer only the
+   * structured-output mechanism on this turn.
+   */
+  structuredOutputRetry?: boolean;
   /** User identifier for tracking */
   user?: string;
 }
@@ -173,6 +180,8 @@ import type { ResponseBuilder } from "./response/ResponseBuilder.js";
 export interface OperateLoopState {
   /** Count of consecutive tool errors (resets on success) */
   consecutiveToolErrors: number;
+  /** Set when the loop has taken a corrective structured-output turn */
+  structuredOutputRetry?: boolean;
   /** Current conversation input/messages */
   currentInput: LlmHistory;
   /** Current turn number (0-indexed, incremented at start of each turn) */

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.100",
+  "version": "0.8.101",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/jaypie/1.2.65.md
+++ b/packages/mcp/release-notes/jaypie/1.2.65.md
@@ -1,0 +1,9 @@
+---
+version: 1.2.65
+date: 2026-07-19
+summary: Pull @jaypie/llm 1.3.13 (structured-output retry)
+---
+
+## Changes
+
+- Update `@jaypie/llm` to `^1.3.13`, adding format-contract enforcement (JSON salvage + corrective retry turn)

--- a/packages/mcp/release-notes/llm/1.3.13.md
+++ b/packages/mcp/release-notes/llm/1.3.13.md
@@ -1,0 +1,11 @@
+---
+version: 1.3.13
+date: 2026-07-19
+summary: Enforce format contract with JSON salvage and corrective retry turn
+---
+
+## Changes
+
+- When a `format` request completes as prose, the operate loop first parses the text as JSON (stripping code fences) and returns the object when valid
+- Otherwise, adapters that opt in via `supportsStructuredOutputRetry` get a corrective turn offering only the `structured_output` tool, looping within the `turns` budget
+- Fireworks opts in: its tools+format emulation depends on model compliance, which was nondeterministic on deepseek-v4-pro and minimax-m2p7 (observed in the live CI matrix); with the retry, 10/10 stress runs pass

--- a/packages/mcp/release-notes/mcp/0.8.101.md
+++ b/packages/mcp/release-notes/mcp/0.8.101.md
@@ -1,0 +1,9 @@
+---
+version: 0.8.101
+date: 2026-07-19
+summary: Document Fireworks structured-output retry in the llm skill
+---
+
+## Changes
+
+- `skill("llm")` notes the format-contract corrective retry for Fireworks tools+structured requests

--- a/packages/mcp/skills/llm.md
+++ b/packages/mcp/skills/llm.md
@@ -655,7 +655,10 @@ erroring):
 - **OpenRouter** — always forwarded; OpenRouter maps to the routed model's
   nearest supported level.
 - **Fireworks** — always forwarded (`reasoning_effort`); the API accepts it on
-  every model and no-ops where unsupported.
+  every model and no-ops where unsupported. Structured output combined with
+  tools uses a tool emulation (the API rejects the pair); the operate loop
+  enforces the format contract with a corrective retry turn when a model
+  answers in prose.
 - **Bedrock** — not yet wired; `effort` is ignored.
 
 First-class `effort` takes precedence over a raw `providerOptions.reasoning`


### PR DESCRIPTION
## Summary

- When a `format` request completes as prose, `OperateLoop` now (1) tries to parse the text as JSON (stripping code fences) and returns the object when valid, then (2) for adapters that opt in via `supportsStructuredOutputRetry`, takes a corrective turn offering only the `structured_output` tool and demanding it be called, looping within the `turns` budget
- Fireworks opts in: its tools+format path rides tool emulation (the API rejects `response_format` + tools) and compliance is a model decision — deepseek-v4-pro and minimax-m2p7 answered in prose ~half the time in the live matrix
- Versions: llm 1.3.13, mcp 0.8.101, jaypie 1.2.65 (dep range synced); release notes added

## Testing

- 1142 llm unit tests pass including 5 new loop tests (salvage, fenced salvage, corrective turn, non-opt-in passthrough, turn-budget stop) and a Fireworks retry-request test
- Live stress: the exact matrix `both` cell 10/10 across minimax-m2p7 and deepseek-v4-pro (previously ~50%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XaJ4VEmHYNUMvg4nQoAF5A