### PR TITLE
fix(llm): resolve Gemini key as GOOGLE_API_KEY first, warn on GEMINI_API_KEY fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15421,7 +15421,7 @@
     },
     "packages/llm": {
       "name": "@jaypie/llm",
-      "version": "1.3.18",
+      "version": "1.3.19",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "*",
@@ -15507,7 +15507,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.106",
+      "version": "0.8.107",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.3.3",

--- a/packages/llm/CLAUDE.md
+++ b/packages/llm/CLAUDE.md
@@ -582,7 +582,7 @@ when the matching `*_API_KEY` is set and skip otherwise.
 
 - `OPENAI_API_KEY` - OpenAI API key
 - `ANTHROPIC_API_KEY` - Anthropic API key
-- `GOOGLE_API_KEY` - Google API key
+- `GOOGLE_API_KEY` - Google API key (`GEMINI_API_KEY` is a deprecated fallback; a `log.warn` fires when it is used)
 - `FIREWORKS_API_KEY` - Fireworks API key
 - `OPENROUTER_API_KEY` - OpenRouter API key
 - `XAI_API_KEY` - xAI (Grok) API key

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/llm",
-  "version": "1.3.18",
+  "version": "1.3.19",
   "description": "Large language model utilities",
   "repository": {
     "type": "git",

--- a/packages/llm/src/providers/google/__tests__/client.hot.spec.ts
+++ b/packages/llm/src/providers/google/__tests__/client.hot.spec.ts
@@ -8,13 +8,14 @@ import { GoogleProvider } from "../GoogleProvider.class.js";
 //
 // Hot tests
 //
-// Live tests against the real Gemini API. Skipped unless GEMINI_API_KEY is
-// set, so CI stays green and `npm test` runs them automatically with a key.
+// Live tests against the real Gemini API. Skipped unless GOOGLE_API_KEY (or the
+// deprecated GEMINI_API_KEY) is set, so CI stays green and `npm test` runs them
+// automatically with a key.
 //
-//   GEMINI_API_KEY=... npm run test -w packages/llm
+//   GOOGLE_API_KEY=... npm run test -w packages/llm
 //
 
-const apiKey = process.env.GEMINI_API_KEY;
+const apiKey = process.env.GOOGLE_API_KEY || process.env.GEMINI_API_KEY;
 const TIMEOUT = 60_000;
 
 describe.skipIf(!apiKey)("GoogleClient (hot)", () => {

--- a/packages/llm/src/providers/google/__tests__/utils.spec.ts
+++ b/packages/llm/src/providers/google/__tests__/utils.spec.ts
@@ -1,0 +1,108 @@
+import { getEnvSecret } from "@jaypie/aws";
+import { log } from "@jaypie/logger";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { GoogleClient } from "../client.js";
+import { initializeClient } from "../utils.js";
+
+vi.mock("@jaypie/aws", () => ({
+  getEnvSecret: vi.fn(),
+}));
+
+vi.mock("@jaypie/errors", () => ({
+  ConfigurationError: class ConfigurationError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "ConfigurationError";
+    }
+  },
+}));
+
+vi.mock("@jaypie/kit", () => ({
+  placeholders: vi.fn((text) => text),
+  JAYPIE: {
+    LIB: {
+      LLM: "llm",
+    },
+  },
+}));
+
+vi.mock("@jaypie/logger", () => {
+  const mockLogger = {
+    trace: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    var: vi.fn(),
+  };
+
+  return {
+    createLogger: vi.fn().mockReturnValue(mockLogger),
+    log: {
+      lib: vi.fn().mockReturnValue(mockLogger),
+    },
+  };
+});
+
+vi.mock("../client.js", () => ({
+  GoogleClient: vi.fn().mockImplementation(() => ({})),
+}));
+
+describe("Google Utils initializeClient key resolution", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(log.lib).mockReturnValue({
+      trace: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      var: vi.fn(),
+    } as any);
+  });
+
+  it("resolves GOOGLE_API_KEY first and does not consult GEMINI_API_KEY", async () => {
+    vi.mocked(getEnvSecret).mockImplementation(async (name: string) =>
+      name === "GOOGLE_API_KEY" ? "google-key" : undefined,
+    );
+
+    await initializeClient();
+
+    expect(getEnvSecret).toHaveBeenCalledWith("GOOGLE_API_KEY");
+    expect(getEnvSecret).not.toHaveBeenCalledWith("GEMINI_API_KEY");
+    expect(GoogleClient).toHaveBeenCalledWith({ apiKey: "google-key" });
+  });
+
+  it("falls back to GEMINI_API_KEY with a deprecation warning", async () => {
+    const mockLogger = {
+      trace: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      var: vi.fn(),
+    };
+    vi.mocked(log.lib).mockReturnValue(mockLogger as any);
+    vi.mocked(getEnvSecret).mockImplementation(async (name: string) =>
+      name === "GEMINI_API_KEY" ? "gemini-key" : undefined,
+    );
+
+    await initializeClient();
+
+    expect(getEnvSecret).toHaveBeenCalledWith("GOOGLE_API_KEY");
+    expect(getEnvSecret).toHaveBeenCalledWith("GEMINI_API_KEY");
+    expect(GoogleClient).toHaveBeenCalledWith({ apiKey: "gemini-key" });
+    expect(mockLogger.warn).toHaveBeenCalled();
+  });
+
+  it("prefers the apiKey option over any env secret", async () => {
+    vi.mocked(getEnvSecret).mockResolvedValue("env-key");
+
+    await initializeClient({ apiKey: "provided-key" });
+
+    expect(getEnvSecret).not.toHaveBeenCalled();
+    expect(GoogleClient).toHaveBeenCalledWith({ apiKey: "provided-key" });
+  });
+
+  it("throws ConfigurationError when no key resolves", async () => {
+    vi.mocked(getEnvSecret).mockResolvedValue(null as unknown as string);
+
+    await expect(initializeClient()).rejects.toThrow(
+      "The application could not resolve the requested keys",
+    );
+  });
+});

--- a/packages/llm/src/providers/google/utils.ts
+++ b/packages/llm/src/providers/google/utils.ts
@@ -16,7 +16,17 @@ export async function initializeClient({
   apiKey?: string;
 } = {}): Promise<GoogleClient> {
   const logger = getLogger();
-  const resolvedApiKey = apiKey || (await getEnvSecret("GEMINI_API_KEY"));
+  let resolvedApiKey = apiKey || (await getEnvSecret("GOOGLE_API_KEY"));
+
+  if (!resolvedApiKey) {
+    const geminiApiKey = await getEnvSecret("GEMINI_API_KEY");
+    if (geminiApiKey) {
+      logger.warn(
+        "GEMINI_API_KEY is a deprecated fallback; set GOOGLE_API_KEY instead",
+      );
+      resolvedApiKey = geminiApiKey;
+    }
+  }
 
   if (!resolvedApiKey) {
     throw new ConfigurationError(

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.106",
+  "version": "0.8.107",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/llm/1.3.19.md
+++ b/packages/mcp/release-notes/llm/1.3.19.md
@@ -1,0 +1,16 @@
+---
+version: 1.3.19
+date: 2026-07-23
+summary: Resolve the Gemini key as GOOGLE_API_KEY first, warn on GEMINI_API_KEY fallback
+---
+
+## Changes
+
+- **Google `initializeClient` now resolves `GOOGLE_API_KEY` first.** Every other provider key is named for the provider (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`), and Google issues the key for the provider surface, so deploy environments standardize on `GOOGLE_API_KEY` / `SECRET_GOOGLE_API_KEY`.
+- **`GEMINI_API_KEY` is now a deprecated fallback.** When `GOOGLE_API_KEY` is absent and `GEMINI_API_KEY` resolves, it is used and a `log.warn` marks it deprecated. Precedence: `apiKey` option, then `getEnvSecret("GOOGLE_API_KEY")`, then `getEnvSecret("GEMINI_API_KEY")` + warn.
+- Fixes #434.
+
+## Testing
+
+- New `src/providers/google/__tests__/utils.spec.ts` covers the four precedence cases: `GOOGLE_API_KEY` first (never consulting `GEMINI_API_KEY`), the `GEMINI_API_KEY` fallback + warn, the `apiKey` option winning over env, and the `ConfigurationError` when nothing resolves.
+- The Google hot test now honors `GOOGLE_API_KEY` (falling back to `GEMINI_API_KEY`).

--- a/packages/mcp/release-notes/mcp/0.8.107.md
+++ b/packages/mcp/release-notes/mcp/0.8.107.md
@@ -1,0 +1,9 @@
+---
+version: 0.8.107
+date: 2026-07-23
+summary: Document the deprecated GEMINI_API_KEY fallback in the llm skill
+---
+
+## Changes
+
+- **`skills/llm.md`** notes that Google accepts the deprecated `GEMINI_API_KEY` as a fallback (with a `log.warn`) and that `GOOGLE_API_KEY` is preferred, tracking the `@jaypie/llm` 1.3.19 key-resolution change (#434).

--- a/packages/mcp/skills/llm.md
+++ b/packages/mcp/skills/llm.md
@@ -507,6 +507,8 @@ XAI_API_KEY         # Required for xAI (Grok)
 ```
 
 Keys are resolved via `getEnvSecret()` which supports AWS Secrets Manager.
+Google also accepts the deprecated `GEMINI_API_KEY` as a fallback (a `log.warn`
+fires); prefer `GOOGLE_API_KEY`.
 
 ## Report Totals
 


### PR DESCRIPTION
Closes #434.

## Summary
`@jaypie/llm`'s Google `initializeClient` resolved its key with `getEnvSecret("GEMINI_API_KEY")` only, the lone provider keyed by model rather than provider. It now resolves `GOOGLE_API_KEY` first and treats `GEMINI_API_KEY` as a deprecated fallback.

Precedence:
1. `apiKey` option (unchanged)
2. `getEnvSecret("GOOGLE_API_KEY")`
3. `getEnvSecret("GEMINI_API_KEY")` + `log.warn` deprecation

## Changes
- `packages/llm/src/providers/google/utils.ts` — new precedence + deprecation warn
- New `google/__tests__/utils.spec.ts` — four precedence cases
- Google hot test honors `GOOGLE_API_KEY` (falls back to `GEMINI_API_KEY`)
- Docs: `packages/llm/CLAUDE.md`, `packages/mcp/skills/llm.md`
- Versions: `@jaypie/llm` 1.3.18 → 1.3.19, `@jaypie/mcp` 0.8.106 → 0.8.107, release notes added

## Testing
- `npm run test -w packages/llm` — 1196 passed
- `npm run test -w packages/mcp` — 41 passed
- typecheck + format clean on both

🤖 Generated with [Claude Code](https://claude.com/claude-code)