### PR TITLE
docs(mcp): severity moves from level to status in Fabric vocabulary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15507,7 +15507,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.110",
+      "version": "0.8.111",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.3.3",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.110",
+  "version": "0.8.111",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/mcp/0.8.111.md
+++ b/packages/mcp/release-notes/mcp/0.8.111.md
@@ -1,0 +1,12 @@
+---
+version: 0.8.111
+date: 2026-07-25
+summary: Severity moves from level to status in the Fabric vocabulary; new mdaml and repository skills
+---
+
+## Changes
+
+- Vocabulary: `level` removed from Attribute Definitions; severity is a `status` vocabulary aligned with Datadog
+- Logs: `LOG_LEVEL_FIELD=status` documented as preferred
+- New skills: `mdaml`, `repository`
+- Updated `monorepo` skill

--- a/packages/mcp/skills/agents.md
+++ b/packages/mcp/skills/agents.md
@@ -33,9 +33,9 @@ Complete stack styles, techniques, and traditions.
 `mcp__jaypie__skill(alias: String)`
 
 Contents: index, releasenotes
-Development: apikey, documentation, errors, llm, logs, mocks, monorepo, repokit, style, subpackages, tests, tools
+Development: apikey, documentation, errors, llm, logs, mdaml, mocks, monorepo, repokit, style, subpackages, tests, tools
 Infrastructure: apigateway, aws, cdk, cicd, datadog, dns, dynamodb, express, lambda, migrations, ports, secrets, sqs, streaming, variables, waf, web, websockets
-Patterns: api, fabric, handlers, models, services, vocabulary
+Patterns: api, fabric, handlers, models, repository, services, vocabulary
 Recipes: recipe-api-server
 Meta: issues, jaypie, mcp, skills
 ```

--- a/packages/mcp/skills/logs.md
+++ b/packages/mcp/skills/logs.md
@@ -1,6 +1,6 @@
 ---
 description: Logging patterns and conventions
-related: debugging, datadog, variables
+related: debugging, datadog, variables, vocabulary
 ---
 
 # Logging Patterns
@@ -106,10 +106,12 @@ LOG_LEVEL=trace MODULE_LOG_LEVEL=warn npm test
 By default, the log level is not included in JSON output (Lambda determines level from the console method). To include it:
 
 ```bash
+LOG_LEVEL_FIELD=status        # Adds "status": "debug" (etc.) — preferred
 LOG_LEVEL_FIELD=true          # Adds "level": "debug" (etc.)
-LOG_LEVEL_FIELD=status        # Adds "status": "debug" (etc.)
 LOG_LEVEL_FIELD=false         # Omit (default)
 ```
+
+Prefer `status` as the field name: Datadog reserves `status` for log severity and cannot be reconfigured, and the Fabric vocabulary follows — severity is a `status` vocabulary, and `level` is not a reserved attribute (see `skill("vocabulary")`).
 
 Or via constructor option:
 
@@ -182,3 +184,4 @@ Logs will include the `env`, `invoke`, and `handler` name. For example:
 - **`skill("datadog")`** - Datadog integration and log forwarding
 - **`skill("handlers")`** - Handler lifecycle with automatic log context
 - **`skill("variables")`** - LOG_LEVEL and other environment variables
+- **`skill("vocabulary")`** - Severity as a `status` vocabulary; reserved attribute names

--- a/packages/mcp/skills/mdaml.md
+++ b/packages/mcp/skills/mdaml.md
@@ -1,0 +1,25 @@
+---
+description: Markdown as/ain't markup language, guidelines for parsable markdown
+---
+
+# MDAML
+
+**M**arkdown **A**s (or ain't!) **M**arkup **L**anguage (MDAML) uses heading structure, paragraph placement, and YAML-inspired lists to attempt to encode extractable information for humans and machines.
+
+## Heading Structure
+
+Heading structure is expected to include a single level one `#` followed by optional `##` and additional sub-nesting.
+
+### Tokens
+
+- Use SCREAMING_SNAKE for headings that should be treated as tokens
+
+## Lists
+
+- Lists are preferred over narrative
+- Lists promote punchier writing
+- Lists simplify re-organization
+
+## Paragraphs and Other Content
+
+- If the first node in a section is a paragraph, it is treated as the description for that section, especially when immediately followed by another heading or a list

--- a/packages/mcp/skills/monorepo.md
+++ b/packages/mcp/skills/monorepo.md
@@ -94,35 +94,23 @@ export default ["packages/*/vitest.config.{ts,js}"];
 
 ```
 .DS_Store
-node_modules
-dist
-
-# Local env files
 .env
-.env.local
 .env.*.local
-
-# Log files
-npm-debug.log*
-
-# Editor directories
-.idea
-*.sw?
-
-# Build artifacts
+.env.local
+.env.local.*
+.jaypie
+.next
+.open-next
 *.tsbuildinfo
-```
-
-### .vscode/settings.json
-
-```json
-{
-  "editor.formatOnSave": true,
-  "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": "explicit"
-  },
-  "typescript.preferences.importModuleSpecifier": "relative"
-}
+build/
+cdk.context.json
+cdk.out
+dist
+LOCAL
+next-env.d.ts
+node_modules
+npm-debug.log*
+var
 ```
 
 ## Installation
@@ -160,6 +148,37 @@ npm install --save-dev @jaypie/eslint @jaypie/repokit @jaypie/testkit eslint vit
 - Use `"version": "0.0.1"`, `"type": "module"`, and `"private": true` for new packages
 - Do not include authors, keywords, or external links in package.json
 - If this is the first commit, commit directly to main; otherwise create a branch
+
+### File Systems
+
+- bin: scripts
+- docs: markdown, etc
+- etc: configurations
+- lib: usually within a src directory, modules of encapsulated logic that could be refactored out later
+- LOCAL: human local scratch directory, include in gitignore
+- packages: default and preferred name for NPM workspaces; always use for packages publishing to NPM
+- stacks: allowed name for NPM workspaces that publish via CDK
+- templates: usually CloudFormation
+- workspaces: allowed name for NPM workspace that do not publish
+- var: agent and machine local scratch directory, include in gitignore
+
+### Discouraged Folder Names
+
+- scripts => bin
+
+### Example
+
+```
+bin/
+packages/
+  cdk/
+  express/
+    src/
+      lib/
+      app.ts
+      index.ts
+package.json
+```
 
 ## Next Steps
 

--- a/packages/mcp/skills/repository.md
+++ b/packages/mcp/skills/repository.md
@@ -1,0 +1,87 @@
+---
+description: REPOSITORY.md, fabric vocabulary standard for internal documentation; see ~monorepo for setup
+related: fabric, mdaml, monorepo, vocabulary
+---
+
+# REPOSITORY.md Fabric Specification
+
+Specifies common documentation that may exist and where it should exist within the repository for alignment with coding agents.
+
+_See ~monorepo for TypeScript repository setup guidelines_
+
+## Files
+
+### REPOSITORY.md
+
+- REPOSITORY.md, optional, should be placed at the site root
+- Should include `name: REPOSITORY` in document frontmatter
+- Should begin with `# REPOSITORY`
+- Should contain a standard introductory description, "This document is a structured description of extractable ~repository policies. The all-cap headings are tokens for parsing but content between should be modified freely."
+- Matching subsection SCREAMING_SNAKE tokens improves parse-ability
+
+### SUBSECTIONS.md
+
+- All subsections are optional
+- Any recognized subsection can be broken out as its own SUBSECTION.md
+- Usually this is only done with level two headings
+- Additional subsections can be created as needed where needed but may not be automatically recognized by extracting tools; ideally document these
+
+## Markdown Structure
+
+Markdown follows the ~mdaml guidelines of nested headings, an optional description paragraph, and bulleted lists for guidelines.
+
+### Sections
+
+- `AGENTS`
+  - `INTERACTIONS` - describing interactions with users and how it should act
+  - `SKILLS`
+  - `TOOLS` - may include MCP, may be bundled in skills
+- `ARCHITECTURE`
+  - `API`
+    - `APP` - The internal API surface for the front end, usually bearer authenticated
+    - `EXTERNAL` - Outward facing API functionality, usually key authenticated
+    - `INTERACTIONS` - Web hooks and other inbound
+  - `INFRASTRUCTURE`
+  - `PACKAGES`
+  - `SDK`
+  - `SERVICES`
+  - `USES`
+- `CONTRIBUTING`
+  - `BRANCHING`
+  - `CHECKS` - Sometimes called "green," defines what checks should be run before deploying
+  - `COMMANDS`
+  - `DEPLOY`
+  - `DESIGN`
+  - `INSTALL`
+  - `ISSUES`
+  - `LINT`
+  - `SETUP` - For local development
+  - `TESTING`
+  - `VERSIONING`
+- `DOCUMENTATION`
+  - `CHANGELOG`
+  - `REFERENCES` - Sources for code, inspiration, and other materials as appropriate
+  - `STYLE`
+  - `VOICE`
+- `LICENSE`
+- `ROADMAP`
+  - `GOAL`
+  - `TIMELINE`
+  - `TODO`
+  - `VISION`
+  - `WISHLIST`
+- `SPONSOR`
+  - `AUTHORS`
+  - `CONTACT`
+  - `LEGAL`
+
+## Markdown Template
+
+```markdown
+---
+name: REPOSITORY
+---
+
+# REPOSITORY
+This document is a structured description of extractable ~repository policies. The all-cap headings are tokens for parsing but content between should be modified freely.
+```

--- a/packages/mcp/skills/skills.md
+++ b/packages/mcp/skills/skills.md
@@ -16,8 +16,8 @@ Look up skills by alias: `mcp__jaypie__skill(alias)`
 | Category | Skills |
 |----------|--------|
 | contents | index, releasenotes |
-| development | apikey, documentation, errors, llm, logs, mocks, monorepo, repokit, style, subpackages, tests, tools |
+| development | apikey, documentation, errors, llm, logs, mdaml, mocks, monorepo, repokit, style, subpackages, tests, tools |
 | infrastructure | apigateway, aws, cdk, cicd, datadog, dns, dynamodb, express, lambda, migrations, ports, secrets, sqs, streaming, variables, waf, web, websockets |
-| patterns | api, fabric, handlers, models, services, vocabulary |
+| patterns | api, fabric, handlers, models, repository, services, vocabulary |
 | recipes | recipe-api-server |
 | meta | issues, jaypie, mcp, skills |

--- a/packages/mcp/skills/vocabulary.md
+++ b/packages/mcp/skills/vocabulary.md
@@ -1,6 +1,6 @@
 ---
 description: Definitions, naming conventions, ontology, and pedantry
-related: dynamodb, fabric, models, services
+related: dynamodb, fabric, models, repository, services
 ---
 
 # Vocabulary
@@ -38,7 +38,7 @@ Arguably identity, instance, and relation would form a more complete vocabulary.
 
 - abbreviation: Shortest distinguishable arrangement of 1-4 letters
 - alias: convenient lookup string modeled after a human-memorable shorthand like email alias; possibly but not guaranteed to be unique with model and scope
-- archiveAt: archive timestamp; pro user expectation
+- archiveAt: archive timestamp; pro user expectation as an addition to delete
 - category: free text classifier, ideally a vocabulary under model; substitute for "type"
 - content: often the entity text
 - createdAt: timestamp
@@ -51,7 +51,6 @@ Arguably identity, instance, and relation would form a more complete vocabulary.
 - input: request parameters
 - label: shortened, accepted version of name
 - llm: served LLM model id (e.g., "claude-sonnet-5"); used because `model` is reserved for the entity type
-- level: severity of a log emission (trace, debug, info, warn, error, fatal); a property of an emission, distinct from a lifecycle `status` though Datadog serializes it under the `status` field (see logs skill)
 - links: usually http references
 - message/s: string/s or message object/s
 - metadata: usually immutable, what the entity is
@@ -61,7 +60,7 @@ Arguably identity, instance, and relation would form a more complete vocabulary.
 - scope: organizes entities, usually a reference to a parent entity
 - sequence: deprecated; ordering now uses `updatedAt` via GSI composite sort key
 - state: mutable data the entity tracks
-- status: the entity's position in its model's lifecycle; the value vocabulary is declared by the model. The default job/message vocabulary is `canceled, complete, error, pending, processing, queued, sending`. Every model that uses `status` should declare its vocabulary rather than reuse words across unrelated models — a job's `error` and a log line's `error` are different predicates. The reservation is the declaration requirement, not the values (cf. `category`)
+- status: the entity's position in its model's lifecycle; the value vocabulary is declared by the model. The default job/message vocabulary is `canceled, complete, error, pending, processing, queued, sending`. Severity of a log emission (trace, debug, info, warn, error, fatal) is also a `status` vocabulary — the diagnostic vocabulary, aligned with Datadog, which serializes severity under the `status` field (see logs skill). Every model that uses `status` should declare its vocabulary rather than reuse words across unrelated models — a job's `error` and a log line's `error` are different predicates. The reservation is the declaration requirement, not the values (cf. `category`)
 - updatedAt: timestamp
 - value: computed scalar the entity evaluates to
 - xid: convenient machine lookup string modeled as an external identifier; possibly but not guaranteed to be unique with model and scope
@@ -97,7 +96,7 @@ Avoid words defined elsewhere (services, terminology)
 - case: the subject entity a job operates on; long-lived, accretes jobs and messages over time. Jobs reference their case via `job.case` (optional — jobs usually operate on a case; system jobs may not). Neither model requires the other: a case exists before any job runs on it, and a case never stores a job list (query jobs by case). `case` (subject of work) and `session` (span of engagement) are distinct axes that cross rather than nest: one session may touch several cases; one case accretes across many sessions
 - exchange: an event entity representing one LLM `operate()` call. Attributes use reserved words: `input` (request), `content` (response text), `data` (interpolation parameters — the vocabulary's sanctioned use of the word), `xid` (provider response id), `llm` (served model id), declared `status` vocabulary `completed | incomplete | in_progress` aligned with operate settlement. Turn chains reference the parent exchange (an `exchange` attribute) and store input deltas only — never the resent history; tool loops are the history delta within one exchange, not separate entities. Canonical registration ships upstream: `registerExchangeModel()` / `EXCHANGE_MODEL` in `@jaypie/fabric`
 - job: a run of a plan — the executing or executed instance a plan defines. References its `plan` and, optionally, the `case` it operates on. Declares the default run lifecycle `status` vocabulary (`canceled, complete, error, pending, processing, queued, sending`)
-- message: an emitted unit of directed content — the emission genus covering inter-actor, workflow, and diagnostic (log) messages. `content` holds the text; `category` selects the species **and** its disposition vocabulary; `scope` is optional — a threadless emission (a log) has none, a threaded emission (a chat line) references its parent. Disposition is category-selected: an **operational** message carries `status` with a category-dependent enum (a *transmission* message, actor↔actor, uses a delivery lifecycle `queued | sending | complete`; a *workflow* message, service↔service, uses a coordination lifecycle — the enum is declared per category, not fixed across the model); a **diagnostic** message carries `level` (severity `trace … fatal`) for a message reporting on itself or the system. The reservation is a vocabulary claim, not a storage commitment: a diagnostic message need not persist as an entity. Severity living on `level` rather than `status` is a version detail, not ontology — the observability layer reserves `status` for severity and Jaypie 1 yields to it (see Additional Terminology and the logs skill); the invariant is that a message's disposition vocabulary is category-selected. Distinct from `event` (ground #6, "an entity that happens"): an event is an occurrence that *triggers* and need carry neither content nor a recipient; a message always carries both and is not intrinsically a stimulus. The same utterance may be a `message` (content in a thread), give rise to an `event` (a trigger), and be answered by an `exchange` (the model turn) — different predicates on one utterance, not one primitive doing three jobs
+- message: an emitted unit of directed content — the emission genus covering inter-actor, workflow, and diagnostic (log) messages. `content` holds the text; `category` selects the species **and** its disposition vocabulary; `scope` is optional — a threadless emission (a log) has none, a threaded emission (a chat line) references its parent. Disposition is category-selected: an **operational** message carries `status` with a category-dependent enum (a *transmission* message, actor↔actor, uses a delivery lifecycle `queued | sending | complete`; a *workflow* message, service↔service, uses a coordination lifecycle — the enum is declared per category, not fixed across the model); a **diagnostic** message carries `status` with the severity vocabulary (`trace … fatal`) for a message reporting on itself or the system. The reservation is a vocabulary claim, not a storage commitment: a diagnostic message need not persist as an entity. Severity is not a second attribute — the observability layer reserves the `status` field for severity, and the vocabulary aligns with it rather than reserving `level` alongside (see Additional Terminology and the logs skill); the invariant is that a message's disposition vocabulary is category-selected. Distinct from `event` (ground #6, "an entity that happens"): an event is an occurrence that *triggers* and need carry neither content nor a recipient; a message always carries both and is not intrinsically a stimulus. The same utterance may be a `message` (content in a thread), give rise to an `event` (a trigger), and be answered by an `exchange` (the model turn) — different predicates on one utterance, not one primitive doing three jobs
 - plan: a persisted definition an executor runs; what a job executes. plan : job :: definition : run. A composition projected into data is a plan. Suggested attributes: `alias`, `name`, `description`, `category` (a vocabulary under the model — e.g. composition plans use `workflow` | `agent`), optional `definitionHash` (content hash gating idempotent reseeds), optional `source` (provenance)
 - scenario: a named category of cases (see Category in Ontological Grounding). `case.category` holds the scenario alias; the scenario model defines the category itself: `alias`, `name`, `description`, and `plans` (references) — scenarios prescribe which plans respond to them
 - session: a bounded, resumable scope of coherence over a span, within which events, jobs, and messages cohere and share context and memory — the reified form of Context (ground #8). Nests recursively via `scope` (a session may scope another session), so a finer-grained dialogue thread is a leaf session rather than a separate model. Declares its own `status` vocabulary, not the job lifecycle: `active` (engagement in progress — a turn in flight or a participant present), `idle` (alive and resumable, no in-flight turn; the resting state that makes "resumable" real), `closed` (ended and no longer resumable; sticky terminal). Transitions: *(birth)* → `active` when born of an activity (a first message), or → `idle` when pre-opened empty (a thread created before anyone speaks); `active → idle` when the in-flight turn settles and nothing is queued; `idle → active` on new input (the resume path); `idle → closed` when the resumability deadline lapses or on an explicit end (the terminate path); `active → closed` on an explicit end mid-turn (rare). No `canceled` and no `error` state — a session is a *scope*, not a *task*: cancellation is a *reason* a session reached `closed` (recorded as metadata, `reason: ended | canceled | expired`), and a scope does not error — errors belong to the jobs and exchanges *within* a session, which holds failed turns and remains a valid, open scope; unrecoverable backing context is a `closed` (reason `expired`/`error`), not a live `error` state. A conversation is a collection (ground #2), not a model — messages sharing a `scope`; promote it to a model (ground #9) only if it earns identity that survives zero members or state irreducible to its members. The empty thread's pre-message identity belongs to its `scope` target — a session — not to a separate entity: a chat thread is a session at chat-grain; platform thread-isms (native thread id, parent channel, archived flag) are `xid` / references / `status`, not a new identity
@@ -139,47 +138,12 @@ Avoid words defined elsewhere (services, terminology)
 
 A composition wires services into a graph; it is itself a service.
 
+- workflow: composition model that specifies its selector, entry, and terminal
 - edge: directed link carrying one service's emitted state to the next service's event-input
 - guard: per-edge predicate; whether an edge is eligible to fire; gates, does not choose; optional
 - selector: node function choosing which eligible edge fires
 - entry: where a composition begins
 - terminal: where a composition halts; a state it no longer transforms
-
-### Composition Models
-
-- workflow: a composition that specifies its selector, entry, and terminal
-- agent: a composition that infers its selector, entry, or terminal
-
-## File Systems and Monorepos
-
-- bin: scripts
-- docs: markdown, etc
-- etc: configurations
-- lib: usually within a src directory, modules of encapsulated logic that could be refactored out later
-- LOCAL: human local scratch directory, include in gitignore
-- packages: default and preferred name for NPM workspaces; always use for packages publishing to NPM
-- stacks: allowed name for NPM workspaces that publish via CDK
-- templates: usually CloudFormation
-- workspaces: allowed name for NPM workspace that do not publish
-- var: agent and machine local scratch directory, include in gitignore
-
-### Discouraged Folder Names
-
-- scripts => bin
-
-### Example
-
-```
-bin/
-packages/
-  cdk/
-  express/
-    src/
-      lib/
-      app.ts
-      index.ts
-package.json
-```
 
 ## Constants and Special Characters
 
@@ -190,7 +154,7 @@ SEPARATOR = "#";
 
 ## Additional Terminology
 
-The six log levels are **severity**. Severity is a property of an emission; a lifecycle `status` is a position in a model's declared vocabulary. They are distinct concepts that share the word `error`, so keep them straight — but the *word* `status` is not off-limits for severity. Jaypie names the property `level`; Datadog reserves the field name `status` for log severity and cannot be reconfigured, so serialized logs legitimately emit severity as `status` (`LOG_LEVEL_FIELD=status`, see logs skill). Reserve the caution for the concepts, not the term.
+The six log levels are **severity**. Severity is a property of an emission; a lifecycle `status` is a position in a model's declared vocabulary. They are distinct concepts that share the word `error` (a job's `error` is a lifecycle position; a log line's `error` is a severity), so keep the concepts straight. Both live on `status`: Datadog reserves the field name `status` for log severity and cannot be reconfigured, so the vocabulary aligns rather than reserving `level` as a separate attribute — severity is the `status` vocabulary of a diagnostic emission (`LOG_LEVEL_FIELD=status`, see logs skill). The logger API surface (`log.trace`, `LOG_LEVEL`, the `level` constructor option) keeps the word `level`; that is API, not vocabulary.
 
 - debug: logging, operating checkpoint or abnormal condition
 - error: logging, detected an unrecoverable state and exiting (caught error)


### PR DESCRIPTION
## Summary

- Remove `level` from the vocabulary Attribute Definitions; severity is now a `status` vocabulary aligned with Datadog
- Update `message` model definition and Additional Terminology: diagnostic messages carry `status` with the severity vocabulary
- Logs skill: document `LOG_LEVEL_FIELD=status` as preferred
- Add `mdaml` and `repository` skills; update `monorepo`
- Bump `@jaypie/mcp` to 0.8.111 with release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P1kZyShwWcQJZrN4a5erds