### PR TITLE
feat(llm): onExchange exchange envelope and default DynamoDB persistence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,7 @@
 | `CDK_ENV_DATADOG_API_KEY_ARN` | Datadog API key ARN in Secrets Manager |
 | `SECRET_MONGODB_URI` | MongoDB URI secret name |
 | `MONGODB_URI` | Direct MongoDB connection URI |
+| `LLM_EXCHANGE_ENABLED` | Persist each LLM operate() call as an `exchange` entity via @jaypie/dynamodb |
 | `ANTHROPIC_API_KEY` | Anthropic API key for LLM |
 | `OPENAI_API_KEY` | OpenAI API key for LLM |
 | `AWS_SESSION_TOKEN` | AWS session token (set by Lambda runtime) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -15008,12 +15008,12 @@
     },
     "packages/dynamodb": {
       "name": "@jaypie/dynamodb",
-      "version": "0.6.7",
+      "version": "0.6.8",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.726.1",
         "@aws-sdk/lib-dynamodb": "^3.726.1",
-        "@jaypie/fabric": "^0.3.4"
+        "@jaypie/fabric": "^0.3.5"
       },
       "devDependencies": {
         "@rollup/plugin-typescript": "^12.1.2",
@@ -15154,7 +15154,7 @@
     },
     "packages/fabric": {
       "name": "@jaypie/fabric",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*"
@@ -15264,7 +15264,7 @@
       "license": "MIT"
     },
     "packages/jaypie": {
-      "version": "1.2.65",
+      "version": "1.2.66",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "^1.2.10",
@@ -15289,7 +15289,7 @@
         "typescript-eslint": "^8.46.1"
       },
       "peerDependencies": {
-        "@jaypie/llm": "^1.3.13"
+        "@jaypie/llm": "^1.3.14"
       },
       "peerDependenciesMeta": {
         "@jaypie/llm": {
@@ -15421,7 +15421,7 @@
     },
     "packages/llm": {
       "name": "@jaypie/llm",
-      "version": "1.3.13",
+      "version": "1.3.14",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "*",
@@ -15440,11 +15440,15 @@
       },
       "peerDependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.1045.0",
+        "@jaypie/dynamodb": "*",
         "@jaypie/kit": "*",
         "@jaypie/logger": "*"
       },
       "peerDependenciesMeta": {
         "@aws-sdk/client-bedrock-runtime": {
+          "optional": true
+        },
+        "@jaypie/dynamodb": {
           "optional": true
         }
       }
@@ -15503,7 +15507,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.101",
+      "version": "0.8.102",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.3.3",
@@ -15583,7 +15587,7 @@
     },
     "packages/testkit": {
       "name": "@jaypie/testkit",
-      "version": "1.2.56",
+      "version": "1.2.57",
       "license": "MIT",
       "dependencies": {
         "jest-json-schema": "^6.1.0",

--- a/packages/dynamodb/package.json
+++ b/packages/dynamodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/dynamodb",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"
@@ -49,7 +49,7 @@
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.726.1",
     "@aws-sdk/lib-dynamodb": "^3.726.1",
-    "@jaypie/fabric": "^0.3.4"
+    "@jaypie/fabric": "^0.3.5"
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^12.1.2",

--- a/packages/dynamodb/src/__tests__/client.spec.ts
+++ b/packages/dynamodb/src/__tests__/client.spec.ts
@@ -11,7 +11,9 @@ import {
 
 // Mock AWS SDK
 vi.mock("@aws-sdk/client-dynamodb", () => ({
-  DynamoDBClient: vi.fn().mockImplementation(() => ({})),
+  DynamoDBClient: vi.fn(function DynamoDBClient() {
+    return {};
+  }),
 }));
 
 vi.mock("@aws-sdk/lib-dynamodb", () => ({

--- a/packages/dynamodb/src/__tests__/query.spec.ts
+++ b/packages/dynamodb/src/__tests__/query.spec.ts
@@ -20,11 +20,15 @@ vi.mock("@aws-sdk/lib-dynamodb", () => ({
       send: mockSend,
     })),
   },
-  QueryCommand: vi.fn((params) => ({ input: params })),
+  QueryCommand: vi.fn(function QueryCommand(params) {
+    return { input: params };
+  }),
 }));
 
 vi.mock("@aws-sdk/client-dynamodb", () => ({
-  DynamoDBClient: vi.fn(() => ({})),
+  DynamoDBClient: vi.fn(function DynamoDBClient() {
+    return {};
+  }),
 }));
 
 // =============================================================================

--- a/packages/dynamodb/src/__tests__/storeExchange.spec.ts
+++ b/packages/dynamodb/src/__tests__/storeExchange.spec.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { storeExchange } from "../storeExchange.js";
+import { isInitialized } from "../client.js";
+import { createEntity } from "../entities.js";
+
+vi.mock("../client.js", () => ({
+  isInitialized: vi.fn(() => true),
+}));
+
+vi.mock("../entities.js", () => ({
+  createEntity: vi.fn(async ({ entity }) => entity),
+}));
+
+vi.mock("@jaypie/logger", () => ({
+  default: {
+    var: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+const envelope = () => ({
+  ids: ["resp_1", "resp_2"],
+  request: {
+    data: { user: "Taylor" },
+    input: "Hello",
+    model: "mock-model",
+  },
+  resolution: {
+    fallbackAttempts: 1,
+    fallbackUsed: false,
+    model: "mock-model",
+    provider: "mock",
+    retries: 0,
+  },
+  response: {
+    content: "Hi!",
+    historyDelta: [{ content: "Hi!", role: "assistant" }],
+    reasoning: [],
+    status: "completed",
+    stopReason: "end_turn",
+    usage: [],
+    usageTotals: { "mock:mock-model": { input: 1, output: 2 } },
+  },
+  timing: { duration: 42, startedAt: "2026-01-01T00:00:00.000Z" },
+});
+
+describe("storeExchange", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(isInitialized).mockReturnValue(true);
+    vi.mocked(createEntity).mockImplementation(
+      async ({ entity }) => entity as never,
+    );
+  });
+
+  describe("Base Cases", () => {
+    it("is a function", () => {
+      expect(typeof storeExchange).toBe("function");
+    });
+  });
+
+  describe("Error Conditions", () => {
+    it("warns and returns null when client is not initialized", async () => {
+      vi.mocked(isInitialized).mockReturnValue(false);
+      const result = await storeExchange(envelope());
+      expect(result).toBeNull();
+      expect(createEntity).not.toHaveBeenCalled();
+    });
+
+    it("returns null instead of throwing when the write fails", async () => {
+      vi.mocked(createEntity).mockRejectedValue(new Error("Dynamo down"));
+      await expect(storeExchange(envelope())).resolves.toBeNull();
+    });
+  });
+
+  describe("Features", () => {
+    it("maps the envelope onto an exchange entity", async () => {
+      const result = await storeExchange(envelope());
+      expect(result).toMatchObject({
+        content: "Hi!",
+        data: { user: "Taylor" },
+        input: "Hello",
+        llm: "mock-model",
+        model: "exchange",
+        scope: "@",
+        status: "completed",
+        xid: "resp_2",
+      });
+      expect(result!.metadata).toMatchObject({
+        duration: 42,
+        fallbackAttempts: 1,
+        fallbackUsed: false,
+        provider: "mock",
+        retries: 0,
+        startedAt: "2026-01-01T00:00:00.000Z",
+        stopReason: "end_turn",
+      });
+      expect(
+        (result!.state as Record<string, unknown>).historyDelta,
+      ).toHaveLength(1);
+    });
+
+    it("serializes structured content", async () => {
+      const structured = envelope();
+      structured.response.content = { answer: 42 } as never;
+      const result = await storeExchange(structured);
+      expect(result!.content).toBe('{"answer":42}');
+    });
+
+    it("accepts scope and parent exchange options", async () => {
+      const result = await storeExchange(envelope(), {
+        exchange: "parent-id",
+        scope: "case#abc",
+      });
+      expect(result!.scope).toBe("case#abc");
+      expect(result!.exchange).toBe("parent-id");
+    });
+
+    it("truncates oversized items and marks metadata", async () => {
+      const big = envelope();
+      big.response.historyDelta = [
+        { content: "x".repeat(200 * 1024), role: "assistant" },
+      ];
+      big.request.input = "y".repeat(200 * 1024);
+      big.response.content = "z".repeat(400 * 1024);
+      const result = await storeExchange(big);
+      const metadata = result!.metadata as Record<string, unknown>;
+      expect(metadata.truncated).toContain("historyDelta");
+      expect(
+        (result!.state as Record<string, unknown>).historyDelta,
+      ).toBeUndefined();
+      expect((result!.content as string).endsWith("[truncated]")).toBe(true);
+    });
+  });
+});

--- a/packages/dynamodb/src/__tests__/tables.spec.ts
+++ b/packages/dynamodb/src/__tests__/tables.spec.ts
@@ -6,9 +6,15 @@ import { createTable, destroyTable } from "../tables.js";
 const send = vi.fn();
 
 vi.mock("@aws-sdk/client-dynamodb", () => ({
-  CreateTableCommand: vi.fn().mockImplementation((input) => ({ input })),
-  DeleteTableCommand: vi.fn().mockImplementation((input) => ({ input })),
-  DescribeTableCommand: vi.fn().mockImplementation((input) => ({ input })),
+  CreateTableCommand: vi.fn(function CreateTableCommand(input) {
+    return { input };
+  }),
+  DeleteTableCommand: vi.fn(function DeleteTableCommand(input) {
+    return { input };
+  }),
+  DescribeTableCommand: vi.fn(function DescribeTableCommand(input) {
+    return { input };
+  }),
   waitUntilTableExists: vi.fn().mockResolvedValue({ state: "SUCCESS" }),
 }));
 

--- a/packages/dynamodb/src/index.ts
+++ b/packages/dynamodb/src/index.ts
@@ -56,6 +56,13 @@ export type { ScanTableOptions } from "./scan.js";
 export { createTable, destroyTable } from "./tables.js";
 export type { CreateTableOptions, CreateTableResult } from "./tables.js";
 
+// Exchange persistence (default persister for @jaypie/llm onExchange)
+export { storeExchange } from "./storeExchange.js";
+export type {
+  StoreExchangeEnvelope,
+  StoreExchangeOptions,
+} from "./storeExchange.js";
+
 // Seed and export utilities
 export {
   exportEntities,

--- a/packages/dynamodb/src/storeExchange.ts
+++ b/packages/dynamodb/src/storeExchange.ts
@@ -1,0 +1,191 @@
+import { APEX, registerExchangeModel } from "@jaypie/fabric";
+import log from "@jaypie/logger";
+
+import { isInitialized } from "./client.js";
+import { createEntity } from "./entities.js";
+import { StorableEntity } from "./types.js";
+
+//
+//
+// Constants
+//
+
+/**
+ * Byte budget below the 400KB DynamoDB item limit, leaving headroom for
+ * GSI keys and attribute-name overhead added at write time.
+ */
+const MAX_ITEM_BYTES = 350 * 1024;
+
+const TRUNCATED_MARKER = "[truncated]";
+
+//
+//
+// Types
+//
+
+/**
+ * Structural subset of @jaypie/llm's LlmExchangeEnvelope. Declared locally so
+ * @jaypie/dynamodb takes no dependency on @jaypie/llm.
+ */
+export interface StoreExchangeEnvelope {
+  ids?: string[];
+  request?: {
+    data?: Record<string, unknown>;
+    input?: unknown;
+    model?: string;
+    [key: string]: unknown;
+  };
+  resolution?: {
+    fallbackAttempts?: number;
+    fallbackUsed?: boolean;
+    model?: string;
+    provider?: string;
+    retries?: number;
+    [key: string]: unknown;
+  };
+  response?: {
+    content?: unknown;
+    error?: unknown;
+    historyDelta?: unknown[];
+    reasoning?: string[];
+    status?: string;
+    stopReason?: string;
+    usage?: unknown[];
+    usageTotals?: Record<string, unknown>;
+    [key: string]: unknown;
+  };
+  timing?: {
+    duration?: number;
+    startedAt?: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+export interface StoreExchangeOptions {
+  /** Parent exchange id for turn chains */
+  exchange?: string;
+  /** Scope for the entity; defaults to APEX */
+  scope?: string;
+}
+
+//
+//
+// Helpers
+//
+
+function byteSize(value: unknown): number {
+  try {
+    return Buffer.byteLength(JSON.stringify(value) ?? "", "utf8");
+  } catch {
+    return Number.MAX_SAFE_INTEGER;
+  }
+}
+
+//
+//
+// Main
+//
+
+/**
+ * Persist one operate() exchange envelope as an `exchange` entity.
+ *
+ * Never throws: warns and returns null when the client is uninitialized or
+ * the write fails — exchange persistence must not break the LLM call. Owns
+ * 400KB item-limit safety by dropping the history delta, then long content,
+ * with an explicit truncation marker in metadata.
+ */
+export async function storeExchange(
+  envelope: StoreExchangeEnvelope,
+  { exchange, scope }: StoreExchangeOptions = {},
+): Promise<StorableEntity | null> {
+  try {
+    registerExchangeModel();
+
+    if (!isInitialized()) {
+      log.warn(
+        "[storeExchange] DynamoDB client is not initialized; call initClient() first. Exchange not persisted.",
+      );
+      return null;
+    }
+
+    const { request, resolution, response, timing } = envelope;
+
+    const content =
+      typeof response?.content === "string"
+        ? response.content
+        : response?.content !== undefined
+          ? JSON.stringify(response.content)
+          : undefined;
+
+    const entity: StorableEntity = {
+      id: crypto.randomUUID(),
+      model: "exchange",
+      scope: scope ?? APEX,
+      ...(exchange && { exchange }),
+      ...(content !== undefined && { content }),
+      ...(request?.data && { data: request.data }),
+      ...(request?.input !== undefined && { input: request.input }),
+      ...(resolution?.model && { llm: resolution.model }),
+      ...(response?.status && { status: response.status }),
+      ...(envelope.ids?.length && {
+        xid: envelope.ids[envelope.ids.length - 1],
+      }),
+      metadata: {
+        ...(timing?.duration !== undefined && { duration: timing.duration }),
+        ...(timing?.startedAt && { startedAt: timing.startedAt }),
+        ...(resolution?.provider && { provider: resolution.provider }),
+        ...(resolution?.fallbackUsed !== undefined && {
+          fallbackUsed: resolution.fallbackUsed,
+        }),
+        ...(resolution?.fallbackAttempts !== undefined && {
+          fallbackAttempts: resolution.fallbackAttempts,
+        }),
+        ...(resolution?.retries !== undefined && {
+          retries: resolution.retries,
+        }),
+        ...(response?.stopReason && { stopReason: response.stopReason }),
+        ...(response?.error !== undefined && { error: response.error }),
+        ...(response?.usageTotals && { usage: response.usageTotals }),
+        ...(envelope.ids?.length && { ids: envelope.ids }),
+      },
+      state: {
+        ...(response?.historyDelta?.length && {
+          historyDelta: response.historyDelta,
+        }),
+        ...(response?.reasoning?.length && { reasoning: response.reasoning }),
+      },
+    };
+
+    // 400KB item-limit safety: drop the largest payloads first, then
+    // truncate long fields, marking each drop in metadata.truncated
+    if (byteSize(entity) > MAX_ITEM_BYTES) {
+      const truncated: string[] = [];
+      const state = entity.state as Record<string, unknown>;
+      if (state.historyDelta) {
+        delete state.historyDelta;
+        truncated.push("historyDelta");
+      }
+      if (byteSize(entity) > MAX_ITEM_BYTES && entity.input !== undefined) {
+        entity.input = TRUNCATED_MARKER;
+        truncated.push("input");
+      }
+      if (
+        byteSize(entity) > MAX_ITEM_BYTES &&
+        typeof entity.content === "string"
+      ) {
+        entity.content = entity.content.slice(0, 1024) + TRUNCATED_MARKER;
+        truncated.push("content");
+      }
+      (entity.metadata as Record<string, unknown>).truncated = truncated;
+      log.warn("[storeExchange] Exchange exceeded item size budget; truncated");
+      log.var({ truncated });
+    }
+
+    return await createEntity({ entity });
+  } catch (error) {
+    log.warn("[storeExchange] Failed to persist exchange");
+    log.var({ error });
+    return null;
+  }
+}

--- a/packages/fabric/package.json
+++ b/packages/fabric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/fabric",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Jaypie modeling framework with type conversion, service handlers, and adapters",
   "repository": {
     "type": "git",

--- a/packages/fabric/src/__tests__/exchange.spec.ts
+++ b/packages/fabric/src/__tests__/exchange.spec.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  assertModelStatus,
+  clearRegistry,
+  getModelIndexes,
+  getModelStatus,
+  isModelRegistered,
+} from "../index/registry.js";
+import {
+  EXCHANGE_MODEL,
+  EXCHANGE_MODEL_NAME,
+  EXCHANGE_STATUS,
+  registerExchangeModel,
+} from "../models/exchange.js";
+
+describe("Exchange Model", () => {
+  beforeEach(() => {
+    clearRegistry();
+  });
+
+  describe("Base Cases", () => {
+    it("registerExchangeModel is a function", () => {
+      expect(typeof registerExchangeModel).toBe("function");
+    });
+    it("EXCHANGE_MODEL declares the exchange model", () => {
+      expect(EXCHANGE_MODEL.model).toBe(EXCHANGE_MODEL_NAME);
+      expect(EXCHANGE_MODEL_NAME).toBe("exchange");
+    });
+  });
+
+  describe("Features", () => {
+    it("registers the exchange model with indexModel and indexModelXid", () => {
+      registerExchangeModel();
+      expect(isModelRegistered("exchange")).toBe(true);
+      const indexes = getModelIndexes("exchange");
+      expect(indexes.map(({ name }) => name)).toEqual([
+        "indexModel",
+        "indexModelXid",
+      ]);
+    });
+
+    it("declares the operate settlement status vocabulary", () => {
+      registerExchangeModel();
+      expect(getModelStatus("exchange")).toEqual([
+        EXCHANGE_STATUS.COMPLETED,
+        EXCHANGE_STATUS.INCOMPLETE,
+        EXCHANGE_STATUS.IN_PROGRESS,
+      ]);
+      expect(() => assertModelStatus("exchange", "completed")).not.toThrow();
+      expect(() => assertModelStatus("exchange", "banana")).toThrow();
+    });
+
+    it("is idempotent", () => {
+      registerExchangeModel();
+      expect(() => registerExchangeModel()).not.toThrow();
+      expect(isModelRegistered("exchange")).toBe(true);
+    });
+  });
+});

--- a/packages/fabric/src/data/services/create.ts
+++ b/packages/fabric/src/data/services/create.ts
@@ -42,9 +42,7 @@ export function createCreateService<T extends FabricModel = FabricModel>(
 
       // Calculate scope
       const scopeConfig = globalConfig.scope as
-        | ScopeFunction
-        | string
-        | undefined;
+        ScopeFunction | string | undefined;
       const httpContext = context?.http;
       const scope = httpContext
         ? await calculateScopeFromConfig(scopeConfig, httpContext)

--- a/packages/fabric/src/data/services/list.ts
+++ b/packages/fabric/src/data/services/list.ts
@@ -93,9 +93,7 @@ export function createListService<T extends FabricModel = FabricModel>(
 
       // Calculate scope
       const scopeConfig = globalConfig.scope as
-        | ScopeFunction
-        | string
-        | undefined;
+        ScopeFunction | string | undefined;
       const httpContext = context?.http;
       const scope = httpContext
         ? await calculateScopeFromConfig(scopeConfig, httpContext)

--- a/packages/fabric/src/data/types.ts
+++ b/packages/fabric/src/data/types.ts
@@ -70,8 +70,7 @@ export interface FabricDataOperationConfig<
  * Simplified operation config - boolean to enable/disable or full config
  */
 export type FabricDataOperationOption<T extends FabricModel = FabricModel> =
-  | FabricDataOperationConfig<T>
-  | boolean;
+  FabricDataOperationConfig<T> | boolean;
 
 // #endregion
 

--- a/packages/fabric/src/express/FabricRouter.ts
+++ b/packages/fabric/src/express/FabricRouter.ts
@@ -91,12 +91,7 @@ export function FabricRouter(config: FabricRouterConfig): FabricExpressRouter {
     // Register all methods for this path
     for (const method of middleware.methods) {
       const lowerMethod = method.toLowerCase() as
-        | "get"
-        | "post"
-        | "put"
-        | "delete"
-        | "patch"
-        | "options";
+        "get" | "post" | "put" | "delete" | "patch" | "options";
 
       // Express router methods
       if (lowerMethod === "options") {

--- a/packages/fabric/src/http/types.ts
+++ b/packages/fabric/src/http/types.ts
@@ -43,8 +43,7 @@ export type AuthorizationFunction<TAuth = unknown> = (
  * Authorization configuration - either a function or false for public endpoints
  */
 export type AuthorizationConfig<TAuth = unknown> =
-  | AuthorizationFunction<TAuth>
-  | false;
+  AuthorizationFunction<TAuth> | false;
 
 // #endregion
 
@@ -124,8 +123,7 @@ export interface FabricHttpConfig<
 > extends Omit<ServiceConfig<TInput, TOutput>, "service"> {
   /** Pre-built fabricService or inline service function */
   service?:
-    | Service<TInput, TOutput>
-    | ServiceConfig<TInput, TOutput>["service"];
+    Service<TInput, TOutput> | ServiceConfig<TInput, TOutput>["service"];
 
   /** Transform HTTP context to service input (defaults to body + query merge) */
   http?: HttpTransformFunction<TInput>;
@@ -166,12 +164,7 @@ export interface FabricHttpService<
  * Supported HTTP methods
  */
 export type HttpMethod =
-  | "GET"
-  | "POST"
-  | "PUT"
-  | "DELETE"
-  | "PATCH"
-  | "OPTIONS";
+  "GET" | "POST" | "PUT" | "DELETE" | "PATCH" | "OPTIONS";
 
 /**
  * Default HTTP methods for fabric services
@@ -350,8 +343,7 @@ export interface FabricHttpServerRoute<
  * Service entry - either a FabricHttpService or a route config
  */
 export type FabricHttpServerServiceEntry =
-  | FabricHttpService
-  | FabricHttpServerRoute;
+  FabricHttpService | FabricHttpServerRoute;
 
 /**
  * Configuration for FabricHttpServer

--- a/packages/fabric/src/index.ts
+++ b/packages/fabric/src/index.ts
@@ -24,6 +24,15 @@ export type {
   FabricProgress,
 } from "./models/base.js";
 
+// FabricExchange (canonical exchange model: one LLM operate() call)
+export {
+  EXCHANGE_MODEL,
+  EXCHANGE_MODEL_NAME,
+  EXCHANGE_STATUS,
+  registerExchangeModel,
+} from "./models/exchange.js";
+export type { ExchangeStatus, FabricExchange } from "./models/exchange.js";
+
 // Constants
 export { APEX, FABRIC_VERSION, SEPARATOR, SYSTEM_MODELS } from "./constants.js";
 export type { SystemModel } from "./constants.js";

--- a/packages/fabric/src/lambda/fabricLambda.ts
+++ b/packages/fabric/src/lambda/fabricLambda.ts
@@ -153,7 +153,7 @@ export function fabricLambda<TResult = unknown>(
   // Create the inner Lambda handler logic (context param required for lambdaHandler signature)
   const innerHandler = async (
     event: unknown,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
     _context?: LambdaContext,
   ): Promise<TResult | TResult[]> => {
     // Extract messages from SQS/SNS event wrapper

--- a/packages/fabric/src/models/exchange.ts
+++ b/packages/fabric/src/models/exchange.ts
@@ -1,0 +1,87 @@
+/**
+ * FabricExchange - Canonical `exchange` model: an event entity representing
+ * one LLM operate() call.
+ *
+ * Turn chains reference the parent exchange and store input deltas only —
+ * never the resent history. Tool loops are the history delta within one
+ * exchange, not separate entities.
+ */
+
+import { fabricIndex } from "../index/fabricIndex.js";
+import { isModelRegistered, registerModel } from "../index/registry.js";
+import type { ModelSchema } from "../index/types.js";
+import type { FabricModel } from "./base.js";
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+export const EXCHANGE_MODEL_NAME = "exchange";
+
+/**
+ * Status vocabulary aligned with operate() settlement
+ * (LlmResponseStatus in @jaypie/llm)
+ */
+export const EXCHANGE_STATUS = {
+  COMPLETED: "completed",
+  IN_PROGRESS: "in_progress",
+  INCOMPLETE: "incomplete",
+} as const;
+
+export type ExchangeStatus =
+  (typeof EXCHANGE_STATUS)[keyof typeof EXCHANGE_STATUS];
+
+/**
+ * Canonical registration schema for the exchange model. Every project shares
+ * these attributes, status vocabulary, and indexes.
+ */
+export const EXCHANGE_MODEL: ModelSchema = {
+  indexes: [fabricIndex(), fabricIndex("xid")],
+  model: EXCHANGE_MODEL_NAME,
+  status: [
+    EXCHANGE_STATUS.COMPLETED,
+    EXCHANGE_STATUS.INCOMPLETE,
+    EXCHANGE_STATUS.IN_PROGRESS,
+  ],
+};
+
+// =============================================================================
+// FabricExchange
+// =============================================================================
+
+export interface FabricExchange extends FabricModel {
+  /** The actual response text or serialized structured output */
+  content?: string;
+
+  /** Interpolation parameters passed to the call */
+  data?: Record<string, unknown>;
+
+  /** Reference to the parent exchange for turn chains */
+  exchange?: string;
+
+  /** Request input; turn chains store the input delta only */
+  input?: unknown;
+
+  /** Served LLM model id (e.g., "claude-sonnet-5"); `model` is the entity type */
+  llm?: string;
+
+  /** Position in the exchange lifecycle */
+  status: ExchangeStatus;
+
+  /** Provider response id */
+  xid?: string;
+}
+
+// =============================================================================
+// Registration
+// =============================================================================
+
+/**
+ * Idempotently register the canonical exchange model.
+ */
+export function registerExchangeModel(): void {
+  if (isModelRegistered(EXCHANGE_MODEL_NAME)) {
+    return;
+  }
+  registerModel(EXCHANGE_MODEL);
+}

--- a/packages/fabric/src/service.ts
+++ b/packages/fabric/src/service.ts
@@ -246,8 +246,7 @@ export function isService<
 async function runSerializer<TInput, TOutput, TSerializedOutput>(
   data: { input: TInput; output: TOutput },
   serializer:
-    | SerializerFunction<TInput, TOutput, TSerializedOutput>
-    | undefined,
+    SerializerFunction<TInput, TOutput, TSerializedOutput> | undefined,
   context: ServiceContext | undefined,
 ): Promise<TOutput | TSerializedOutput> {
   if (!serializer) {

--- a/packages/jaypie/package.json
+++ b/packages/jaypie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jaypie",
-  "version": "1.2.65",
+  "version": "1.2.66",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"
@@ -59,7 +59,7 @@
     "typescript-eslint": "^8.46.1"
   },
   "peerDependencies": {
-    "@jaypie/llm": "^1.3.13"
+    "@jaypie/llm": "^1.3.14"
   },
   "peerDependenciesMeta": {
     "@jaypie/llm": {

--- a/packages/llm/CLAUDE.md
+++ b/packages/llm/CLAUDE.md
@@ -373,6 +373,24 @@ loop. The `hooks` option remains the right choice when the full provider
 request/response payloads are needed. `stream()` communicates progress
 through its chunks; `onProgress` applies to `operate()`.
 
+### Exchange Capture
+
+`operate()` accepts `onExchange`, fired once per settlement (success or
+failure) with a fully serializable `LlmExchangeEnvelope`: `request` (raw
+pre-interpolation input, data, placeholders, system, instructions, model,
+format as JSON Schema, tool names, turns, temperature, effort,
+providerOptions, user), `response` (content, historyDelta, per-call usage +
+`usageTotals` keyed `provider:model`, reasoning, status, error, stopReason),
+`resolution` (served provider/model, fallbackUsed, fallbackAttempts,
+retries), `timing`, and provider response `ids`. Callback errors are logged
+and never interrupt the call. The loop assembles the envelope
+(`src/operate/exchange/`), attaches it as `response.exchange` (or onto a
+thrown error), and the `Llm` facade stamps `resolution` and fires the
+callback exactly once per `operate()`. Setting `LLM_EXCHANGE_ENABLED` also
+persists each envelope via `@jaypie/dynamodb`'s `storeExchange`
+(`src/observability/exchangeStore.ts`, same lazy bundler-safe pattern as
+LLMObs; silent no-op when the optional peer is absent).
+
 ### Operate Logging
 
 The operate loop logs `operate.input`, `operate.options`, `operate.request`,
@@ -497,6 +515,7 @@ when the matching `*_API_KEY` is set and skip otherwise.
 - `FIREWORKS_API_KEY` - Fireworks API key
 - `OPENROUTER_API_KEY` - OpenRouter API key
 - `XAI_API_KEY` - xAI (Grok) API key
+- `LLM_EXCHANGE_ENABLED` - Persist each `operate()` call as an `exchange` entity via `@jaypie/dynamodb` `storeExchange` (optional peer, lazily resolved; silent no-op when absent)
 
 Keys are resolved via `getEnvSecret` from `@jaypie/aws` (supports AWS Secrets Manager).
 

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/llm",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "description": "Large language model utilities",
   "repository": {
     "type": "git",
@@ -55,11 +55,15 @@
   },
   "peerDependencies": {
     "@aws-sdk/client-bedrock-runtime": "^3.1045.0",
+    "@jaypie/dynamodb": "*",
     "@jaypie/kit": "*",
     "@jaypie/logger": "*"
   },
   "peerDependenciesMeta": {
     "@aws-sdk/client-bedrock-runtime": {
+      "optional": true
+    },
+    "@jaypie/dynamodb": {
       "optional": true
     }
   },

--- a/packages/llm/src/Llm.ts
+++ b/packages/llm/src/Llm.ts
@@ -4,7 +4,11 @@ import log from "@jaypie/logger";
 import { DEFAULT, LlmProviderName, PROVIDER } from "./constants.js";
 import { determineModelProvider } from "./util/determineModelProvider.js";
 import { resolveModelChain } from "./util/resolveModelChain.js";
+import { emitExchange } from "./operate/exchange/index.js";
+import { persistExchange } from "./observability/exchangeStore.js";
 import {
+  LlmExchangeCallback,
+  LlmExchangeEnvelope,
   LlmFallbackConfig,
   LlmHistory,
   LlmInputMessage,
@@ -216,12 +220,17 @@ class Llm implements LlmProvider {
     attempts++;
     try {
       const response = await this._llm.operate(input, optionsWithoutFallback);
-      return {
+      const settled = {
         ...response,
         fallbackAttempts: attempts,
         fallbackUsed: false,
         provider: response.provider || this._provider,
       };
+      await this.settleExchange({
+        onExchange: resolvedOptions.onExchange,
+        response: settled,
+      });
+      return settled;
     } catch (error) {
       lastError = error as Error;
       log.warn(`Provider ${this._provider} failed`, {
@@ -230,21 +239,33 @@ class Llm implements LlmProvider {
       });
     }
 
-    // Try fallback providers
+    // Try fallback providers. The fallback instance's underlying provider is
+    // called directly so the nested facade does not settle the exchange —
+    // exactly one settlement per operate() happens here.
     for (const fallbackConfig of fallbackChain) {
       attempts++;
       try {
         const fallbackInstance = this.createFallbackInstance(fallbackConfig);
-        const response = await fallbackInstance.operate(
+        if (!fallbackInstance._llm.operate) {
+          throw new NotImplementedError(
+            `Provider ${fallbackConfig.provider} does not support operate method`,
+          );
+        }
+        const response = await fallbackInstance._llm.operate(
           input,
           optionsWithoutFallback,
         );
-        return {
+        const settled = {
           ...response,
           fallbackAttempts: attempts,
           fallbackUsed: true,
           provider: response.provider || fallbackConfig.provider,
         };
+        await this.settleExchange({
+          onExchange: resolvedOptions.onExchange,
+          response: settled,
+        });
+        return settled;
       } catch (error) {
         lastError = error as Error;
         log.warn(`Fallback provider ${fallbackConfig.provider} failed`, {
@@ -254,8 +275,50 @@ class Llm implements LlmProvider {
       }
     }
 
-    // All providers failed, throw the last error
+    // All providers failed: settle the exchange from the envelope the loop
+    // attached to the last error, then throw
+    const failureEnvelope = (lastError as { exchange?: LlmExchangeEnvelope })
+      ?.exchange;
+    if (failureEnvelope) {
+      failureEnvelope.resolution = {
+        ...failureEnvelope.resolution,
+        fallbackAttempts: attempts,
+        fallbackUsed: attempts > 1,
+      };
+      await emitExchange({
+        envelope: failureEnvelope,
+        onExchange: resolvedOptions.onExchange,
+      });
+      await persistExchange(failureEnvelope);
+    }
     throw lastError;
+  }
+
+  /**
+   * Stamp fallback resolution onto the envelope the operate loop attached to
+   * the response and deliver it to the caller's onExchange. Fires once per
+   * operate() settlement; callback errors are logged and never thrown.
+   */
+  private async settleExchange({
+    onExchange,
+    response,
+  }: {
+    onExchange?: LlmExchangeCallback;
+    response: LlmOperateResponse;
+  }): Promise<void> {
+    const envelope = response.exchange;
+    if (!envelope) {
+      return;
+    }
+    envelope.resolution = {
+      ...envelope.resolution,
+      fallbackAttempts: response.fallbackAttempts,
+      fallbackUsed: response.fallbackUsed,
+      model: response.model,
+      provider: response.provider,
+    };
+    await emitExchange({ envelope, onExchange });
+    await persistExchange(envelope);
   }
 
   async *stream(

--- a/packages/llm/src/__tests__/Llm.class.spec.ts
+++ b/packages/llm/src/__tests__/Llm.class.spec.ts
@@ -464,4 +464,76 @@ describe("Llm Class", () => {
       expect(result.fallbackUsed).toBe(true);
     });
   });
+
+  describe("Exchange Settlement", () => {
+    const mockEnvelope = () => ({
+      request: { input: "test" },
+      resolution: {},
+      response: { historyDelta: [], status: "completed", usage: [] },
+      timing: { duration: 1, startedAt: "2026-01-01T00:00:00.000Z" },
+    });
+
+    it("fires onExchange once with fallback resolution stamped", async () => {
+      openAiOperateMock.mockResolvedValue({
+        content: "ok",
+        exchange: mockEnvelope(),
+        model: "gpt-4",
+        provider: "openai",
+      });
+      const onExchange = vi.fn();
+      const llm = new Llm(PROVIDER.OPENAI.NAME);
+      await llm.operate("test", { onExchange });
+      expect(onExchange).toHaveBeenCalledOnce();
+      const envelope = onExchange.mock.calls[0][0];
+      expect(envelope.resolution.fallbackAttempts).toBe(1);
+      expect(envelope.resolution.fallbackUsed).toBe(false);
+      expect(envelope.resolution.provider).toBe("openai");
+      expect(envelope.resolution.model).toBe("gpt-4");
+    });
+
+    it("fires onExchange once on the fallback path", async () => {
+      openAiOperateMock.mockRejectedValue(new Error("Primary failed"));
+      anthropicOperateMock.mockResolvedValue({
+        content: "ok",
+        exchange: mockEnvelope(),
+        model: "claude-3-opus",
+        provider: "anthropic",
+      });
+      const onExchange = vi.fn();
+      const llm = new Llm(PROVIDER.OPENAI.NAME, {
+        fallback: [{ provider: "anthropic", model: "claude-3-opus" }],
+      });
+      await llm.operate("test", { onExchange });
+      expect(onExchange).toHaveBeenCalledOnce();
+      const envelope = onExchange.mock.calls[0][0];
+      expect(envelope.resolution.fallbackAttempts).toBe(2);
+      expect(envelope.resolution.fallbackUsed).toBe(true);
+      expect(envelope.resolution.provider).toBe("anthropic");
+    });
+
+    it("fires onExchange on total failure before throwing", async () => {
+      const failure = new Error("Primary failed") as Error & {
+        exchange?: unknown;
+      };
+      failure.exchange = mockEnvelope();
+      openAiOperateMock.mockRejectedValue(failure);
+      const onExchange = vi.fn();
+      const llm = new Llm(PROVIDER.OPENAI.NAME);
+      await expect(llm.operate("test", { onExchange })).rejects.toThrow(
+        "Primary failed",
+      );
+      expect(onExchange).toHaveBeenCalledOnce();
+      const envelope = onExchange.mock.calls[0][0];
+      expect(envelope.resolution.fallbackAttempts).toBe(1);
+      expect(envelope.resolution.fallbackUsed).toBe(false);
+    });
+
+    it("does not fire onExchange when the response has no envelope", async () => {
+      openAiOperateMock.mockResolvedValue({ content: "ok" });
+      const onExchange = vi.fn();
+      const llm = new Llm(PROVIDER.OPENAI.NAME);
+      await llm.operate("test", { onExchange });
+      expect(onExchange).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/llm/src/index.ts
+++ b/packages/llm/src/index.ts
@@ -2,6 +2,12 @@ export { default as Llm } from "./Llm.js";
 export * as LLM from "./constants.js";
 export type { LlmEffort } from "./constants.js";
 export type {
+  LlmExchangeCallback,
+  LlmExchangeEnvelope,
+  LlmExchangeRequest,
+  LlmExchangeResolution,
+  LlmExchangeResponse,
+  LlmExchangeTiming,
   LlmFallbackConfig,
   LlmHistory,
   LlmInputContent,

--- a/packages/llm/src/observability/exchangeStore.ts
+++ b/packages/llm/src/observability/exchangeStore.ts
@@ -1,0 +1,111 @@
+import { createRequire } from "module";
+import { pathToFileURL } from "url";
+
+import { LlmExchangeEnvelope } from "../types/LlmProvider.interface.js";
+import { getLogger } from "../util/index.js";
+import { isExchangeStoreEnabled } from "../operate/exchange/emitExchange.js";
+
+//
+//
+// Types
+//
+
+/** Minimal shape of the @jaypie/dynamodb surface this module uses. */
+interface ExchangeStoreSdk {
+  storeExchange: (envelope: LlmExchangeEnvelope) => Promise<unknown>;
+}
+
+//
+//
+// Constants
+//
+
+const MODULE = {
+  // Computed at runtime so bundlers (esbuild) do not attempt to include
+  // @jaypie/dynamodb, which is an optional peer dependency.
+  JAYPIE_DYNAMODB: ["@jaypie", "dynamodb"].join("/"),
+};
+
+//
+//
+// Helpers
+//
+
+// CJS/ESM compatible require - handles bundling to CJS where import.meta.url
+// becomes undefined (mirrors observability/llmobs.ts).
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore - __filename exists in CJS context when ESM is bundled to CJS
+const requireModule =
+  typeof __filename !== "undefined"
+    ? createRequire(pathToFileURL(__filename).href)
+    : createRequire(import.meta.url);
+
+let resolved = false;
+let cachedSdk: ExchangeStoreSdk | null = null;
+let injectedSdk: ExchangeStoreSdk | null = null;
+
+/**
+ * Lazily resolve @jaypie/dynamodb's storeExchange. Returns null (and never
+ * throws) when the peer is absent. Cached after the first attempt.
+ */
+function resolveExchangeStore(): ExchangeStoreSdk | null {
+  if (resolved) {
+    return cachedSdk;
+  }
+  resolved = true;
+  try {
+    const dynamodb = requireModule(MODULE.JAYPIE_DYNAMODB);
+    const sdk = dynamodb?.default ?? dynamodb;
+    if (sdk && typeof sdk.storeExchange === "function") {
+      cachedSdk = sdk as ExchangeStoreSdk;
+    }
+  } catch {
+    cachedSdk = null;
+  }
+  return cachedSdk;
+}
+
+/** Reset the cached resolution. Exposed for tests. */
+export function _resetExchangeStore(): void {
+  resolved = false;
+  cachedSdk = null;
+  injectedSdk = null;
+}
+
+/**
+ * Inject a store to bypass @jaypie/dynamodb resolution. Test-only: the peer
+ * is optional, so the enabled path cannot otherwise be exercised in unit
+ * tests without it installed.
+ */
+export function _setExchangeStore(sdk: ExchangeStoreSdk | null): void {
+  injectedSdk = sdk;
+}
+
+//
+//
+// Main
+//
+
+/**
+ * Persist an exchange envelope via @jaypie/dynamodb when
+ * LLM_EXCHANGE_ENABLED is set. Silent no-op when the flag is unset or the
+ * peer is absent; persister failures are logged and never thrown.
+ */
+export async function persistExchange(
+  envelope: LlmExchangeEnvelope,
+): Promise<void> {
+  if (!isExchangeStoreEnabled()) {
+    return;
+  }
+  const sdk = injectedSdk ?? resolveExchangeStore();
+  if (!sdk) {
+    return;
+  }
+  try {
+    await sdk.storeExchange(envelope);
+  } catch (error) {
+    const log = getLogger();
+    log.warn("[operate] Exchange persistence failed");
+    log.var({ error });
+  }
+}

--- a/packages/llm/src/operate/OperateLoop.ts
+++ b/packages/llm/src/operate/OperateLoop.ts
@@ -3,6 +3,7 @@ import { JsonObject } from "@jaypie/types";
 
 import { Toolkit } from "../tools/Toolkit.class.js";
 import {
+  LlmExchangeEnvelope,
   LlmHistory,
   LlmHistoryItem,
   LlmInputMessage,
@@ -13,6 +14,7 @@ import {
   LlmOperateResponse,
   LlmOutputMessage,
   LlmProgressEventType,
+  LlmResponseStatus,
   LlmToolCall,
   LlmToolResult,
 } from "../types/LlmProvider.interface.js";
@@ -29,6 +31,10 @@ import {
   tallyOperate,
 } from "../util/index.js";
 import { ProviderAdapter } from "./adapters/ProviderAdapter.interface.js";
+import {
+  buildExchangeEnvelope,
+  isExchangeRequested,
+} from "./exchange/index.js";
 import { HookRunner, hookRunner, LlmHooks } from "./hooks/index.js";
 import { InputProcessor, inputProcessor } from "./input/index.js";
 import { emitProgress } from "./progress/index.js";
@@ -159,10 +165,15 @@ export class OperateLoop {
     log.trace.var({ "operate.input": input });
     log.trace.var({ "operate.options": options });
 
+    const startedAt = new Date().toISOString();
+    const startMs = Date.now();
+
     // Initialize state
     const state = await this.initializeState(input, options);
     const context = this.createContext(options);
     const modelName = options.model ?? this.adapter.defaultModel;
+    const exchangeRequested = isExchangeRequested(options);
+    const initialHistoryLength = state.responseBuilder.getHistory().length;
 
     await emitProgress({
       event: {
@@ -176,72 +187,120 @@ export class OperateLoop {
 
     // Enclosing LLM Observability span (no-op when DD_LLMOBS_ENABLED is unset).
     // Child llm/tool spans nest under it via the SDK's active-span context.
-    return withLlmObsSpan(
-      {
-        kind: state.toolkit ? "agent" : "llm",
-        modelName,
-        modelProvider: this.adapter.name,
-        name: "jaypie.llm.operate",
-      },
-      async () => {
-        // Build initial request
-        let request = this.buildInitialRequest(state, options);
+    try {
+      return await withLlmObsSpan(
+        {
+          kind: state.toolkit ? "agent" : "llm",
+          modelName,
+          modelProvider: this.adapter.name,
+          name: "jaypie.llm.operate",
+        },
+        async () => {
+          // Build initial request
+          let request = this.buildInitialRequest(state, options);
 
-        // Multi-turn loop
-        while (state.currentTurn < state.maxTurns) {
-          state.currentTurn++;
+          // Multi-turn loop
+          while (state.currentTurn < state.maxTurns) {
+            state.currentTurn++;
 
-          // Execute one turn with retry logic
-          const shouldContinue = await this.executeOneTurn(
-            request,
-            state,
-            context,
-            options,
-          );
+            // Execute one turn with retry logic
+            const shouldContinue = await this.executeOneTurn(
+              request,
+              state,
+              context,
+              options,
+            );
 
-          if (!shouldContinue) {
-            break;
+            if (!shouldContinue) {
+              break;
+            }
+
+            // Rebuild request with updated history for next turn
+            request = {
+              effort: options.effort,
+              format: state.formattedFormat,
+              instructions: options.instructions,
+              messages: state.currentInput,
+              model: modelName,
+              providerOptions: options.providerOptions,
+              structuredOutputRetry: state.structuredOutputRetry,
+              system: options.system,
+              temperature: options.temperature,
+              tools: state.formattedTools,
+              user: options.user,
+            };
           }
 
-          // Rebuild request with updated history for next turn
-          request = {
-            effort: options.effort,
-            format: state.formattedFormat,
-            instructions: options.instructions,
-            messages: state.currentInput,
-            model: modelName,
-            providerOptions: options.providerOptions,
-            structuredOutputRetry: state.structuredOutputRetry,
-            system: options.system,
-            temperature: options.temperature,
-            tools: state.formattedTools,
-            user: options.user,
+          const response = state.responseBuilder.build();
+          if (exchangeRequested) {
+            response.exchange = buildExchangeEnvelope({
+              duration: Date.now() - startMs,
+              initialHistoryLength,
+              input,
+              options,
+              response,
+              startedAt,
+              state,
+            });
+          }
+          annotateLlmObs({
+            inputData: input,
+            metrics: usageToLlmObsMetrics(response.usage),
+            outputData: response.content,
+          });
+          tallyOperate({
+            toolCallNames: state.toolCallNames,
+            turns: state.currentTurn,
+            usage: response.usage,
+          });
+          await emitProgress({
+            event: {
+              content: response.content,
+              turn: state.currentTurn,
+              type: LlmProgressEventType.Done,
+              usage: response.usage,
+            },
+            onProgress: options.onProgress,
+          });
+          return response;
+        },
+      );
+    } catch (error) {
+      // A hard failure (retry budget exhausted, unrecoverable) still settles
+      // the exchange: attach the envelope to the thrown error so the facade
+      // can emit it before rethrowing to the caller.
+      if (exchangeRequested) {
+        const response = state.responseBuilder.build();
+        if (!response.error) {
+          const thrown = error as {
+            detail?: string;
+            message?: string;
+            status?: number | string;
+            title?: string;
+            name?: string;
+          };
+          response.error = {
+            detail: thrown.detail ?? thrown.message,
+            status: thrown.status ?? 500,
+            title: thrown.title ?? thrown.name ?? "Error",
           };
         }
-
-        const response = state.responseBuilder.build();
-        annotateLlmObs({
-          inputData: input,
-          metrics: usageToLlmObsMetrics(response.usage),
-          outputData: response.content,
-        });
-        tallyOperate({
-          toolCallNames: state.toolCallNames,
-          turns: state.currentTurn,
-          usage: response.usage,
-        });
-        await emitProgress({
-          event: {
-            content: response.content,
-            turn: state.currentTurn,
-            type: LlmProgressEventType.Done,
-            usage: response.usage,
-          },
-          onProgress: options.onProgress,
-        });
-        return response;
-      },
-    );
+        if (response.status === LlmResponseStatus.InProgress) {
+          response.status = LlmResponseStatus.Incomplete;
+        }
+        (error as { exchange?: LlmExchangeEnvelope }).exchange =
+          buildExchangeEnvelope({
+            duration: Date.now() - startMs,
+            initialHistoryLength,
+            input,
+            options,
+            response,
+            startedAt,
+            state,
+          });
+      }
+      throw error;
+    }
   }
 
   //
@@ -315,6 +374,7 @@ export class OperateLoop {
       formattedTools,
       maxTurns,
       responseBuilder,
+      retries: 0,
       toolCallNames: [],
       toolkit,
     };
@@ -395,27 +455,27 @@ export class OperateLoop {
       providerRequest,
     });
 
-    // Emit retry progress alongside the caller's onRetryableModelError hook
+    // Count retries for the exchange envelope and emit retry progress
+    // alongside the caller's onRetryableModelError hook
     const hooks = context.hooks as LlmHooks;
-    const hooksWithProgress: LlmHooks = options.onProgress
-      ? {
-          ...hooks,
-          onRetryableModelError: async (retryContext) => {
-            await emitProgress({
-              event: {
-                error:
-                  retryContext.error instanceof Error
-                    ? retryContext.error.message
-                    : String(retryContext.error),
-                turn: state.currentTurn,
-                type: LlmProgressEventType.Retry,
-              },
-              onProgress: options.onProgress,
-            });
-            return hooks?.onRetryableModelError?.(retryContext);
+    const hooksWithProgress: LlmHooks = {
+      ...hooks,
+      onRetryableModelError: async (retryContext) => {
+        state.retries++;
+        await emitProgress({
+          event: {
+            error:
+              retryContext.error instanceof Error
+                ? retryContext.error.message
+                : String(retryContext.error),
+            turn: state.currentTurn,
+            type: LlmProgressEventType.Retry,
           },
-        }
-      : hooks;
+          onProgress: options.onProgress,
+        });
+        return hooks?.onRetryableModelError?.(retryContext);
+      },
+    };
 
     // Execute with retry inside a child llm span (no-op when llmobs disabled).
     // RetryExecutor handles error hooks and throws appropriate errors.
@@ -490,6 +550,11 @@ export class OperateLoop {
     // Track usage
     if (parsed.usage) {
       state.responseBuilder.addUsage(parsed.usage);
+    }
+
+    // Track stop reason for the exchange envelope
+    if (parsed.stopReason) {
+      state.lastStopReason = parsed.stopReason;
     }
 
     // Add raw response

--- a/packages/llm/src/operate/exchange/__tests__/exchange.spec.ts
+++ b/packages/llm/src/operate/exchange/__tests__/exchange.spec.ts
@@ -1,0 +1,236 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { OperateLoop, OperateLoopConfig } from "../../OperateLoop.js";
+import { BaseProviderAdapter } from "../../adapters/index.js";
+import {
+  LlmExchangeEnvelope,
+  LlmResponseStatus,
+} from "../../../types/LlmProvider.interface.js";
+import {
+  ErrorCategory,
+  ParsedResponse,
+  StandardToolCall,
+} from "../../types.js";
+import { emitExchange, isExchangeStoreEnabled } from "../emitExchange.js";
+
+//
+//
+// Mock
+//
+
+vi.mock("@jaypie/kit", () => ({
+  JAYPIE: {
+    LIB: {
+      LLM: "@jaypie/llm",
+    },
+  },
+  placeholders: vi.fn((str: string) => str),
+  resolveValue: vi.fn((val) => val),
+  sleep: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@jaypie/logger", () => ({
+  log: {
+    lib: vi.fn(() => ({
+      debug: vi.fn(),
+      error: vi.fn(),
+      trace: Object.assign(vi.fn(), { var: vi.fn() }),
+      var: vi.fn(),
+      warn: vi.fn(),
+    })),
+    tally: vi.fn(),
+  },
+}));
+
+//
+//
+// Fixtures
+//
+
+class MockAdapter extends BaseProviderAdapter {
+  readonly name = "mock";
+  readonly defaultModel = "mock-model";
+
+  buildRequest = vi.fn((request) => request);
+  formatTools = vi.fn(() => []);
+  formatOutputSchema = vi.fn((schema) => schema);
+  executeRequest = vi.fn(() =>
+    Promise.resolve({
+      content: [{ type: "text", text: "Hello!" }],
+      id: "resp_123",
+      stop_reason: "end_turn",
+      usage: { input_tokens: 10, output_tokens: 20 },
+    }),
+  );
+  parseResponse = vi.fn((response): ParsedResponse => ({
+    content: "Hello!",
+    hasToolCalls: false,
+    stopReason: "end_turn",
+    usage: {
+      input: 10,
+      output: 20,
+      reasoning: 0,
+      total: 30,
+      provider: "mock",
+      model: "mock-model",
+    },
+    raw: response,
+  }));
+  extractToolCalls = vi.fn((): StandardToolCall[] => []);
+  extractUsage = vi.fn(() => ({
+    input: 10,
+    output: 20,
+    reasoning: 0,
+    total: 30,
+    provider: "mock",
+    model: "mock-model",
+  }));
+  formatToolResult = vi.fn(() => ({}));
+  appendToolResult = vi.fn((request) => request);
+  responseToHistoryItems = vi.fn(() => []);
+  classifyError = vi.fn(() => ({
+    error: new Error("Test"),
+    category: ErrorCategory.Unrecoverable,
+    shouldRetry: false,
+  }));
+  isComplete = vi.fn(() => true);
+}
+
+function createConfig(): OperateLoopConfig {
+  return {
+    adapter: new MockAdapter(),
+    client: {},
+  };
+}
+
+//
+//
+// Tests
+//
+
+describe("Exchange", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.LLM_EXCHANGE_ENABLED;
+  });
+
+  describe("Base Cases", () => {
+    it("emitExchange is a function", () => {
+      expect(typeof emitExchange).toBe("function");
+    });
+    it("isExchangeStoreEnabled defaults false", () => {
+      expect(isExchangeStoreEnabled()).toBe(false);
+    });
+  });
+
+  describe("Features", () => {
+    it("attaches an envelope to the response when onExchange is passed", async () => {
+      const loop = new OperateLoop(createConfig());
+      const response = await loop.execute("Hello", {
+        data: { user: "Taylor" },
+        model: "mock-model",
+        onExchange: vi.fn(),
+        temperature: 0.5,
+        user: "user-1",
+      });
+      const envelope = response.exchange;
+      expect(envelope).toBeDefined();
+      expect(envelope!.request.input).toBe("Hello");
+      expect(envelope!.request.data).toEqual({ user: "Taylor" });
+      expect(envelope!.request.model).toBe("mock-model");
+      expect(envelope!.request.temperature).toBe(0.5);
+      expect(envelope!.request.user).toBe("user-1");
+      expect(envelope!.response.status).toBe(LlmResponseStatus.Completed);
+      expect(envelope!.response.stopReason).toBe("end_turn");
+      expect(envelope!.response.usage).toHaveLength(1);
+      expect(envelope!.response.usageTotals).toEqual({
+        "mock:mock-model": {
+          input: 10,
+          model: "mock-model",
+          output: 20,
+          provider: "mock",
+          reasoning: 0,
+          total: 30,
+        },
+      });
+      expect(envelope!.ids).toEqual(["resp_123"]);
+      expect(envelope!.timing.startedAt).toBeDefined();
+      expect(envelope!.timing.duration).toBeGreaterThanOrEqual(0);
+    });
+
+    it("does not attach an envelope when not requested", async () => {
+      const loop = new OperateLoop(createConfig());
+      const response = await loop.execute("Hello", { model: "mock-model" });
+      expect(response.exchange).toBeUndefined();
+    });
+
+    it("attaches an envelope when LLM_EXCHANGE_ENABLED is set", async () => {
+      process.env.LLM_EXCHANGE_ENABLED = "1";
+      const loop = new OperateLoop(createConfig());
+      const response = await loop.execute("Hello", { model: "mock-model" });
+      expect(response.exchange).toBeDefined();
+    });
+
+    it("envelope survives JSON round-trip with no functions", async () => {
+      const loop = new OperateLoop(createConfig());
+      const response = await loop.execute("Hello", {
+        model: "mock-model",
+        onExchange: vi.fn(),
+      });
+      const serialized = JSON.parse(JSON.stringify(response.exchange));
+      expect(serialized.request.input).toBe("Hello");
+      const hasFunction = (value: unknown): boolean => {
+        if (typeof value === "function") return true;
+        if (value && typeof value === "object") {
+          return Object.values(value).some(hasFunction);
+        }
+        return false;
+      };
+      expect(hasFunction(response.exchange)).toBe(false);
+    });
+
+    it("attaches an envelope to a hard error", async () => {
+      const config = createConfig();
+      (config.adapter as MockAdapter).executeRequest = vi.fn(() =>
+        Promise.reject(new Error("Boom")),
+      );
+      const loop = new OperateLoop(config);
+      let thrown: unknown;
+      try {
+        await loop.execute("Hello", {
+          model: "mock-model",
+          onExchange: vi.fn(),
+        });
+      } catch (error) {
+        thrown = error;
+      }
+      expect(thrown).toBeDefined();
+      const envelope = (thrown as { exchange?: LlmExchangeEnvelope }).exchange;
+      expect(envelope).toBeDefined();
+      expect(envelope!.response.status).toBe(LlmResponseStatus.Incomplete);
+      expect(envelope!.response.error).toBeDefined();
+    });
+  });
+
+  describe("Specific Scenarios", () => {
+    it("emitExchange swallows callback errors", async () => {
+      const envelope = {} as LlmExchangeEnvelope;
+      const onExchange = vi.fn(() => {
+        throw new Error("Callback boom");
+      });
+      await expect(
+        emitExchange({ envelope, onExchange }),
+      ).resolves.toBeUndefined();
+      expect(onExchange).toHaveBeenCalledOnce();
+    });
+
+    it("isExchangeStoreEnabled honors truthy-except-false/0", () => {
+      process.env.LLM_EXCHANGE_ENABLED = "true";
+      expect(isExchangeStoreEnabled()).toBe(true);
+      process.env.LLM_EXCHANGE_ENABLED = "false";
+      expect(isExchangeStoreEnabled()).toBe(false);
+      process.env.LLM_EXCHANGE_ENABLED = "0";
+      expect(isExchangeStoreEnabled()).toBe(false);
+    });
+  });
+});

--- a/packages/llm/src/operate/exchange/buildExchangeEnvelope.ts
+++ b/packages/llm/src/operate/exchange/buildExchangeEnvelope.ts
@@ -1,0 +1,121 @@
+import {
+  LlmExchangeEnvelope,
+  LlmHistory,
+  LlmInputMessage,
+  LlmOperateInput,
+  LlmOperateOptions,
+  LlmOperateResponse,
+  LlmUsageItem,
+} from "../../types/LlmProvider.interface.js";
+import { OperateLoopState } from "../types.js";
+
+//
+//
+// Helpers
+//
+
+function sumUsageByProviderModel(
+  usage: LlmUsageItem[],
+): Record<string, LlmUsageItem> | undefined {
+  if (!usage.length) {
+    return undefined;
+  }
+  const totals: Record<string, LlmUsageItem> = {};
+  for (const item of usage) {
+    const key = `${item.provider ?? "unknown"}:${item.model ?? "unknown"}`;
+    if (!totals[key]) {
+      totals[key] = {
+        input: 0,
+        model: item.model,
+        output: 0,
+        provider: item.provider,
+        reasoning: 0,
+        total: 0,
+      };
+    }
+    totals[key].input += item.input;
+    totals[key].output += item.output;
+    totals[key].reasoning += item.reasoning;
+    totals[key].total += item.total;
+  }
+  return totals;
+}
+
+function extractResponseIds(responses: unknown[]): string[] | undefined {
+  const ids = responses
+    .map((response) =>
+      response && typeof response === "object"
+        ? (response as { id?: unknown }).id
+        : undefined,
+    )
+    .filter((id): id is string => typeof id === "string");
+  return ids.length ? ids : undefined;
+}
+
+//
+//
+// Main
+//
+
+/**
+ * Assemble the serializable exchange envelope for one operate() settlement.
+ * The `resolution` block is stamped by the Llm facade, which is the layer
+ * that knows fallback outcome; the loop fills provider/model best-effort.
+ */
+export function buildExchangeEnvelope({
+  duration,
+  initialHistoryLength,
+  input,
+  options,
+  response,
+  startedAt,
+  state,
+}: {
+  duration: number;
+  initialHistoryLength: number;
+  input: string | LlmHistory | LlmInputMessage | LlmOperateInput;
+  options: LlmOperateOptions;
+  response: LlmOperateResponse;
+  startedAt: string;
+  state: OperateLoopState;
+}): LlmExchangeEnvelope {
+  const historyDelta = response.history.slice(initialHistoryLength);
+  return {
+    ids: extractResponseIds(response.responses),
+    request: {
+      data: options.data,
+      effort: options.effort,
+      explain: options.explain,
+      format: state.formattedFormat,
+      input,
+      instructions: options.instructions,
+      model: options.model,
+      placeholders: options.placeholders,
+      providerOptions: options.providerOptions,
+      system: options.system,
+      temperature: options.temperature,
+      tools: state.formattedTools?.map(({ name }) => name),
+      turns: options.turns,
+      user: options.user,
+    },
+    resolution: {
+      model: response.model,
+      provider: response.provider,
+      retries: state.retries,
+    },
+    response: {
+      content: response.content,
+      error: response.error,
+      historyDelta,
+      reasoning: response.reasoning,
+      status: response.status,
+      stopReason: state.lastStopReason,
+      usage: response.usage,
+      usageTotals: sumUsageByProviderModel(response.usage),
+    },
+    timing: {
+      duration,
+      startedAt,
+    },
+  };
+}

--- a/packages/llm/src/operate/exchange/emitExchange.ts
+++ b/packages/llm/src/operate/exchange/emitExchange.ts
@@ -1,0 +1,51 @@
+import {
+  LlmExchangeCallback,
+  LlmExchangeEnvelope,
+} from "../../types/LlmProvider.interface.js";
+import { getLogger } from "../../util/index.js";
+
+/**
+ * Truthy-except-"false"/"0" gate on LLM_EXCHANGE_ENABLED, matching the
+ * DD_LLMOBS_ENABLED convention in observability/llmobs.ts.
+ */
+export function isExchangeStoreEnabled(): boolean {
+  const flag = process.env.LLM_EXCHANGE_ENABLED;
+  if (!flag) {
+    return false;
+  }
+  return flag.toLowerCase() !== "false" && flag !== "0";
+}
+
+/**
+ * Whether the loop should assemble an exchange envelope at settlement.
+ */
+export function isExchangeRequested({
+  onExchange,
+}: {
+  onExchange?: LlmExchangeCallback;
+}): boolean {
+  return Boolean(onExchange) || isExchangeStoreEnabled();
+}
+
+/**
+ * Deliver an exchange envelope to a callback. Errors thrown by the callback
+ * are logged and swallowed — exchange capture must never interrupt the call.
+ */
+export async function emitExchange({
+  envelope,
+  onExchange,
+}: {
+  envelope: LlmExchangeEnvelope;
+  onExchange?: LlmExchangeCallback;
+}): Promise<void> {
+  if (!onExchange) {
+    return;
+  }
+  try {
+    await onExchange(envelope);
+  } catch (error) {
+    const log = getLogger();
+    log.warn("[operate] onExchange callback threw");
+    log.var({ error });
+  }
+}

--- a/packages/llm/src/operate/exchange/index.ts
+++ b/packages/llm/src/operate/exchange/index.ts
@@ -1,0 +1,6 @@
+export { buildExchangeEnvelope } from "./buildExchangeEnvelope.js";
+export {
+  emitExchange,
+  isExchangeRequested,
+  isExchangeStoreEnabled,
+} from "./emitExchange.js";

--- a/packages/llm/src/operate/types.ts
+++ b/packages/llm/src/operate/types.ts
@@ -188,6 +188,10 @@ export interface OperateLoopState {
   currentTurn: number;
   /** Formatted output schema for structured output */
   formattedFormat?: JsonObject;
+  /** Stop reason from the most recent model response */
+  lastStopReason?: string;
+  /** Model-request retries across all turns (exchange envelope) */
+  retries: number;
   /** Formatted tools for the provider */
   formattedTools?: ProviderToolDefinition[];
   /** Maximum allowed turns */

--- a/packages/llm/src/types/LlmProvider.interface.ts
+++ b/packages/llm/src/types/LlmProvider.interface.ts
@@ -40,7 +40,7 @@ export enum LlmResponseStatus {
 
 // Errors
 
-interface LlmError {
+export interface LlmError {
   detail?: string;
   status: number | string;
   title: string;
@@ -268,6 +268,91 @@ export type LlmProgressCallback = (
   event: LlmProgressEvent,
 ) => unknown | Promise<unknown>;
 
+// Exchange
+
+/**
+ * Serializable snapshot of the request side of one operate() call.
+ * `input` is the raw, pre-interpolation input with multimodal parts preserved.
+ */
+export interface LlmExchangeRequest {
+  data?: NaturalMap;
+  effort?: LlmEffort;
+  explain?: boolean;
+  /** Format normalized to JSON Schema (Zod/Natural already rendered) */
+  format?: JsonObject;
+  input: string | LlmHistory | LlmInputMessage | LlmOperateInput;
+  instructions?: string;
+  /** Requested model (pre-fallback) */
+  model?: string;
+  placeholders?: {
+    input?: boolean;
+    instructions?: boolean;
+    system?: boolean;
+  };
+  providerOptions?: JsonObject;
+  system?: string;
+  temperature?: number;
+  /** Names of tools offered to the model */
+  tools?: string[];
+  turns?: boolean | number;
+  user?: string;
+}
+
+/**
+ * Serializable snapshot of the response side of one operate() call.
+ */
+export interface LlmExchangeResponse {
+  content?: string | JsonObject;
+  error?: LlmError;
+  /** Turns this call added to history (tool calls/results included); never the resent history */
+  historyDelta: LlmHistory;
+  reasoning?: string[];
+  status: LlmResponseStatus;
+  stopReason?: string;
+  /** Per-model-call usage items (provider/model on each item) */
+  usage: LlmUsage;
+  /** Cumulative usage keyed `provider:model` */
+  usageTotals?: Record<string, LlmUsageItem>;
+}
+
+/**
+ * How the call was actually served after fallback and retry resolution.
+ */
+export interface LlmExchangeResolution {
+  fallbackAttempts?: number;
+  fallbackUsed?: boolean;
+  /** Served model */
+  model?: string;
+  /** Served provider */
+  provider?: string;
+  /** Model-request retries within the served attempt */
+  retries?: number;
+}
+
+export interface LlmExchangeTiming {
+  /** Milliseconds from start to settlement */
+  duration: number;
+  /** ISO 8601 */
+  startedAt: string;
+}
+
+/**
+ * One serializable request/response envelope per operate() settlement
+ * (success or failure). Contains no functions.
+ */
+export interface LlmExchangeEnvelope {
+  /** Provider response id(s) per model turn, when available */
+  ids?: string[];
+  request: LlmExchangeRequest;
+  resolution: LlmExchangeResolution;
+  response: LlmExchangeResponse;
+  timing: LlmExchangeTiming;
+}
+
+export type LlmExchangeCallback = (
+  envelope: LlmExchangeEnvelope,
+) => unknown | Promise<unknown>;
+
 export interface LlmOperateOptions {
   data?: NaturalMap;
   /**
@@ -368,6 +453,12 @@ export interface LlmOperateOptions {
   instructions?: string;
   model?: string;
   /**
+   * Fires once per operate() settlement (success or failure) with a fully
+   * serializable request/response envelope. Errors thrown by the callback
+   * are logged and never interrupt the call.
+   */
+  onExchange?: LlmExchangeCallback;
+  /**
    * Receives lightweight progress events as the operate loop runs:
    * start, model_request, model_response, tool_call, tool_result,
    * tool_error, retry, done. Errors thrown by the callback are logged
@@ -420,6 +511,11 @@ export type LlmUsage = LlmUsageItem[];
 export interface LlmOperateResponse {
   content?: string | JsonObject;
   error?: LlmError;
+  /**
+   * Serializable exchange envelope for this call. Present only when
+   * `onExchange` was passed or exchange persistence is enabled.
+   */
+  exchange?: LlmExchangeEnvelope;
   /** Number of providers attempted (1 = primary only, >1 = fallback(s) used) */
   fallbackAttempts?: number;
   /** Whether a fallback provider was used instead of the primary */

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.101",
+  "version": "0.8.102",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/dynamodb/0.6.8.md
+++ b/packages/mcp/release-notes/dynamodb/0.6.8.md
@@ -1,0 +1,11 @@
+---
+version: 0.6.8
+date: 2026-07-19
+summary: storeExchange default persister for LLM operate exchanges
+---
+
+## Changes
+
+- `storeExchange(envelope, { exchange?, scope? })` persists an `@jaypie/llm` exchange envelope as an `exchange` entity (#427)
+- Registers the canonical exchange model, warns (never throws) when `initClient()` has not run, and owns 400KB item-limit safety (drops history delta, then truncates input/content, marking `metadata.truncated`)
+- Test fix: constructor mocks use function expressions (vitest 4 rejects `new` on arrow implementations)

--- a/packages/mcp/release-notes/fabric/0.3.5.md
+++ b/packages/mcp/release-notes/fabric/0.3.5.md
@@ -1,0 +1,12 @@
+---
+version: 0.3.5
+date: 2026-07-19
+summary: Canonical exchange model — EXCHANGE_MODEL, registerExchangeModel, FabricExchange
+---
+
+## Changes
+
+- `exchange` joins the fabric models: an event entity representing one LLM `operate()` call (#427)
+- `EXCHANGE_MODEL` schema constant (indexModel + indexModelXid indexes; status vocabulary `completed | incomplete | in_progress`)
+- `registerExchangeModel()` idempotent canonical registration
+- `FabricExchange` interface: `input`, `content`, `data`, `xid`, `llm` (served model id), `status`, `exchange` (parent reference for turn chains)

--- a/packages/mcp/release-notes/jaypie/1.2.66.md
+++ b/packages/mcp/release-notes/jaypie/1.2.66.md
@@ -1,0 +1,9 @@
+---
+version: 1.2.66
+date: 2026-07-19
+summary: Pull @jaypie/llm 1.3.14 (onExchange envelope + exchange persistence flag)
+---
+
+## Changes
+
+- `@jaypie/llm` peer range advanced to ^1.3.14

--- a/packages/mcp/release-notes/llm/1.3.14.md
+++ b/packages/mcp/release-notes/llm/1.3.14.md
@@ -1,0 +1,12 @@
+---
+version: 1.3.14
+date: 2026-07-19
+summary: onExchange lifecycle hook — one serializable request/response envelope per operate() settlement; LLM_EXCHANGE_ENABLED default persistence
+---
+
+## Changes
+
+- `operate()` accepts `onExchange`, fired once per settlement (success or failure) with a fully serializable `LlmExchangeEnvelope`: request (raw pre-interpolation input, data, placeholders, system, instructions, model, format as JSON Schema, tool names, turns, temperature, effort, providerOptions, user), response (content, history delta, per-turn and cumulative usage keyed provider:model, reasoning, status, error, stop reason), resolution (served provider/model, fallbackUsed, fallbackAttempts, retries), timing, and provider response ids (#426)
+- Callback errors are logged and never interrupt the call
+- `LLM_EXCHANGE_ENABLED` activates default persistence via `@jaypie/dynamodb` `storeExchange` (new optional peer dependency), lazily resolved and bundler-safe; silent no-op when absent (#427)
+- `LlmOperateResponse.exchange` carries the envelope when exchange capture is active

--- a/packages/mcp/release-notes/mcp/0.8.102.md
+++ b/packages/mcp/release-notes/mcp/0.8.102.md
@@ -1,0 +1,11 @@
+---
+version: 0.8.102
+date: 2026-07-19
+summary: Document exchange model, onExchange hook, and LLM_EXCHANGE_ENABLED
+---
+
+## Changes
+
+- `vocabulary` skill: `exchange` fabric model and `llm` attribute definition
+- `llm` skill: `onExchange` envelope and `LLM_EXCHANGE_ENABLED`
+- `dynamodb` skill: `storeExchange`

--- a/packages/mcp/release-notes/testkit/1.2.57.md
+++ b/packages/mcp/release-notes/testkit/1.2.57.md
@@ -1,0 +1,9 @@
+---
+version: 1.2.57
+date: 2026-07-19
+summary: Mock storeExchange from @jaypie/dynamodb
+---
+
+## Changes
+
+- `storeExchange` mock added to the dynamodb mock namespace (resolves null by default)

--- a/packages/mcp/skills/dynamodb.md
+++ b/packages/mcp/skills/dynamodb.md
@@ -364,6 +364,10 @@ const nextPage = await queryByScope({
 });
 ```
 
+### Exchange Persistence
+
+`storeExchange(envelope, { exchange?, scope? })` persists an `@jaypie/llm` exchange envelope (see `skill("llm")`) as an `exchange` entity. It registers the canonical exchange model (`registerExchangeModel()` from `@jaypie/fabric`), maps envelope fields onto reserved attributes (`input`, `content`, `data`, `llm`, `status`, `xid`), and owns 400KB item-limit safety (drops the history delta, then truncates long fields, marking `metadata.truncated`). It warns and returns `null` — never throws — when `initClient()` has not run or the write fails. `@jaypie/llm` calls it automatically when `LLM_EXCHANGE_ENABLED` is set; pass `exchange` (parent id) for turn chains and `scope` to nest under a parent entity.
+
 ### Seed and Export
 
 Idempotent seeding for bootstrapping data and export for migrations:

--- a/packages/mcp/skills/llm.md
+++ b/packages/mcp/skills/llm.md
@@ -383,6 +383,36 @@ Fields carried by each event (`turn` is 1-indexed):
 
 Errors thrown by the callback are logged and never interrupt the loop. Hooks remain the right choice when you need the full provider request/response payloads. `stream()` communicates progress through its chunks; `onProgress` applies to `operate()`.
 
+## Exchange Capture
+
+For a durable record of each `operate()` call (replay, labeling pipelines, cost accounting, dataset export), `onExchange` fires once per settlement (success or failure) with a fully serializable envelope:
+
+```typescript
+const response = await Llm.operate(input, {
+  model: "claude-sonnet-5",
+  onExchange: (envelope) => {
+    // envelope.request  — raw pre-interpolation input, data, placeholders,
+    //                     system, instructions, model, format (JSON Schema),
+    //                     tool names, turns, temperature, effort,
+    //                     providerOptions, user
+    // envelope.response — content, historyDelta (turns this call added),
+    //                     usage (per model call) + usageTotals (keyed
+    //                     provider:model), reasoning, status, error, stopReason
+    // envelope.resolution — served provider/model, fallbackUsed,
+    //                     fallbackAttempts, retries
+    // envelope.timing   — startedAt, duration
+    // envelope.ids      — provider response id(s) per model turn
+    queue.send(JSON.stringify(envelope));
+  },
+});
+```
+
+Callback errors are logged and never interrupt the call. The envelope contains no functions. When exchange capture is active, `response.exchange` carries the same envelope.
+
+### Default Persistence
+
+Set `LLM_EXCHANGE_ENABLED` (truthy, except `false`/`0`) and every `operate()` call persists as an `exchange` entity via `storeExchange` from `@jaypie/dynamodb` (optional peer dependency, resolved lazily and bundler-safe; silent no-op when absent). Requires `initClient()` to have run — warns, never throws, when uninitialized. Consumers with custom needs use the raw `onExchange` hook instead. See `skill("vocabulary")` for the exchange model and `skill("dynamodb")` for `storeExchange`.
+
 ## Fallback Providers
 
 Configure a chain of fallback providers that automatically retry failed calls when the primary provider fails:

--- a/packages/mcp/skills/vocabulary.md
+++ b/packages/mcp/skills/vocabulary.md
@@ -44,6 +44,7 @@ Arguably identity, instance, and relation would form a more complete vocabulary.
 - image: tbd, likely urls and references
 - input: request parameters
 - label: shortened, accepted version of name
+- llm: served LLM model id (e.g., "claude-sonnet-5"); used because `model` is reserved for the entity type
 - level: severity of a log emission (trace, debug, info, warn, error, fatal); a property of an emission, distinct from a lifecycle `status` though Datadog serializes it under the `status` field (see logs skill)
 - links: usually http references
 - message/s: string/s or message object/s
@@ -81,11 +82,13 @@ Avoid words defined elsewhere (services, terminology)
 - plan
 - case
 - scenario
+- exchange
 
 ### Model Definitions
 
 - plan: a persisted definition an executor runs; what a job executes. plan : job :: definition : run. A composition projected into data is a plan. Suggested attributes: `alias`, `name`, `description`, `category` (a vocabulary under the model — e.g. composition plans use `workflow` | `agent`), optional `definitionHash` (content hash gating idempotent reseeds), optional `source` (provenance)
 - case: the subject entity a job operates on; long-lived, accretes jobs and messages over time. Jobs reference their case via `job.case` (optional — jobs usually operate on a case; system jobs may not). Neither model requires the other: a case exists before any job runs on it, and a case never stores a job list (query jobs by case)
+- exchange: an event entity representing one LLM `operate()` call. Attributes use reserved words: `input` (request), `content` (response text), `data` (interpolation parameters — the vocabulary's sanctioned use of the word), `xid` (provider response id), `llm` (served model id), declared `status` vocabulary `completed | incomplete | in_progress` aligned with operate settlement. Turn chains reference the parent exchange (an `exchange` attribute) and store input deltas only — never the resent history; tool loops are the history delta within one exchange, not separate entities. Canonical registration ships upstream: `registerExchangeModel()` / `EXCHANGE_MODEL` in `@jaypie/fabric`
 - scenario: a named category of cases (see Category in Ontological Grounding). `case.category` holds the scenario alias; the scenario model defines the category itself: `alias`, `name`, `description`, and `plans` (references) — scenarios prescribe which plans respond to them
 
 ### Implied Attributes

--- a/packages/testkit/package.json
+++ b/packages/testkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/testkit",
-  "version": "1.2.56",
+  "version": "1.2.57",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"

--- a/packages/testkit/src/mock/dynamodb.ts
+++ b/packages/testkit/src/mock/dynamodb.ts
@@ -206,6 +206,14 @@ export const query = createMockFunction<
   lastEvaluatedKey: undefined,
 }));
 
+// Exchange persistence — resolves the mapped entity without writing
+export const storeExchange = createMockFunction<
+  (
+    envelope: Record<string, unknown>,
+    options?: { exchange?: string; scope?: string },
+  ) => Promise<StorableEntity | null>
+>(async () => null);
+
 // Seed and export utilities
 export const seedEntityIfNotExists = createMockFunction<
   <T extends Partial<StorableEntity>>(entity: T) => Promise<boolean>


### PR DESCRIPTION
## Summary
- #426: `@jaypie/llm` fires `onExchange` once per `operate()` settlement (success or failure) with a fully serializable envelope (request, response, resolution, timing, provider ids); callback errors logged, never thrown
- #427: canonical `exchange` fabric model (`registerExchangeModel`, `EXCHANGE_MODEL`, `FabricExchange`), `storeExchange` persister in `@jaypie/dynamodb` with 400KB safety, activated via `LLM_EXCHANGE_ENABLED` through a lazy bundler-safe resolver (optional peer)
- Testkit mock, skills/docs, release notes, patch bumps (llm 1.3.14, fabric 0.3.5, dynamodb 0.6.8, testkit 1.2.57, mcp 0.8.102, jaypie 1.2.66)
- Fix vitest 4 constructor mocks in dynamodb specs

Closes #426
Closes #427

## Test plan
- [x] typecheck, lint, tests green across llm (1155), fabric (1006), dynamodb (216), testkit (293)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XaJ4VEmHYNUMvg4nQoAF5A