### PR TITLE
test(llm): pin qwen3p7-plus structured expectation on evidence

### DIFF
--- a/packages/llm/test/models.ts
+++ b/packages/llm/test/models.ts
@@ -80,6 +80,12 @@ const MATRIX_EXPECT: Record<
   [MODEL.FIREWORKS.GPT_OSS]: { both: "warn", pdf: "skip", image: "skip" },
   [MODEL.FIREWORKS.KIMI]: { both: "warn", pdf: "skip" },
   [MODEL.FIREWORKS.MINIMAX]: { both: "warn", pdf: "skip", image: "skip" },
+  // QWEN `structured` is pinned "ok" on evidence, not omission: it failed once
+  // in three samples (2026-07), then passed 10 for 10 on resample (2026-07-25,
+  // issue #438) — 12 of 13 overall, so the miss reads as flake. Schema
+  // adherence is loose even when passing (observed ["R","Y","B"] and
+  // ["Red","","Blue"]); the cell only asserts a non-empty array, so degraded
+  // content still counts as ok. A second failure means reopening #438.
   [MODEL.FIREWORKS.QWEN]: { both: "warn", pdf: "skip" },
   [MODEL.NOVA_LITE]: { both: "skip" },
   [MODEL.NOVA_PRO]: { structured: "skip" },


### PR DESCRIPTION
Closes #438.

## Problem

`packages/llm/test/models.ts` pinned the `qwen3p7-plus` × `structured` matrix cell to `ok` **by omission** — the capability was simply absent from its `MATRIX_EXPECT` entry, and the file header defaults anything unlisted to `ok`. The cell had failed once in three samples and been set aside as flake.

That left a genuine capability regression and a transport flake indistinguishable from CI, with no record that the question had ever been raised.

## Verification

```
APP_MODELS=accounts/fireworks/models/qwen3p7-plus \
APP_CAPABILITIES=structured \
npm run test:matrix -w packages/llm
```

Ten consecutive runs, all pass. With the original three samples: **12 of 13**. The miss reads as flake and the `ok` expectation stands.

## Change

A comment at the pin now carries the date, the sample count, the observed degradation, and the condition for reopening #438. The expectation is unchanged in behavior — what changes is that it is now recorded as a decision rather than an accident of omission.

## Secondary finding, deliberately not fixed

`runStructured` (`test/matrix.ts:187`) asserts only "object with a non-empty `colors` array." Two passing runs cleared that bar while degrading against the prompt:

| Run | `colors` |
|---|---|
| 1 | `["R","Y","B"]` |
| 7 | `["Red","","Blue"]` |

Both are valid `string` values, so schema and harness agree the cell is green. Tightening the assertion to catch this would add real flake across a live multi-provider matrix to catch a soft problem — trading a rare false negative for frequent false positives, which is the failure mode that produced this ticket. Recorded in the comment instead.

## Versioning

No version bump. The diff is one comment in a test file; nothing enters a published tarball, and `npm-deploy` publishes nothing.

## Checks

- `npm run typecheck -w packages/llm` — pass
- `npm run test -w packages/llm` — 1196 passed, 80 skipped
- `npm run format` — no changes to this file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018BhrQhud99oLPFtz4EpDLZ
