### PR TITLE
feat(llm): add claude-opus-5 and freeze the deprecated size tiers

### DIFF
--- a/.claude/skills/new-model-release/SKILL.md
+++ b/.claude/skills/new-model-release/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: new-model-release
+description: Add a newly released LLM model to the Jaypie catalog
+---
+
+# New Model Release
+
+Steps to add a newly released provider model to `@jaypie/llm`.
+
+## Principle
+
+Every model id lives in exactly one file: `packages/llm/src/constants.ts`.
+
+| Structure | Role |
+|-----------|------|
+| `MODEL.*` | The catalog. Aliases applications and tests reference by name. |
+| `COST` | Prices by **literal id**, never by `MODEL.*` reference. |
+| `PROVIDER.*.DEFAULT` | The provider's default model, referenced as `MODEL.*`. |
+
+`MODEL` is flat for first-class providers. Anthropic, Google, OpenAI, and xAI ids are top-level keys; only `FIREWORKS` and `OPENROUTER` are nested subtrees.
+
+The catalog is the single source of CI truth. `packages/llm/test/models.ts` derives the live capability matrix from `MODEL.*` plus each `PROVIDER.*.DEFAULT`, and the workflows shard that matrix by provider group. No id list exists anywhere else.
+
+## Decide the shape
+
+Two shapes, with different propagation:
+
+| Shape | When | Consequence |
+|-------|------|-------------|
+| Repoint an existing alias (`OPUS: "claude-opus-5"`) | The new model supersedes the one the alias names | Every `MODEL.OPUS` consumer follows automatically, including `src/__tests__/hotModels.ts`, `test/document.ts`, and the CI matrix |
+| Add a new alias (`OPUS_5: "claude-opus-5"`) | The models coexist as distinct offerings | The catalog and matrix pick it up, but `src/__tests__/hotModels.ts` enumerates aliases by hand and needs the new key added |
+
+Prefer repointing. The catalog names tiers, not versions, so a superseding release is a value swap.
+
+## Required edits
+
+Both live in `packages/llm/src/constants.ts`.
+
+1. **Catalog** — set the `MODEL.*` value to the new id.
+2. **Price** — add a `COST` entry keyed by the literal id, alphabetized within the provider block. Leave the superseded id's entry in place: retired models keep their prices so historic usage records stay replayable.
+
+Anthropic entries carry a cache-write premium and use the TTL-keyed form:
+
+```ts
+  "claude-opus-5": {
+    cachedInputRead: 0.5,
+    cachedInputWrite: { "1h": 10.0, "5m": 6.25 },
+    input: 5.0,
+    output: 25.0,
+  },
+```
+
+Rates are the standard short-context text tier per million tokens. Exclude introductory, batch, flex, priority, fast-mode, and data-residency pricing, and long-prompt surcharges.
+
+### COST invariants
+
+| Rule | Reason |
+|------|--------|
+| `input > 0` | A free tier is not a price |
+| `output >= input` | No provider inverts the ratio |
+| `0 < cachedInputRead < input` | A cache read that costs full price is not a cache |
+| Scalar `cachedInputWrite` is `0` or `>= input` | Amazon publishes a literal `0`; everyone else charges a premium |
+| TTL form requires `write["5m"] > input` and `write["1h"] > write["5m"]` | Longer residency costs more |
+
+Omitting `cachedInputWrite` means writes bill at `input`.
+
+## Conditional edits
+
+| Edit | Condition |
+|------|-----------|
+| `src/util/maxOutputTokens.ts` | The model's documented output ceiling differs from the pattern that already matches it. The table is ordered and first match wins, so a narrower pattern goes **above** the catch-all. |
+| `PROVIDER.*.MODEL_MATCH_WORDS` | `determineModelProvider` cannot resolve the id. Matching is substring-on-lowercase, so most new ids resolve on an existing word. |
+| `src/__tests__/hotModels.ts` | A new alias key was added, or the model should be excluded from live hot tests. |
+| Adapter capability patterns | The model gates a capability differently — reasoning effort, temperature support, or a required beta header. |
+| `MATRIX_EXCLUDE` in `packages/llm/test/models.ts` | The model is unlaunched, unavailable on typical keys, or too costly to exercise every run. |
+| `MATRIX_EXPECT` in `packages/llm/test/models.ts` | A capability is expected to warn, skip, or fail rather than pass. |
+
+Verify each condition rather than assuming it. For Anthropic specifically, `AnthropicAdapter` already parses the version out of a `claude-<tier>-<major>` id to gate reasoning effort, and its temperature-deprecation list is written as version ranges, so a new point release usually needs nothing.
+
+## What never needs editing
+
+| Location | Why |
+|----------|-----|
+| `packages/llm/test/models.ts` matrix construction | `catalogIds()` recursively flattens `MODEL` |
+| `packages/llm/test/matrix.ts` | Selects by `APP_MODELS`, then `APP_GROUP`, then everything |
+| `.github/workflows/npm-check.yml`, `npm-deploy.yml` | Shard by provider group, not by id |
+| `packages/testkit` | Carries no model ids |
+
+### Never edit the deprecated size tiers
+
+`PROVIDER.*.MODEL.DEFAULT` / `LARGE` / `SMALL` / `TINY` are retired in 2.0. Their values are frozen.
+
+Repointing a tier at a newer model keeps it useful, which is the opposite of the goal: a deprecated surface should decay, not track the catalog. Leaving `LARGE` on a superseded id gives callers a reason to migrate to `PROVIDER.*.DEFAULT` or a named `MODEL.*` alias. Staleness in a deprecated map is the intended state, not drift to be corrected.
+
+The same reasoning applies to the deprecated `MODEL.GPT*` aliases and the `ALL` map.
+
+## Release
+
+Follow [VERSIONING.md](../VERSIONING.md): patch only, one bump per branch.
+
+1. Bump `packages/llm/package.json`.
+2. Add `packages/mcp/release-notes/llm/<version>.md` with frontmatter `version`, `date`, `summary`, then `## Changes` and `## Testing`.
+3. Bump `packages/mcp` — the release notes ship inside it.
+4. Update the `@jaypie/llm` range in `packages/jaypie/package.json` and bump `jaypie`.
+5. Run `npm i --package-lock-only`.
+
+Update `packages/mcp/skills/llm.md` only when its provider table or catalog bullets change. Those name aliases and provider defaults, so a value swap behind an existing alias leaves them accurate.
+
+## Verify
+
+Run ~green against `packages/llm`. Then confirm the resolution path end to end:
+
+```bash
+node -e 'import("./packages/llm/dist/index.js").then(m => {
+  console.log(m.MODEL.OPUS, m.COST[m.MODEL.OPUS]);
+})'
+```
+
+With a provider key present, exercise the seven capability cells against the live API:
+
+```bash
+APP_MODELS=<model-id> npm run test:llm:matrix
+```
+
+## Promotion
+
+This document lives in the gitignored `var/` scratch directory. Promoting it to a first-class skill means moving it to `packages/mcp/skills/new-model-release.md` and hand-editing three curated listings, which are not generated:
+
+- `packages/mcp/skills/skills.md` — the Categories table
+- `packages/mcp/skills/development.md` — the `## Skills` alias table
+- `packages/mcp/skills/agents.md` — the category lists in the AGENTS.md snippet
+
+Then bump and rebuild `@jaypie/mcp`.

--- a/.claude/skills/new-model-release/SKILL.md
+++ b/.claude/skills/new-model-release/SKILL.md
@@ -96,7 +96,7 @@ The same reasoning applies to the deprecated `MODEL.GPT*` aliases and the `ALL` 
 
 ## Release
 
-Follow [VERSIONING.md](../VERSIONING.md): patch only, one bump per branch.
+Follow [VERSIONING.md](../../../VERSIONING.md): patch only, one bump per branch.
 
 1. Bump `packages/llm/package.json`.
 2. Add `packages/mcp/release-notes/llm/<version>.md` with frontmatter `version`, `date`, `summary`, then `## Changes` and `## Testing`.
@@ -111,8 +111,8 @@ Update `packages/mcp/skills/llm.md` only when its provider table or catalog bull
 Run ~green against `packages/llm`. Then confirm the resolution path end to end:
 
 ```bash
-node -e 'import("./packages/llm/dist/index.js").then(m => {
-  console.log(m.MODEL.OPUS, m.COST[m.MODEL.OPUS]);
+node -e 'import("./packages/llm/dist/esm/index.js").then(m => {
+  console.log(m.LLM.MODEL.OPUS, m.LLM.COST[m.LLM.MODEL.OPUS]);
 })'
 ```
 
@@ -122,12 +122,12 @@ With a provider key present, exercise the seven capability cells against the liv
 APP_MODELS=<model-id> npm run test:llm:matrix
 ```
 
-## Promotion
+## Publishing this skill
 
-This document lives in the gitignored `var/` scratch directory. Promoting it to a first-class skill means moving it to `packages/mcp/skills/new-model-release.md` and hand-editing three curated listings, which are not generated:
+This skill is repository-local. Publishing it to the MCP server, so consumers reach it through `mcp__jaypie__skill("new-model-release")`, means copying it to `packages/mcp/skills/new-model-release.md` with `description` / `related` frontmatter in place of `name` / `description`, then hand-editing three curated listings, which are not generated:
 
 - `packages/mcp/skills/skills.md` — the Categories table
 - `packages/mcp/skills/development.md` — the `## Skills` alias table
 - `packages/mcp/skills/agents.md` — the category lists in the AGENTS.md snippet
 
-Then bump and rebuild `@jaypie/mcp`.
+Then bump `@jaypie/mcp`. A rebuild is not required for the skills to resolve: the store reads `packages/mcp/skills/` from the package root, not from `dist/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,13 @@ constants only; nothing else carries a model id:
   `MODEL.OPENROUTER.*` and third-party Bedrock ids are deliberately unpriced —
   they resell another vendor per route. Amazon's own Nova models are
   first-class and priced.
+- The deprecated `PROVIDER.*.MODEL` size-tier maps (`DEFAULT`/`LARGE`/`SMALL`/
+  `TINY`), the deprecated `MODEL.GPT*` aliases, and `ALL` are **frozen**. Never
+  repoint them at a newer model: a deprecated surface should decay so callers
+  migrate, and refreshing it only prolongs its use. Staleness there is intended,
+  not drift to correct.
+- `.claude/skills/new-model-release/SKILL.md` is the step-by-step procedure for
+  landing a newly released model.
 ### Lore
 - These are golden numbers: 0.021, 0.146, 0.236, 0.382, and 0.618
 - Start with 0.618 when user suggests "partial" and down as they want less

--- a/package-lock.json
+++ b/package-lock.json
@@ -15264,7 +15264,7 @@
       "license": "MIT"
     },
     "packages/jaypie": {
-      "version": "1.2.68",
+      "version": "1.2.69",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "^1.2.10",
@@ -15289,7 +15289,7 @@
         "typescript-eslint": "^8.46.1"
       },
       "peerDependencies": {
-        "@jaypie/llm": "^1.3.18"
+        "@jaypie/llm": "^1.3.20"
       },
       "peerDependenciesMeta": {
         "@jaypie/llm": {
@@ -15421,7 +15421,7 @@
     },
     "packages/llm": {
       "name": "@jaypie/llm",
-      "version": "1.3.19",
+      "version": "1.3.20",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "*",
@@ -15507,7 +15507,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.107",
+      "version": "0.8.108",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.3.3",

--- a/packages/jaypie/package.json
+++ b/packages/jaypie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jaypie",
-  "version": "1.2.68",
+  "version": "1.2.69",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"
@@ -59,7 +59,7 @@
     "typescript-eslint": "^8.46.1"
   },
   "peerDependencies": {
-    "@jaypie/llm": "^1.3.18"
+    "@jaypie/llm": "^1.3.20"
   },
   "peerDependenciesMeta": {
     "@jaypie/llm": {

--- a/packages/llm/CLAUDE.md
+++ b/packages/llm/CLAUDE.md
@@ -103,7 +103,7 @@ Provider Class → OperateLoop → ProviderAdapter → Provider API
 import Llm from "@jaypie/llm";
 
 // Auto-detect provider from model
-const response = await Llm.operate("Hello", { model: "claude-sonnet-4" });
+const response = await Llm.operate("Hello", { model: "claude-sonnet-5" });
 
 // Or specify provider explicitly
 const llm = new Llm("openai", { model: "gpt-4o" });
@@ -236,7 +236,7 @@ import Llm from "@jaypie/llm";
 
 // Instance-level fallback configuration
 const llm = new Llm("anthropic", {
-  model: "claude-sonnet-4",
+  model: "claude-sonnet-5",
   fallback: [
     { provider: "openai", model: "gpt-4o" },
     { provider: "google", model: "gemini-2.0-flash" },
@@ -253,7 +253,7 @@ const response = await llm.operate(input, { fallback: false });
 
 // Static method with fallback
 const response = await Llm.operate(input, {
-  model: "claude-sonnet-4",
+  model: "claude-sonnet-5",
   fallback: [{ provider: "openai", model: "gpt-4o" }],
 });
 ```

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/llm",
-  "version": "1.3.19",
+  "version": "1.3.20",
   "description": "Large language model utilities",
   "repository": {
     "type": "git",

--- a/packages/llm/src/constants.ts
+++ b/packages/llm/src/constants.ts
@@ -25,7 +25,7 @@ export const MODEL = {
   NOVA_PRO: "amazon.nova-pro-v1:0",
   // Anthropic
   FABLE: "claude-fable-5",
-  OPUS: "claude-opus-4-8",
+  OPUS: "claude-opus-5",
   SONNET: "claude-sonnet-5",
   HAIKU: "claude-haiku-4-5",
   MYTHOS: "claude-mythos-5",
@@ -199,6 +199,12 @@ export const COST: Record<string, LlmModelCost> = {
     input: 5.0,
     output: 25.0,
   },
+  "claude-opus-5": {
+    cachedInputRead: 0.5,
+    cachedInputWrite: { "1h": 10.0, "5m": 6.25 },
+    input: 5.0,
+    output: 25.0,
+  },
   "claude-sonnet-4-20250514": {
     cachedInputRead: 0.3,
     cachedInputWrite: { "1h": 6.0, "5m": 3.75 },
@@ -304,7 +310,7 @@ export const COST: Record<string, LlmModelCost> = {
 const GOOGLE_PROVIDER = {
   // https://ai.google.dev/gemini-api/docs/models
   DEFAULT: MODEL.GEMINI_FLASH,
-  /** @deprecated Size tiers are retired in 2.0. Use PROVIDER.GOOGLE.DEFAULT, or pick a specific model from MODEL.*. */
+  /** @deprecated Size tiers are retired in 2.0 and these values are frozen; repointing a tier at a newer model only prolongs its use. Use PROVIDER.GOOGLE.DEFAULT, or pick a specific model from MODEL.*. */
   MODEL: {
     DEFAULT: "gemini-3.1-pro-preview",
     LARGE: "gemini-3.1-pro-preview",
@@ -324,7 +330,7 @@ export const PROVIDER = {
   BEDROCK: {
     // nova-pro is the Amazon-native model that reliably does tools+structured.
     DEFAULT: MODEL.NOVA_PRO,
-    /** @deprecated Size tiers are retired in 2.0. Use PROVIDER.BEDROCK.DEFAULT, or pick a specific model from MODEL.NOVA_*. */
+    /** @deprecated Size tiers are retired in 2.0 and these values are frozen; repointing a tier at a newer model only prolongs its use. Use PROVIDER.BEDROCK.DEFAULT, or pick a specific model from MODEL.NOVA_*. */
     MODEL: {
       DEFAULT: MODEL.NOVA_LITE,
       LARGE: MODEL.NOVA_PRO,
@@ -357,7 +363,7 @@ export const PROVIDER = {
       // (see util/maxOutputTokens.ts)
       DEFAULT: 16384 as const,
     },
-    /** @deprecated Size tiers are retired in 2.0. Use PROVIDER.ANTHROPIC.DEFAULT, or pick a specific model from MODEL.*. */
+    /** @deprecated Size tiers are retired in 2.0 and these values are frozen; repointing a tier at a newer model only prolongs its use. Use PROVIDER.ANTHROPIC.DEFAULT, or pick a specific model from MODEL.*. */
     MODEL: {
       DEFAULT: "claude-sonnet-4-6",
       LARGE: "claude-opus-4-8",
@@ -401,7 +407,7 @@ export const PROVIDER = {
   OPENAI: {
     // https://platform.openai.com/docs/models
     DEFAULT: MODEL.SOL,
-    /** @deprecated Size tiers are retired in 2.0. Use PROVIDER.OPENAI.DEFAULT, or pick a specific model from MODEL.*. */
+    /** @deprecated Size tiers are retired in 2.0 and these values are frozen; repointing a tier at a newer model only prolongs its use. Use PROVIDER.OPENAI.DEFAULT, or pick a specific model from MODEL.*. */
     MODEL: {
       DEFAULT: "gpt-5.4",
       LARGE: "gpt-5.5",
@@ -413,7 +419,7 @@ export const PROVIDER = {
   },
   OPENROUTER: {
     DEFAULT: MODEL.OPENROUTER.SONNET,
-    /** @deprecated Size tiers are retired in 2.0. Use PROVIDER.OPENROUTER.DEFAULT, or pick a specific route from MODEL.OPENROUTER.*. */
+    /** @deprecated Size tiers are retired in 2.0 and these values are frozen; repointing a tier at a newer model only prolongs its use. Use PROVIDER.OPENROUTER.DEFAULT, or pick a specific route from MODEL.OPENROUTER.*. */
     MODEL: {
       DEFAULT: "anthropic/claude-sonnet-4-6" as const,
       LARGE: "anthropic/claude-opus-4-8" as const,
@@ -434,7 +440,7 @@ export const PROVIDER = {
     API_KEY: "XAI_API_KEY" as const,
     BASE_URL: "https://api.x.ai/v1" as const,
     DEFAULT: MODEL.GROK,
-    /** @deprecated Size tiers are retired in 2.0. Use PROVIDER.XAI.DEFAULT, or pick a specific model from MODEL.*. */
+    /** @deprecated Size tiers are retired in 2.0 and these values are frozen; repointing a tier at a newer model only prolongs its use. Use PROVIDER.XAI.DEFAULT, or pick a specific model from MODEL.*. */
     MODEL: {
       DEFAULT: "grok-latest",
       LARGE: "grok-latest",
@@ -457,7 +463,7 @@ export type LlmProviderName =
 
 // Last: Defaults
 export const DEFAULT = {
-  /** @deprecated Size tiers are retired in 2.0. Use DEFAULT.PROVIDER.DEFAULT, or pick a specific model from MODEL.*. */
+  /** @deprecated Size tiers are retired in 2.0 and these values are frozen; repointing a tier at a newer model only prolongs its use. Use DEFAULT.PROVIDER.DEFAULT, or pick a specific model from MODEL.*. */
   MODEL: {
     BASE: PROVIDER.OPENAI.MODEL.DEFAULT,
     LARGE: PROVIDER.OPENAI.MODEL.LARGE,

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.107",
+  "version": "0.8.108",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/llm/1.3.20.md
+++ b/packages/mcp/release-notes/llm/1.3.20.md
@@ -1,0 +1,17 @@
+---
+version: 1.3.20
+date: 2026-07-24
+summary: Add claude-opus-5 to the catalog and price map; MODEL.OPUS now resolves to it
+---
+
+## Changes
+
+- **`MODEL.OPUS` is now `claude-opus-5`.** Anthropic released Claude Opus 5 as a drop-in successor to Opus 4.8 at the same price, so the tier alias moves rather than gaining a new key. Every `MODEL.OPUS` consumer follows, including the live capability matrix and the Anthropic hot test.
+- **`COST["claude-opus-5"]` added** at $5.00 input / $25.00 output per million tokens, with `cachedInputRead: 0.5` and `cachedInputWrite: { "1h": 10.0, "5m": 6.25 }`. `COST["claude-opus-4-8"]` is retained so historic usage records stay replayable.
+- **Every deprecated size-tier map is now documented as frozen.** The `@deprecated` tag on `PROVIDER.*.MODEL` states that repointing a tier at a newer model only prolongs its use. `LARGE` stays on the superseded id so callers migrate to `PROVIDER.*.DEFAULT` or a named `MODEL.*` alias.
+
+No other change was required. `determineModelProvider` already resolves the id through the existing Anthropic match words, `maxOutputTokens` already returns 128,000 for it, and `AnthropicAdapter` already treats `claude-opus-[5-9]` as effort-capable and temperature-free.
+
+## Testing
+
+- No test changes. `constants.spec.ts` guards the catalog: it asserts every `MODEL.*` id resolves to a provider, every first-class id is priced, and every `COST` entry satisfies the pricing invariants.

--- a/packages/mcp/skills/llm.md
+++ b/packages/mcp/skills/llm.md
@@ -13,7 +13,7 @@ Unified interface for calling LLM providers with multi-turn conversations, tool 
 import Llm from "@jaypie/llm";
 
 // Auto-detect provider from model name
-const response = await Llm.operate("What is 2+2?", { model: "claude-sonnet-4" });
+const response = await Llm.operate("What is 2+2?", { model: "claude-sonnet-5" });
 console.log(response.content); // "4"
 ```
 
@@ -62,7 +62,7 @@ Rates are the standard short-context text tier. Introductory, batch, flex, prior
 ```typescript
 // Provider auto-detected from model
 await Llm.operate(input, { model: "gpt-5.1" });      // OpenAI
-await Llm.operate(input, { model: "claude-opus-4" }); // Anthropic
+await Llm.operate(input, { model: "claude-opus-5" }); // Anthropic
 await Llm.operate(input, { model: "gemini-3" });     // Google
 ```
 
@@ -94,7 +94,7 @@ For single-shot text completions:
 
 ```typescript
 const response = await Llm.send("Explain REST APIs", {
-  model: "claude-sonnet-4",
+  model: "claude-sonnet-5",
   system: "You are a technical writer",
 });
 ```
@@ -327,7 +327,7 @@ const response = await Llm.operate([
   { file: "report.pdf", bucket: "my-bucket" },
   { image: "chart.png" },
 ], {
-  model: "claude-sonnet-4",
+  model: "claude-sonnet-5",
 });
 ```
 
@@ -442,7 +442,7 @@ Configure a chain of fallback providers that automatically retry failed calls wh
 ```typescript
 // Instance-level configuration
 const llm = new Llm("anthropic", {
-  model: "claude-sonnet-4",
+  model: "claude-sonnet-5",
   fallback: [
     { provider: "openai", model: "gpt-4o" },
     { provider: "google", model: "gemini-2.0-flash" },
@@ -459,7 +459,7 @@ const response = await llm.operate(input, { fallback: false });
 
 // Static method with fallback
 const response = await Llm.operate(input, {
-  model: "claude-sonnet-4",
+  model: "claude-sonnet-5",
   fallback: [{ provider: "openai", model: "gpt-4o" }],
 });
 ```
@@ -478,7 +478,7 @@ For repeated calls with same configuration:
 
 ```typescript
 const llm = new Llm("anthropic", {
-  model: "claude-sonnet-4",
+  model: "claude-sonnet-5",
   system: "You are a code reviewer",
 });
 

--- a/packages/mcp/skills/placeholders.md
+++ b/packages/mcp/skills/placeholders.md
@@ -66,7 +66,7 @@ placeholders("{{known}} and {{unknown}}", { known: "yes" });
 import Llm from "@jaypie/llm";
 
 const response = await Llm.operate("Summarize {{topic}}", {
-  model: "claude-sonnet-4",
+  model: "claude-sonnet-5",
   data: { topic: "climate change" },
   system: "You are an expert on {{topic}}",
   instructions: "Focus on {{aspect}}",

--- a/packages/mcp/skills/tools.md
+++ b/packages/mcp/skills/tools.md
@@ -127,7 +127,7 @@ const toolkit = new Toolkit([
 ]);
 
 const response = await Llm.operate("Find all pending orders", {
-  model: "claude-sonnet-4",
+  model: "claude-sonnet-5",
   tools: toolkit,
   turns: 3,
 });

--- a/workspaces/documentation/src/content/docs/docs/experimental/mcp.md
+++ b/workspaces/documentation/src/content/docs/docs/experimental/mcp.md
@@ -209,7 +209,7 @@ import { mcp__jaypie__llm_debug_call } from "@jaypie/mcp";
 const response = await mcp__jaypie__llm_debug_call({
   provider: "anthropic",
   message: "Test message",
-  model: "claude-sonnet-4",
+  model: "claude-sonnet-5",
 });
 ```
 

--- a/workspaces/documentation/src/content/docs/docs/guides/llm-integration.md
+++ b/workspaces/documentation/src/content/docs/docs/guides/llm-integration.md
@@ -18,7 +18,7 @@ The `Llm` class handles provider-specific implementations while exposing a consi
 
 | Provider | Models | Env Variable |
 |----------|--------|--------------|
-| Anthropic | claude-sonnet-4, claude-opus-4, claude-haiku | `ANTHROPIC_API_KEY` |
+| Anthropic | claude-sonnet-5, claude-opus-5, claude-haiku-4-5 | `ANTHROPIC_API_KEY` |
 | Fireworks | glm, deepseek, kimi, minimax, qwen | `FIREWORKS_API_KEY` |
 | Google | gemini-2.0-flash, gemini-1.5-pro | `GOOGLE_API_KEY` |
 | OpenAI | gpt-4o, gpt-4o-mini, o1-mini, o3-mini | `OPENAI_API_KEY` |
@@ -42,7 +42,7 @@ import Llm from "@jaypie/llm";
 
 // Provider auto-detected from model
 const response = await Llm.operate("What is 2+2?", {
-  model: "claude-sonnet-4",
+  model: "claude-sonnet-5",
 });
 console.log(response); // "4"
 ```
@@ -53,7 +53,7 @@ console.log(response); // "4"
 import Llm from "@jaypie/llm";
 
 const llm = new Llm("anthropic", {
-  model: "claude-sonnet-4",
+  model: "claude-sonnet-5",
   system: "You are a helpful assistant.",
 });
 
@@ -74,9 +74,9 @@ const llm = new Llm("claude-sonnet-4-6"); // -> anthropic, claude-sonnet-4-6
 
 ```typescript
 // Anthropic models
-await Llm.operate(prompt, { model: "claude-sonnet-4" });
-await Llm.operate(prompt, { model: "claude-opus-4" });
-await Llm.operate(prompt, { model: "claude-haiku" });
+await Llm.operate(prompt, { model: "claude-sonnet-5" });
+await Llm.operate(prompt, { model: "claude-opus-5" });
+await Llm.operate(prompt, { model: "claude-haiku-4-5" });
 
 // OpenAI models
 await Llm.operate(prompt, { model: "gpt-4o" });
@@ -167,7 +167,7 @@ const toolkit = new Toolkit([
 ]);
 
 const response = await Llm.operate("What's the weather in NYC?", {
-  model: "claude-sonnet-4",
+  model: "claude-sonnet-5",
   tools: toolkit,
 });
 ```
@@ -279,7 +279,7 @@ const response = await Llm.operate(prompt, {
 
 ```typescript
 const llm = new Llm("anthropic", {
-  model: "claude-sonnet-4",
+  model: "claude-sonnet-5",
   system: "You are a math tutor.",
 });
 
@@ -300,7 +300,7 @@ console.log(llm.history);
 const response = await Llm.operate(
   "What's in this image?",
   {
-    model: "claude-sonnet-4",
+    model: "claude-sonnet-5",
     files: [
       {
         type: "image",
@@ -337,7 +337,7 @@ Seven hooks fire through the operate loop, each receiving the full provider requ
 
 ```typescript
 const response = await Llm.operate(prompt, {
-  model: "claude-sonnet-4",
+  model: "claude-sonnet-5",
   hooks: {
     beforeEachModelRequest: ({ providerRequest }) => {
       log.trace("[llm] calling model");
@@ -374,7 +374,7 @@ For progress reporting (UI updates, websockets, queue notifications), prefer a s
 
 ```typescript
 const response = await Llm.operate(prompt, {
-  model: "claude-sonnet-4",
+  model: "claude-sonnet-5",
   tools: toolkit,
   onProgress: (event) => {
     // event.type: start, model_request, model_response,
@@ -407,7 +407,7 @@ import Llm from "@jaypie/llm";
 
 async function askLlm(prompt) {
   try {
-    return await Llm.operate(prompt, { model: "claude-sonnet-4" });
+    return await Llm.operate(prompt, { model: "claude-sonnet-5" });
   } catch (error) {
     log.error("[askLlm] LLM call failed");
     log.var({ error: error.message });
@@ -425,7 +425,7 @@ non-streaming requests). Override it through `providerOptions`:
 
 ```typescript
 await Llm.operate(prompt, {
-  model: "claude-sonnet-4",
+  model: "claude-sonnet-5",
   providerOptions: { max_tokens: 32000 },
   temperature: 0.7,
 });

--- a/workspaces/documentation/src/content/docs/docs/index.md
+++ b/workspaces/documentation/src/content/docs/docs/index.md
@@ -242,7 +242,7 @@ new JaypieApiGateway(this, "Gateway", {
 import Llm from "@jaypie/llm";
 
 const response = await Llm.operate("What is 2+2?", {
-  model: "claude-sonnet-4",
+  model: "claude-sonnet-5",
 });
 
 // Streaming

--- a/workspaces/documentation/src/content/docs/docs/packages/llm.md
+++ b/workspaces/documentation/src/content/docs/docs/packages/llm.md
@@ -29,7 +29,7 @@ npm install @jaypie/llm
 
 | Provider | Models | Env Variable |
 |----------|--------|--------------|
-| `anthropic` | claude-sonnet-4, claude-opus-4, claude-haiku | `ANTHROPIC_API_KEY` |
+| `anthropic` | claude-sonnet-5, claude-opus-5, claude-haiku-4-5 | `ANTHROPIC_API_KEY` |
 | `fireworks` | glm, deepseek, kimi, minimax, qwen | `FIREWORKS_API_KEY` |
 | `google` | gemini-2.0-flash, gemini-1.5-pro | `GOOGLE_API_KEY` |
 | `openai` | gpt-4o, gpt-4o-mini, o1-mini, o3-mini | `OPENAI_API_KEY` |
@@ -44,7 +44,7 @@ Static method for single prompt/response.
 import Llm from "@jaypie/llm";
 
 const response = await Llm.operate("What is 2+2?", {
-  model: "claude-sonnet-4",
+  model: "claude-sonnet-5",
 });
 // Returns: "4"
 ```
@@ -82,7 +82,7 @@ import Llm from "@jaypie/llm";
 
 // Instance-level configuration
 const llm = new Llm("anthropic", {
-  model: "claude-sonnet-4",
+  model: "claude-sonnet-5",
   fallback: [
     { provider: "openai", model: "gpt-4o" },
     { provider: "google", model: "gemini-2.0-flash" },
@@ -99,7 +99,7 @@ const response = await llm.operate(input, { fallback: false });
 
 // Static method with fallback
 const response = await Llm.operate(input, {
-  model: "claude-sonnet-4",
+  model: "claude-sonnet-5",
   fallback: [{ provider: "openai", model: "gpt-4o" }],
 });
 ```
@@ -120,7 +120,7 @@ For multi-turn conversations with history:
 import Llm from "@jaypie/llm";
 
 const llm = new Llm("anthropic", {
-  model: "claude-sonnet-4",
+  model: "claude-sonnet-5",
   system: "You are a helpful assistant.",
 });
 
@@ -166,7 +166,7 @@ const toolkit = new Toolkit([
 ]);
 
 const response = await Llm.operate("What's the weather in NYC?", {
-  model: "claude-sonnet-4",
+  model: "claude-sonnet-5",
   tools: toolkit,
 });
 ```
@@ -294,7 +294,7 @@ const response = await Llm.operate(prompt, {
 
 ```typescript
 const response = await Llm.operate("What's in this image?", {
-  model: "claude-sonnet-4",
+  model: "claude-sonnet-5",
   files: [
     {
       type: "image",
@@ -325,7 +325,7 @@ Lifecycle callbacks with full provider request/response payloads.
 
 ```typescript
 const response = await Llm.operate(prompt, {
-  model: "claude-sonnet-4",
+  model: "claude-sonnet-5",
   hooks: {
     beforeEachModelRequest: ({ providerRequest }) => {
       log.trace("[llm] calling model");
@@ -362,7 +362,7 @@ For progress reporting (UI updates, websockets, queue notifications), prefer a s
 
 ```typescript
 const response = await Llm.operate(prompt, {
-  model: "claude-sonnet-4",
+  model: "claude-sonnet-5",
   tools: toolkit,
   onProgress: (event) => {
     // event.type: start, model_request, model_response,
@@ -397,7 +397,7 @@ export default expressStreamHandler(async (req, res, context) => {
   const stream = createExpressStream(context);
 
   for await (const chunk of Llm.stream(req.body.prompt, {
-    model: "claude-sonnet-4",
+    model: "claude-sonnet-5",
   })) {
     stream.write(chunk.content || "");
   }
@@ -453,7 +453,7 @@ import Llm from "@jaypie/llm";
 
 async function askLlm(prompt) {
   try {
-    return await Llm.operate(prompt, { model: "claude-sonnet-4" });
+    return await Llm.operate(prompt, { model: "claude-sonnet-5" });
   } catch (error) {
     log.error("[askLlm] failed");
     log.var({ error: error.message });


### PR DESCRIPTION
## Summary

Anthropic released Claude Opus 5. It supersedes Opus 4.8 at the same price, so `MODEL.OPUS` moves to it rather than gaining a new key.

The branch also adds a `new-model-release` skill capturing the procedure, and sweeps model ids that no longer resolve out of the docs.

## Catalog

| Change | Value |
|---|---|
| `MODEL.OPUS` | `claude-opus-5` |
| `COST["claude-opus-5"]` | $5 in / $25 out per MTok, cache read `0.5`, write `{ "1h": 10, "5m": 6.25 }` |

`COST["claude-opus-4-8"]` is retained so historic usage records stay replayable.

Nothing else needed changing. `determineModelProvider` resolves the id through the existing Anthropic match words, `maxOutputTokens` already returns 128,000 for it, and `AnthropicAdapter` already treats `claude-opus-[5-9]` as effort-capable and temperature-free. The live capability matrix and the Anthropic hot test pick it up from the catalog.

## Frozen size tiers

The deprecated `PROVIDER.*.MODEL` maps stay on superseded ids. Repointing a deprecated tier at a newer model keeps it useful and prolongs its life, when the surface should decay so callers migrate to `PROVIDER.*.DEFAULT` or a named `MODEL.*` alias. All seven `@deprecated` tags now say so, and the rule is recorded in the root `CLAUDE.md`.

## Documentation

The provider tables listed `claude-sonnet-4, claude-opus-4, claude-haiku` as the supported Anthropic models. Two of those three were never valid ids and would 404; the third is deprecated. Swept to `claude-sonnet-5, claude-opus-5, claude-haiku-4-5` across the documentation workspace, `packages/mcp/skills`, and `packages/llm/CLAUDE.md`.

## Versions

`@jaypie/llm` 1.3.20, `@jaypie/mcp` 0.8.108, `jaypie` 1.2.69. Release note at `packages/mcp/release-notes/llm/1.3.20.md`.

## Testing

`packages/llm` 1196 passed / 80 skipped, `packages/mcp` 41 passed. Typecheck and build clean, lint reports zero errors. `constants.spec.ts` is the guard that matters here: it asserts every catalog id resolves to a provider, every first-class id is priced, and every `COST` entry satisfies the pricing invariants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018BhrQhud99oLPFtz4EpDLZ