### PR TITLE
feat(llm): default Anthropic prompt cache to a 1h TTL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15264,7 +15264,7 @@
       "license": "MIT"
     },
     "packages/jaypie": {
-      "version": "1.2.67",
+      "version": "1.2.68",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "^1.2.10",
@@ -15289,7 +15289,7 @@
         "typescript-eslint": "^8.46.1"
       },
       "peerDependencies": {
-        "@jaypie/llm": "^1.3.17"
+        "@jaypie/llm": "^1.3.18"
       },
       "peerDependenciesMeta": {
         "@jaypie/llm": {
@@ -15421,7 +15421,7 @@
     },
     "packages/llm": {
       "name": "@jaypie/llm",
-      "version": "1.3.17",
+      "version": "1.3.18",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "*",
@@ -15507,7 +15507,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.105",
+      "version": "0.8.106",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.3.3",

--- a/packages/jaypie/package.json
+++ b/packages/jaypie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jaypie",
-  "version": "1.2.67",
+  "version": "1.2.68",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"
@@ -59,7 +59,7 @@
     "typescript-eslint": "^8.46.1"
   },
   "peerDependencies": {
-    "@jaypie/llm": "^1.3.17"
+    "@jaypie/llm": "^1.3.18"
   },
   "peerDependenciesMeta": {
     "@jaypie/llm": {

--- a/packages/llm/CLAUDE.md
+++ b/packages/llm/CLAUDE.md
@@ -166,22 +166,25 @@ provider's cache-read rate (~0.1x input) after the first write.
 Control it with the scalar `cache` option (`LlmCache = boolean | 0 | "5m" | "1h"`):
 
 ```typescript
-await Llm.operate(input, { system: SYSTEM });            // cached @ 5m (default)
-await Llm.operate(input, { system: SYSTEM, cache: "1h" }); // cached @ 1h
+await Llm.operate(input, { system: SYSTEM });            // cached (1h on Anthropic, else 5m)
+await Llm.operate(input, { system: SYSTEM, cache: "5m" }); // cached @ 5m
 await Llm.operate(input, { system: SYSTEM, cache: false }); // opt out
 ```
 
-- `true` / omitted → enabled at the default `"5m"` TTL
+- `true` / omitted → enabled at the adapter's default TTL: `"1h"` on Anthropic,
+  `"5m"` everywhere else
 - `false` / `0` → disabled
 - `"5m"` / `"1h"` → enabled at that TTL
 
 Threaded via `OperateRequest.cache`; each adapter's `buildRequest` resolves it
 with `resolveCache` (`src/util/cacheControl.ts`) and applies the provider-native
-mechanism:
+mechanism. Anthropic passes `defaultTtl: CACHE_TTL_ANTHROPIC_DEFAULT` (`"1h"`):
+its 1h write costs 2x input against 1.25x for 5m, but reads stay at ~0.1x, so
+the hour pays for itself after ~three reads and survives the gaps between turns.
 
 | Provider | Mechanism | TTL |
 |----------|-----------|-----|
-| Anthropic | `cache_control: {type:"ephemeral"}` on the system block + last tool | 5m / 1h |
+| Anthropic | `cache_control: {type:"ephemeral"}` on the system block + last tool | 5m / **1h default** |
 | Bedrock | `cachePoint` blocks after `system` and `toolConfig.tools`; model-gated (unsupported models are denylisted after a 400 and the request transparently retried without cachePoints) | 5m only |
 | OpenAI / xAI | automatic server-side caching + a stable `prompt_cache_key` derived from the prefix | provider default |
 | OpenRouter | `cache_control` breakpoint on the system message (forwarded to Anthropic/Gemini backends, ignored by others) | 5m / 1h |

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/llm",
-  "version": "1.3.17",
+  "version": "1.3.18",
   "description": "Large language model utilities",
   "repository": {
     "type": "git",

--- a/packages/llm/src/operate/adapters/AnthropicAdapter.ts
+++ b/packages/llm/src/operate/adapters/AnthropicAdapter.ts
@@ -18,6 +18,7 @@ import {
   LlmStreamChunkType,
 } from "../../types/LlmStreamChunk.interface.js";
 import {
+  CACHE_TTL_ANTHROPIC_DEFAULT,
   isJsonSchema as isBareJsonSchema,
   naturalZodSchema,
   resolveCache,
@@ -527,7 +528,9 @@ export class AnthropicAdapter extends BaseProviderAdapter {
       stream: false,
     };
 
-    const cache = resolveCache(request.cache);
+    const cache = resolveCache(request.cache, {
+      defaultTtl: CACHE_TTL_ANTHROPIC_DEFAULT,
+    });
     const cacheControl: Anthropic.CacheControlEphemeral | undefined =
       cache.enabled
         ? {

--- a/packages/llm/src/operate/adapters/__tests__/promptCaching.spec.ts
+++ b/packages/llm/src/operate/adapters/__tests__/promptCaching.spec.ts
@@ -30,7 +30,7 @@ const tools = [
 //
 
 describe("Prompt caching — Anthropic", () => {
-  it("Marks system + last tool with cache_control by default", () => {
+  it("Marks system + last tool with cache_control at 1h by default", () => {
     const request: OperateRequest = {
       model: PROVIDER.ANTHROPIC.MODEL.LARGE,
       messages: [],
@@ -40,11 +40,23 @@ describe("Prompt caching — Anthropic", () => {
     const result = anthropicAdapter.buildRequest(request);
     expect(Array.isArray(result.system)).toBe(true);
     const system = result.system as Array<{ cache_control?: unknown }>;
-    expect(system[0].cache_control).toEqual({ type: "ephemeral" });
+    expect(system[0].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
     const built = result.tools as Array<{ cache_control?: unknown }>;
     expect(built[built.length - 1].cache_control).toEqual({
       type: "ephemeral",
+      ttl: "1h",
     });
+  });
+
+  it("Applies the 5m TTL when requested", () => {
+    const result = anthropicAdapter.buildRequest({
+      cache: "5m",
+      model: PROVIDER.ANTHROPIC.MODEL.LARGE,
+      messages: [],
+      system: "You are helpful",
+    });
+    const system = result.system as Array<{ cache_control?: unknown }>;
+    expect(system[0].cache_control).toEqual({ type: "ephemeral" });
   });
 
   it("Applies the 1h TTL when requested", () => {

--- a/packages/llm/src/types/LlmProvider.interface.ts
+++ b/packages/llm/src/types/LlmProvider.interface.ts
@@ -356,7 +356,8 @@ export type LlmExchangeCallback = (
 
 /**
  * Prompt-caching control for operate()/stream().
- * - `true` / omitted → caching enabled at the default `"5m"` TTL
+ * - `true` / omitted → caching enabled at the adapter's default TTL: `"1h"` on
+ *   Anthropic, `"5m"` everywhere else
  * - `false` / `0` → caching disabled
  * - `"5m"` / `"1h"` → enabled at that TTL (TTL honored by Anthropic/OpenRouter;
  *   other providers ignore it and cache with their own defaults)

--- a/packages/llm/src/util/__tests__/cacheControl.spec.ts
+++ b/packages/llm/src/util/__tests__/cacheControl.spec.ts
@@ -31,6 +31,22 @@ describe("resolveCache", () => {
     expect(resolveCache("5m")).toEqual({ enabled: true, ttl: "5m" });
     expect(resolveCache("1h")).toEqual({ enabled: true, ttl: "1h" });
   });
+
+  it("Honors an overridden default TTL", () => {
+    expect(resolveCache(undefined, { defaultTtl: "1h" })).toEqual({
+      enabled: true,
+      ttl: "1h",
+    });
+    expect(resolveCache(true, { defaultTtl: "1h" })).toEqual({
+      enabled: true,
+      ttl: "1h",
+    });
+    expect(resolveCache("5m", { defaultTtl: "1h" })).toEqual({
+      enabled: true,
+      ttl: "5m",
+    });
+    expect(resolveCache(false, { defaultTtl: "1h" }).enabled).toBe(false);
+  });
 });
 
 describe("promptCacheKey", () => {

--- a/packages/llm/src/util/cacheControl.ts
+++ b/packages/llm/src/util/cacheControl.ts
@@ -2,6 +2,13 @@ import { type LlmCache } from "../types/LlmProvider.interface.js";
 
 export const CACHE_TTL_DEFAULT = "5m" as const;
 
+/**
+ * Anthropic bills a 1h cache write at 2x input (vs 1.25x for 5m) but reads at
+ * the same ~0.1x, so an hour of reuse pays for itself after ~three reads and
+ * survives the gaps between turns in a long agentic session.
+ */
+export const CACHE_TTL_ANTHROPIC_DEFAULT = "1h" as const;
+
 export type CacheTtl = "5m" | "1h";
 
 export interface ResolvedCache {
@@ -11,19 +18,22 @@ export interface ResolvedCache {
 
 /**
  * Normalize the caller-facing `cache` option into a concrete decision.
- * - `undefined` / `true` → enabled at the default TTL
+ * - `undefined` / `true` → enabled at `defaultTtl`
  * - `false` / `0` → disabled
  * - `"5m"` / `"1h"` → enabled at that TTL
  */
-export function resolveCache(cache: LlmCache | undefined): ResolvedCache {
+export function resolveCache(
+  cache: LlmCache | undefined,
+  { defaultTtl = CACHE_TTL_DEFAULT }: { defaultTtl?: CacheTtl } = {},
+): ResolvedCache {
   if (cache === false || cache === 0) {
-    return { enabled: false, ttl: CACHE_TTL_DEFAULT };
+    return { enabled: false, ttl: defaultTtl };
   }
   if (cache === "5m" || cache === "1h") {
     return { enabled: true, ttl: cache };
   }
   // undefined or true
-  return { enabled: true, ttl: CACHE_TTL_DEFAULT };
+  return { enabled: true, ttl: defaultTtl };
 }
 
 /**

--- a/packages/llm/test/matrix.ts
+++ b/packages/llm/test/matrix.ts
@@ -123,12 +123,42 @@ interface CapabilityResult {
   detail?: string;
 }
 
+/**
+ * Render an error as a single readable line. `operate()` resolves failures to
+ * an `LlmError` object (`{ status, title, detail }`), which `String()` renders
+ * as "[object Object]" — useless in CI, where the log is the only record of a
+ * live-provider failure. Falls back to `Error.message`, then JSON, then
+ * `String()`.
+ */
+function describeError(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (error && typeof error === "object") {
+    const { detail, status, title } = error as {
+      detail?: string;
+      status?: number | string;
+      title?: string;
+    };
+    if (title || status !== undefined) {
+      const head = status === undefined ? title : `${title} (${status})`;
+      return detail ? `${head}: ${detail}` : String(head);
+    }
+    try {
+      return JSON.stringify(error);
+    } catch {
+      // Circular or otherwise unserializable — name the keys rather than
+      // falling back to String() and printing "[object Object]" again.
+      return `unserializable object with keys: ${Object.keys(error).join(", ")}`;
+    }
+  }
+  return String(error);
+}
+
 async function runPlain(llm: Llm): Promise<CapabilityResult> {
   const result = await llm.operate(
     "Reply with one word: 'pong'. No punctuation.",
     { user: USER },
   );
-  if (result.error) return { ok: false, detail: String(result.error) };
+  if (result.error) return { ok: false, detail: describeError(result.error) };
   if (typeof result.content !== "string" || result.content.length === 0) {
     return {
       ok: false,
@@ -149,7 +179,7 @@ async function runTools(llm: Llm): Promise<CapabilityResult> {
       },
     },
   });
-  if (result.error) return { ok: false, detail: String(result.error) };
+  if (result.error) return { ok: false, detail: describeError(result.error) };
   if (!toolCalled) return { ok: false, detail: "roll tool was not called" };
   return { ok: true };
 }
@@ -159,7 +189,7 @@ async function runStructured(llm: Llm): Promise<CapabilityResult> {
     format: { colors: [String] },
     user: USER,
   });
-  if (result.error) return { ok: false, detail: String(result.error) };
+  if (result.error) return { ok: false, detail: describeError(result.error) };
   const content = result.content as { colors?: unknown } | string | undefined;
   if (!content || typeof content !== "object") {
     return { ok: false, detail: `expected object, got ${typeof content}` };
@@ -185,7 +215,7 @@ async function runBoth(llm: Llm): Promise<CapabilityResult> {
       },
     },
   );
-  if (result.error) return { ok: false, detail: String(result.error) };
+  if (result.error) return { ok: false, detail: describeError(result.error) };
   if (!toolCalled) return { ok: false, detail: "roll tool was not called" };
   const content = result.content as
     { values?: unknown; total?: unknown } | string | undefined;
@@ -219,7 +249,7 @@ async function runPdf(llm: Llm): Promise<CapabilityResult> {
     { file: PDF_PATH },
   ];
   const result = await llm.operate(input, { user: USER });
-  if (result.error) return { ok: false, detail: String(result.error) };
+  if (result.error) return { ok: false, detail: describeError(result.error) };
   return checkDocStrings(result.content);
 }
 
@@ -229,7 +259,7 @@ async function runImage(llm: Llm): Promise<CapabilityResult> {
     { image: IMAGE_PATH },
   ];
   const result = await llm.operate(input, { user: USER });
-  if (result.error) return { ok: false, detail: String(result.error) };
+  if (result.error) return { ok: false, detail: describeError(result.error) };
   return checkDocStrings(result.content);
 }
 
@@ -238,7 +268,7 @@ async function runTemperature(llm: Llm): Promise<CapabilityResult> {
     "Reply with one word: 'pong'. No punctuation.",
     { temperature: 0, user: USER },
   );
-  if (result.error) return { ok: false, detail: String(result.error) };
+  if (result.error) return { ok: false, detail: describeError(result.error) };
   if (typeof result.content !== "string" || result.content.length === 0) {
     return {
       ok: false,
@@ -299,7 +329,7 @@ async function runCell(
   } catch (error) {
     outcome = {
       ok: false,
-      detail: error instanceof Error ? error.message : String(error),
+      detail: describeError(error),
     };
   }
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.105",
+  "version": "0.8.106",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/jaypie/1.2.68.md
+++ b/packages/mcp/release-notes/jaypie/1.2.68.md
@@ -1,0 +1,9 @@
+---
+version: 1.2.68
+date: 2026-07-22
+summary: Pull @jaypie/llm 1.3.18 (Anthropic prompt cache defaults to 1h)
+---
+
+## Changes
+
+- `@jaypie/llm` peer range advanced to ^1.3.18

--- a/packages/mcp/release-notes/llm/1.3.18.md
+++ b/packages/mcp/release-notes/llm/1.3.18.md
@@ -1,0 +1,16 @@
+---
+version: 1.3.18
+date: 2026-07-22
+summary: Default the Anthropic prompt cache to a 1h TTL and render live-matrix errors readably
+---
+
+## Changes
+
+- **Anthropic prompt caching now defaults to `"1h"`.** `resolveCache` (`src/util/cacheControl.ts`) accepts an optional `defaultTtl`, and `AnthropicAdapter` passes the new `CACHE_TTL_ANTHROPIC_DEFAULT`. An omitted `cache` option therefore emits `cache_control: { type: "ephemeral", ttl: "1h" }` on the system block and the last tool.
+- **Rationale.** A 1h write bills 2x input against 1.25x for 5m while reads stay at ~0.1x, so the hour pays for itself after roughly three reads and survives the gaps between turns of a tool-calling loop.
+- **Every other provider keeps the 5m default.** `CACHE_TTL_DEFAULT` is unchanged; Bedrock, OpenAI/xAI, OpenRouter, and Google are untouched.
+- **Explicit TTLs still win.** `cache: "5m"` restores the previous behavior per call; `cache: false` / `0` still opts out entirely.
+
+## Testing
+
+- `test/matrix.ts` renders failures through a new `describeError` helper. `operate()` resolves a failure to an `LlmError` object, which `String()` rendered as `[object Object]` — useless in CI, where the log is the only record of a live-provider failure. Errors now print `title (status): detail`.

--- a/packages/mcp/release-notes/mcp/0.8.106.md
+++ b/packages/mcp/release-notes/mcp/0.8.106.md
@@ -1,0 +1,10 @@
+---
+version: 0.8.106
+date: 2026-07-22
+summary: Document the 1h Anthropic prompt-cache default in the llm skill
+---
+
+## Changes
+
+- `skills/llm.md` records that an omitted `cache` option resolves to `"1h"` on Anthropic and `"5m"` everywhere else.
+- Updates the `LlmOperateOptions` comment and the prompt-caching example to lead with `cache: "5m"` as the opt-down.

--- a/packages/mcp/skills/llm.md
+++ b/packages/mcp/skills/llm.md
@@ -632,7 +632,7 @@ describe("LLM Integration", () => {
 
 ```typescript
 interface LlmOperateOptions {
-  cache?: boolean | 0 | "5m" | "1h";    // Prompt caching (default on @5m; false/0 disables)
+  cache?: boolean | 0 | "5m" | "1h";    // Prompt caching (default on: 1h Anthropic, 5m elsewhere; false/0 disables)
   data?: Record<string, any>;           // Placeholder substitution data
   effort?: LlmEffort;                   // Provider-neutral reasoning effort (lowest|low|medium|high|highest)
   fallback?: LlmFallbackConfig[] | false; // Fallback provider chain
@@ -726,12 +726,13 @@ tool-calling loop is billed at the provider's cache-read rate (~0.1x input)
 after the first write. Control with the scalar `cache` option:
 
 ```typescript
-await Llm.operate(input, { system: SYSTEM });             // cached @ 5m (default)
-await Llm.operate(input, { system: SYSTEM, cache: "1h" }); // cached @ 1h
+await Llm.operate(input, { system: SYSTEM });             // cached (1h Anthropic, else 5m)
+await Llm.operate(input, { system: SYSTEM, cache: "5m" }); // cached @ 5m
 await Llm.operate(input, { system: SYSTEM, cache: false }); // opt out
 ```
 
-`true`/omitted = enabled @5m; `false`/`0` = disabled; `"5m"`/`"1h"` = that TTL.
+`true`/omitted = enabled at the adapter default (`"1h"` on Anthropic, `"5m"`
+elsewhere); `false`/`0` = disabled; `"5m"`/`"1h"` = that TTL.
 
 Per provider: Anthropic `cache_control` on system + last tool; Bedrock
 `cachePoint` blocks (model-gated, auto-denylisted and retried without on a 400;


### PR DESCRIPTION
## Summary

- Anthropic prompt caching now defaults to a `1h` TTL. `resolveCache` takes an optional `defaultTtl`; `AnthropicAdapter` passes the new `CACHE_TTL_ANTHROPIC_DEFAULT`.
- A 1h write bills 2x input against 1.25x for 5m while reads stay ~0.1x, so the hour pays for itself after roughly three reads and survives the gaps between turns of a tool-calling loop.
- Every other provider keeps the 5m default. `cache: "5m"` restores the old behavior per call; `cache: false` / `0` still opts out.
- `test/matrix.ts` renders live-provider failures through `describeError` instead of `String(error)`, which printed `[object Object]` for the `LlmError` object `operate()` resolves.

## Versions

`llm` 1.3.18, `mcp` 0.8.106, `jaypie` 1.2.68 (peer range synced), with release notes.

## Testing

- `npm test` — 3892 passed, 80 skipped
- `npm run typecheck` — clean
- `npm run format` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lb1FLLRZBCftxgmfgTTPm6