### PR TITLE
readOnly tool annotation (#446) and empty secret guard (#447)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14935,7 +14935,7 @@
     },
     "packages/constructs": {
       "name": "@jaypie/constructs",
-      "version": "1.2.72",
+      "version": "1.2.73",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*",
@@ -15192,7 +15192,7 @@
     },
     "packages/fabric": {
       "name": "@jaypie/fabric",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*"
@@ -15302,7 +15302,7 @@
       "license": "MIT"
     },
     "packages/jaypie": {
-      "version": "1.2.71",
+      "version": "1.2.72",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "^1.2.11",
@@ -15327,7 +15327,7 @@
         "typescript-eslint": "^8.46.1"
       },
       "peerDependencies": {
-        "@jaypie/llm": "^1.3.21"
+        "@jaypie/llm": "^1.3.22"
       },
       "peerDependenciesMeta": {
         "@jaypie/llm": {
@@ -15459,7 +15459,7 @@
     },
     "packages/llm": {
       "name": "@jaypie/llm",
-      "version": "1.3.21",
+      "version": "1.3.22",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "*",
@@ -15545,7 +15545,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.112",
+      "version": "0.8.113",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.3.3",

--- a/packages/constructs/CLAUDE.md
+++ b/packages/constructs/CLAUDE.md
@@ -426,6 +426,8 @@ new JaypieSecret(this, "DbPassword", {
 
 `JaypieEnvSecret` extends `JaypieSecret` and is accepted anywhere a `JaypieSecret` is (including `JaypieLambda` `secrets`). `JaypieEnvSecret` is deprecated and will be removed in 2.0.
 
+Synth throws `ConfigurationError` whenever a declared secret source produces no secret string, so a blank credential never defers to runtime. A source is declared by `envKey` or by passing a `value` key, and an empty string counts as empty — `{ value: process.env.MISSING }` fails at synth. A construct with no declared source still creates an empty secret, preserving the placeholder pattern. `JaypieEnvSecret` skips the guard in consumer environments, where the secret is imported.
+
 ### Lambda with Non-Secret Variables
 
 Lambda caps all environment variables at 4KB combined. `variables` stores

--- a/packages/constructs/package.json
+++ b/packages/constructs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/constructs",
-  "version": "1.2.72",
+  "version": "1.2.73",
   "description": "CDK constructs for Jaypie applications",
   "repository": {
     "type": "git",

--- a/packages/constructs/rollup.config.js
+++ b/packages/constructs/rollup.config.js
@@ -41,6 +41,7 @@ const external = [
   "aws-cdk-lib/aws-secretsmanager",
   "aws-cdk-lib/aws-sns",
   "aws-cdk-lib/aws-sqs",
+  "aws-cdk-lib/aws-ssm",
   "aws-cdk-lib/aws-sso",
   "aws-cdk-lib/aws-wafv2",
   "aws-cdk-lib/custom-resources",

--- a/packages/constructs/src/JaypieEnvSecret.ts
+++ b/packages/constructs/src/JaypieEnvSecret.ts
@@ -2,8 +2,6 @@ import { Construct } from "constructs";
 import { CfnOutput, Fn, RemovalPolicy, SecretValue, Tags } from "aws-cdk-lib";
 import * as secretsmanager from "aws-cdk-lib/aws-secretsmanager";
 
-import { ConfigurationError } from "@jaypie/errors";
-
 import { CDK } from "./constants";
 import {
   BuildSecretContext,
@@ -61,6 +59,7 @@ export interface JaypieEnvSecretProps extends JaypieSecretProps {
  * JaypieSecret and will be removed in 2.0.
  */
 export class JaypieEnvSecret extends JaypieSecret {
+  protected static readonly className: string = "JaypieEnvSecret";
   protected static readonly shorthandPrefix: string = "EnvSecret_";
 
   constructor(
@@ -100,18 +99,6 @@ export class JaypieEnvSecret extends JaypieSecret {
       exportName = cleanName(exportParam);
     }
 
-    if (
-      !consumer &&
-      envKey &&
-      !process.env[envKey] &&
-      value === undefined &&
-      !generateSecretString
-    ) {
-      throw new ConfigurationError(
-        `JaypieEnvSecret(${id}): envKey "${envKey}" is empty in process.env and no value or generateSecretString was provided`,
-      );
-    }
-
     if (consumer) {
       const secretName = Fn.importValue(exportName);
       const secret = secretsmanager.Secret.fromSecretNameV2(
@@ -130,6 +117,8 @@ export class JaypieEnvSecret extends JaypieSecret {
 
     const secretValue =
       envKey && process.env[envKey] ? process.env[envKey] : value;
+
+    this.assertSecretValue(context, secretValue);
 
     const secret = new secretsmanager.Secret(this, id, {
       generateSecretString,

--- a/packages/constructs/src/JaypieSecret.ts
+++ b/packages/constructs/src/JaypieSecret.ts
@@ -45,6 +45,10 @@ export class JaypieSecret extends Construct implements ISecret {
   // Subclasses override this to preserve their own naming conventions.
   protected static readonly shorthandPrefix: string = "Secret_";
 
+  // Class name used in configuration error messages. Subclasses override so
+  // the message names the construct the caller wrote.
+  protected static readonly className: string = "JaypieSecret";
+
   protected readonly _envKey?: string;
   protected readonly _secret: secretsmanager.ISecret;
 
@@ -78,6 +82,39 @@ export class JaypieSecret extends Construct implements ISecret {
   }
 
   /**
+   * Fails fast when a declared secret source produced no secret string, so a
+   * blank credential surfaces at synth instead of at runtime. A source is
+   * declared by `envKey` or by the props carrying a `value` key: passing
+   * `value: process.env.MISSING` is a declaration even though it resolves to
+   * undefined. Constructs with no declared source create an empty secret as
+   * before (issue #447).
+   */
+  protected assertSecretValue(
+    context: BuildSecretContext,
+    secretValue?: string,
+  ): void {
+    const { envKey, id, props } = context;
+
+    if (secretValue || props.generateSecretString) {
+      return;
+    }
+
+    const label = (this.constructor as typeof JaypieSecret).className;
+
+    if (envKey) {
+      throw new ConfigurationError(
+        `${label}(${id}): envKey "${envKey}" is empty in process.env and no value or generateSecretString was provided`,
+      );
+    }
+
+    if (Object.prototype.hasOwnProperty.call(props, "value")) {
+      throw new ConfigurationError(
+        `${label}(${id}): value is empty and no envKey or generateSecretString was provided`,
+      );
+    }
+  }
+
+  /**
    * Builds the underlying secret. The base implementation always creates a new
    * Secrets Manager secret from an envKey value, an explicit value, or a
    * generated string. Subclasses may override to import an existing secret or
@@ -88,19 +125,10 @@ export class JaypieSecret extends Construct implements ISecret {
     const { generateSecretString, removalPolicy, roleTag, vendorTag, value } =
       props;
 
-    if (
-      envKey &&
-      !process.env[envKey] &&
-      value === undefined &&
-      !generateSecretString
-    ) {
-      throw new ConfigurationError(
-        `JaypieSecret(${id}): envKey "${envKey}" is empty in process.env and no value or generateSecretString was provided`,
-      );
-    }
-
     const secretValue =
       envKey && process.env[envKey] ? process.env[envKey] : value;
+
+    this.assertSecretValue(context, secretValue);
 
     const secret = new secretsmanager.Secret(this, id, {
       generateSecretString,

--- a/packages/constructs/src/__tests__/JaypieEnvSecret.spec.ts
+++ b/packages/constructs/src/__tests__/JaypieEnvSecret.spec.ts
@@ -359,4 +359,45 @@ describe("JaypieSecret", () => {
       }).not.toThrow();
     });
   });
+
+  describe("Issue #447: value form silently synthesizes a blank secret", () => {
+    it("throws ConfigurationError when value is explicitly undefined", () => {
+      delete process.env.MISSING_SECRET;
+      const stack = new Stack();
+      expect(() => {
+        new JaypieEnvSecret(stack, "GoogleApiKey", {
+          provider: true,
+          value: process.env.MISSING_SECRET,
+        });
+      }).toThrow(ConfigurationError);
+    });
+
+    it("throws ConfigurationError when value is an empty string", () => {
+      process.env.EMPTY_SECRET = "";
+      const stack = new Stack();
+      expect(() => {
+        new JaypieEnvSecret(stack, "GoogleApiKey", {
+          value: process.env.EMPTY_SECRET,
+        });
+      }).toThrow(ConfigurationError);
+      delete process.env.EMPTY_SECRET;
+    });
+
+    it("does not throw when consumer imports the secret", () => {
+      const stack = new Stack();
+      expect(() => {
+        new JaypieEnvSecret(stack, "GoogleApiKey", {
+          consumer: true,
+          value: undefined,
+        });
+      }).not.toThrow();
+    });
+
+    it("does not throw when no source is declared", () => {
+      const stack = new Stack();
+      expect(() => {
+        new JaypieEnvSecret(stack, "Placeholder", { provider: true });
+      }).not.toThrow();
+    });
+  });
 });

--- a/packages/constructs/src/__tests__/JaypieSecret.spec.ts
+++ b/packages/constructs/src/__tests__/JaypieSecret.spec.ts
@@ -268,4 +268,44 @@ describe("JaypieSecret", () => {
       }).not.toThrow();
     });
   });
+
+  describe("Issue #447: value form silently synthesizes a blank secret", () => {
+    it("throws ConfigurationError when value is explicitly undefined", () => {
+      delete process.env.MISSING_SECRET;
+      const stack = new Stack();
+      expect(() => {
+        new JaypieSecret(stack, "TestSecret", {
+          value: process.env.MISSING_SECRET,
+        });
+      }).toThrow(ConfigurationError);
+    });
+
+    it("throws ConfigurationError when value is an empty string", () => {
+      process.env.EMPTY_SECRET = "";
+      const stack = new Stack();
+      expect(() => {
+        new JaypieSecret(stack, "TestSecret", {
+          value: process.env.EMPTY_SECRET,
+        });
+      }).toThrow(ConfigurationError);
+      delete process.env.EMPTY_SECRET;
+    });
+
+    it("does not throw when value is empty but generateSecretString is provided", () => {
+      const stack = new Stack();
+      expect(() => {
+        new JaypieSecret(stack, "TestSecret", {
+          generateSecretString: {},
+          value: undefined,
+        });
+      }).not.toThrow();
+    });
+
+    it("does not throw when no source is declared", () => {
+      const stack = new Stack();
+      expect(() => {
+        new JaypieSecret(stack, "Placeholder", { roleTag: CDK.ROLE.API });
+      }).not.toThrow();
+    });
+  });
 });

--- a/packages/fabric/CLAUDE.md
+++ b/packages/fabric/CLAUDE.md
@@ -142,6 +142,7 @@ const handler = fabricService({
       validate: (v) => v > 0, // Optional: function, RegExp, or array
     },
   },
+  readOnly: true,             // Optional: declares the service free of side effects
   service: (input, context) => input.fieldName * 2,
   serializer: ({ input, output }, context) => {
     // Runs after service - can transform output
@@ -455,6 +456,11 @@ export { fabricTool } from "./fabricTool.js";
 export { inputToJsonSchema } from "./inputToJsonSchema.js";
 export type { FabricToolConfig, FabricToolResult, LlmTool, OnCompleteCallback, OnErrorCallback, OnFatalCallback, OnMessageCallback } from "./types.js";
 ```
+
+`fabricTool` carries `readOnly` onto the tool: `fabricService({ readOnly: true })`
+propagates through, and `fabricTool({ readOnly })` overrides the service. The
+annotation drives `Toolkit.filter({ readOnly: true })` in `@jaypie/llm`, which
+derives a side-effect-free toolkit for verification passes.
 
 ### WebSocket Export (`@jaypie/fabric/websocket`)
 

--- a/packages/fabric/package.json
+++ b/packages/fabric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/fabric",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Jaypie modeling framework with type conversion, service handlers, and adapters",
   "repository": {
     "type": "git",

--- a/packages/fabric/src/__tests__/llm.spec.ts
+++ b/packages/fabric/src/__tests__/llm.spec.ts
@@ -840,5 +840,62 @@ describe("LLM Adapter", () => {
         expect(originalService.description).toBe("Foo service");
       });
     });
+
+    describe("readOnly annotation", () => {
+      it("omits readOnly when the service does not declare it", () => {
+        const { tool } = fabricTool({
+          alias: "write",
+          service: () => "done",
+        });
+
+        expect(tool).not.toHaveProperty("readOnly");
+      });
+
+      it("passes readOnly through from the service config", () => {
+        const service = fabricService({
+          alias: "lookup",
+          readOnly: true,
+          service: () => "result",
+        });
+
+        expect(service.readOnly).toBe(true);
+        expect(fabricTool({ service }).tool.readOnly).toBe(true);
+      });
+
+      it("preserves readOnly when overrides rebuild the service", () => {
+        const service = fabricService({
+          alias: "lookup",
+          readOnly: true,
+          service: () => "result",
+        });
+
+        const { tool } = fabricTool({ alias: "renamed", service });
+
+        expect(tool.name).toBe("renamed");
+        expect(tool.readOnly).toBe(true);
+      });
+
+      it("accepts readOnly directly on the tool config", () => {
+        const { tool } = fabricTool({
+          alias: "lookup",
+          readOnly: true,
+          service: () => "result",
+        });
+
+        expect(tool.readOnly).toBe(true);
+      });
+
+      it("allows the tool config to override the service annotation", () => {
+        const service = fabricService({
+          alias: "lookup",
+          readOnly: true,
+          service: () => "result",
+        });
+
+        expect(fabricTool({ readOnly: false, service }).tool.readOnly).toBe(
+          false,
+        );
+      });
+    });
   });
 });

--- a/packages/fabric/src/llm/fabricTool.ts
+++ b/packages/fabric/src/llm/fabricTool.ts
@@ -55,6 +55,7 @@ export function fabricTool(config: FabricToolConfig): FabricToolResult {
     onError,
     onFatal,
     onMessage,
+    readOnly,
     service: serviceOrFunction,
   } = config;
 
@@ -63,6 +64,7 @@ export function fabricTool(config: FabricToolConfig): FabricToolResult {
     alias,
     description,
     input,
+    readOnly,
     service: serviceOrFunction,
   });
 
@@ -151,6 +153,11 @@ export function fabricTool(config: FabricToolConfig): FabricToolResult {
   // Add message if provided
   if (message !== undefined) {
     tool.message = message;
+  }
+
+  // Annotate side-effect-free tools so verification passes can filter for them
+  if (service.readOnly !== undefined) {
+    tool.readOnly = service.readOnly;
   }
 
   return { tool };

--- a/packages/fabric/src/llm/types.ts
+++ b/packages/fabric/src/llm/types.ts
@@ -49,6 +49,8 @@ export interface FabricToolConfig {
   onFatal?: OnFatalCallback;
   /** Callback for receiving messages from service */
   onMessage?: OnMessageCallback;
+  /** Declares the tool free of side effects (defaults to service.readOnly) */
+  readOnly?: boolean;
   /** The service - either a pre-instantiated Service or an inline function */
   service: Service | ServiceFunction<Record<string, unknown>, unknown>;
 }
@@ -67,6 +69,8 @@ export interface LlmTool {
       ) => Promise<string> | string);
   name: string;
   parameters: Record<string, unknown>;
+  /** Declares the tool free of side effects (mirrors MCP's readOnlyHint) */
+  readOnly?: boolean;
   type: "function" | string;
 }
 

--- a/packages/fabric/src/resolveService.ts
+++ b/packages/fabric/src/resolveService.ts
@@ -22,6 +22,8 @@ export interface ResolveServiceConfig<
   description?: string;
   /** Input field definitions */
   input?: Record<string, InputFieldDefinition>;
+  /** Declares the service free of side effects */
+  readOnly?: boolean;
   /** Serializer function - runs after service */
   serializer?: SerializerFunction<TInput, TOutput, TSerializedOutput>;
   /** The service - either a pre-instantiated Service or an inline function */
@@ -72,7 +74,7 @@ export function resolveService<
 >(
   config: ResolveServiceConfig<TInput, TOutput, TSerializedOutput>,
 ): Service<TInput, TOutput, TSerializedOutput> {
-  const { alias, description, input, serializer, service } = config;
+  const { alias, description, input, readOnly, serializer, service } = config;
 
   if (isService<TInput, TOutput, TSerializedOutput>(service)) {
     // Service is pre-instantiated - config fields act as overrides
@@ -81,6 +83,7 @@ export function resolveService<
       alias: alias ?? service.alias,
       description: description ?? service.description,
       input: input ?? service.input,
+      readOnly: readOnly ?? service.readOnly,
       serializer: serializer ?? service.serializer,
       service: service.service,
     });
@@ -91,6 +94,7 @@ export function resolveService<
     alias,
     description,
     input,
+    readOnly,
     serializer,
     service,
   });

--- a/packages/fabric/src/service.ts
+++ b/packages/fabric/src/service.ts
@@ -343,6 +343,7 @@ export function fabricService<
   if (config.description !== undefined)
     typedHandler.description = config.description;
   if (config.input !== undefined) typedHandler.input = config.input;
+  if (config.readOnly !== undefined) typedHandler.readOnly = config.readOnly;
   if (config.serializer !== undefined)
     typedHandler.serializer = config.serializer;
   if (config.service !== undefined) typedHandler.service = config.service;

--- a/packages/fabric/src/types.ts
+++ b/packages/fabric/src/types.ts
@@ -139,6 +139,11 @@ export interface ServiceConfig<
   alias?: string;
   description?: string;
   input?: Record<string, InputFieldDefinition>;
+  /**
+   * Declares the service free of side effects. Adapters surface it as a
+   * transport-native annotation (`LlmTool.readOnly` via `fabricTool`).
+   */
+  readOnly?: boolean;
   /** Runs after service - can transform output */
   serializer?: SerializerFunction<TInput, TOutput, TSerializedOutput>;
   service?: ServiceFunction<TInput, TOutput>;

--- a/packages/jaypie/package.json
+++ b/packages/jaypie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jaypie",
-  "version": "1.2.71",
+  "version": "1.2.72",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"
@@ -59,7 +59,7 @@
     "typescript-eslint": "^8.46.1"
   },
   "peerDependencies": {
-    "@jaypie/llm": "^1.3.21"
+    "@jaypie/llm": "^1.3.22"
   },
   "peerDependenciesMeta": {
     "@jaypie/llm": {

--- a/packages/llm/CLAUDE.md
+++ b/packages/llm/CLAUDE.md
@@ -408,6 +408,25 @@ call via `Toolkit.resolveMessage()` and surface it in the Toolkit `log`
 option, the `beforeEachTool`/`afterEachTool`/`onToolError` hooks (as
 `message`), and the `tool_call` progress event (as `tool.message`).
 
+Tools may also declare `readOnly: true` (mirroring MCP's `readOnlyHint`) to
+state they carry no side effects. `Toolkit.filter()` derives a new Toolkit from
+that annotation, so a verification or critique pass can re-run `operate()`
+against the read set without repeating side effects:
+
+```typescript
+const verification = toolkit.filter({ readOnly: true });  // annotated only
+const effectful = toolkit.filter({ readOnly: false });    // the complement
+const custom = toolkit.filter((tool) => tool.name.startsWith("search_"));
+```
+
+Tools are side-effecting unless annotated, so new tools stay excluded from the
+read set by default. The derived Toolkit shares the same tool implementations
+and inherits `explain`/`log`; extending either toolkit leaves the other
+unchanged. `readOnly` is stripped from `Toolkit.tools`, so it never reaches a
+provider payload. The built-in tools (`random`, `roll`, `time`, `weather`) are
+annotated read-only, and `fabricService({ readOnly: true })` propagates through
+`fabricTool`.
+
 ### Progress Events
 
 `operate()` accepts an `onProgress` callback that receives lightweight,

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/llm",
-  "version": "1.3.21",
+  "version": "1.3.22",
   "description": "Large language model utilities",
   "repository": {
     "type": "git",

--- a/packages/llm/src/index.ts
+++ b/packages/llm/src/index.ts
@@ -53,6 +53,11 @@ export type {
 export { LlmStreamChunkType } from "./types/LlmStreamChunk.interface.js";
 
 export { JaypieToolkit, toolkit, Toolkit, tools } from "./tools/index.js";
+export type {
+  ToolkitFilter,
+  ToolkitFilterCriteria,
+  ToolkitOptions,
+} from "./tools/Toolkit.class.js";
 
 // Errors
 export {

--- a/packages/llm/src/tools/Toolkit.class.ts
+++ b/packages/llm/src/tools/Toolkit.class.ts
@@ -23,6 +23,17 @@ export interface ToolkitOptions {
   log?: boolean | LogFunction;
 }
 
+export interface ToolkitFilterCriteria {
+  /**
+   * `true` keeps only tools annotated `readOnly: true`; `false` keeps the
+   * complement, every tool not annotated read-only.
+   */
+  readOnly?: boolean;
+}
+
+export type ToolkitFilter =
+  ToolkitFilterCriteria | ((tool: LlmTool) => boolean);
+
 export class Toolkit {
   private readonly _tools: LlmTool[];
   private readonly _options: ToolkitOptions;
@@ -41,6 +52,7 @@ export class Toolkit {
       const toolCopy: any = { ...tool };
       delete toolCopy.call;
       delete toolCopy.message;
+      delete toolCopy.readOnly;
 
       // Convert Zod schema to JSON Schema if needed
       if (toolCopy.parameters instanceof z.ZodType) {
@@ -167,6 +179,31 @@ export class Toolkit {
     }
 
     return await resolveValue(tool.call(parsedArgs));
+  }
+
+  /**
+   * Derive a new Toolkit from a subset of these tools. The tools themselves are
+   * shared, so the derived toolkit calls the same implementations; extending
+   * either toolkit leaves the other unchanged.
+   *
+   * @example
+   * ```typescript
+   * // Verification pass: check facts without repeating side effects
+   * const verification = toolkit.filter({ readOnly: true });
+   * ```
+   */
+  filter(criteria: ToolkitFilter = {}): Toolkit {
+    const predicate =
+      typeof criteria === "function"
+        ? criteria
+        : (tool: LlmTool): boolean =>
+            criteria.readOnly === undefined ||
+            (tool.readOnly === true) === criteria.readOnly;
+
+    return new Toolkit(this._tools.filter(predicate), {
+      explain: this.explain,
+      log: this.log,
+    });
   }
 
   extend(

--- a/packages/llm/src/tools/__tests__/Toolkit.class.test.ts
+++ b/packages/llm/src/tools/__tests__/Toolkit.class.test.ts
@@ -637,5 +637,89 @@ describe("Toolkit", () => {
       const props = params.properties as JsonObject;
       expect(props.__Explanation).toBeDefined();
     });
+
+    it("omits readOnly from the provider-facing tool definition", () => {
+      const toolkit = new Toolkit([{ ...mockTool, readOnly: true }]);
+
+      expect(toolkit.tools[0]).not.toHaveProperty("readOnly");
+    });
+  });
+
+  describe("filter", () => {
+    const readTool: LlmTool = {
+      ...mockTool,
+      name: "readTool",
+      readOnly: true,
+    };
+    const writeTool: LlmTool = { ...mockTool, name: "writeTool" };
+
+    it("returns only read-only tools", () => {
+      const toolkit = new Toolkit([readTool, writeTool]);
+      const filtered = toolkit.filter({ readOnly: true });
+
+      expect(filtered).toBeInstanceOf(Toolkit);
+      expect(filtered.tools.map((tool) => tool.name)).toEqual(["readTool"]);
+    });
+
+    it("returns the complement when readOnly is false", () => {
+      const toolkit = new Toolkit([readTool, writeTool]);
+      const filtered = toolkit.filter({ readOnly: false });
+
+      expect(filtered.tools.map((tool) => tool.name)).toEqual(["writeTool"]);
+    });
+
+    it("excludes unannotated tools from the read-only set", () => {
+      const toolkit = new Toolkit([
+        { ...mockTool, name: "explicitFalse", readOnly: false },
+        writeTool,
+      ]);
+
+      expect(toolkit.filter({ readOnly: true }).tools).toBeArrayOfSize(0);
+    });
+
+    it("accepts a predicate function", () => {
+      const toolkit = new Toolkit([readTool, writeTool]);
+      const filtered = toolkit.filter((tool) => tool.name === "writeTool");
+
+      expect(filtered.tools.map((tool) => tool.name)).toEqual(["writeTool"]);
+    });
+
+    it("returns all tools when no criteria are provided", () => {
+      const toolkit = new Toolkit([readTool, writeTool]);
+
+      expect(toolkit.filter().tools).toBeArrayOfSize(2);
+    });
+
+    it("preserves toolkit options", () => {
+      const toolkit = new Toolkit([readTool], { explain: true, log: false });
+      const filtered = toolkit.filter({ readOnly: true });
+
+      const params = filtered.tools[0].parameters as JsonObject;
+      const props = params.properties as JsonObject;
+      expect(props.__Explanation).toBeDefined();
+    });
+
+    it("does not mutate the source toolkit", async () => {
+      const toolkit = new Toolkit([readTool, writeTool]);
+      const filtered = toolkit.filter({ readOnly: true });
+      filtered.extend([{ ...mockTool, name: "addedTool", readOnly: true }]);
+
+      expect(toolkit.tools).toBeArrayOfSize(2);
+      await expect(
+        toolkit.call({ name: "addedTool", arguments: "{}" }),
+      ).rejects.toThrow("Tool 'addedTool' not found");
+    });
+
+    it("calls through to the original tool implementation", async () => {
+      const call = vi.fn().mockResolvedValue("read-result");
+      const toolkit = new Toolkit([{ ...readTool, call }, writeTool]);
+
+      const result = await toolkit
+        .filter({ readOnly: true })
+        .call({ name: "readTool", arguments: '{"testParam":"a"}' });
+
+      expect(call).toHaveBeenCalledWith({ testParam: "a" });
+      expect(result).toBe("read-result");
+    });
   });
 });

--- a/packages/llm/src/tools/random.ts
+++ b/packages/llm/src/tools/random.ts
@@ -51,6 +51,7 @@ export const random: LlmTool = {
     },
     required: [],
   },
+  readOnly: true,
   type: "function",
   call: (options) => {
     const rng = randomUtil();

--- a/packages/llm/src/tools/roll.ts
+++ b/packages/llm/src/tools/roll.ts
@@ -18,6 +18,7 @@ export const roll: LlmTool = {
     },
     required: ["number", "sides"],
   },
+  readOnly: true,
   type: "function",
   call: ({ number = 1, sides = 6 } = {}): {
     rolls: number[];

--- a/packages/llm/src/tools/time.ts
+++ b/packages/llm/src/tools/time.ts
@@ -15,6 +15,7 @@ export const time: LlmTool = {
     },
     required: [],
   },
+  readOnly: true,
   type: "function",
   call: ({ date } = {}) => {
     if (typeof date === "number" || typeof date === "string") {

--- a/packages/llm/src/tools/weather.ts
+++ b/packages/llm/src/tools/weather.ts
@@ -39,6 +39,7 @@ export const weather: LlmTool = {
     },
     required: ["latitude", "location", "longitude"],
   },
+  readOnly: true,
   type: "function",
   call: async ({
     latitude = 42.051554533384866,

--- a/packages/llm/src/types/LlmTool.interface.ts
+++ b/packages/llm/src/types/LlmTool.interface.ts
@@ -14,4 +14,11 @@ export interface LlmTool {
         args?: JsonObject,
         context?: { name: string },
       ) => Promise<string> | string);
+  /**
+   * Declares the tool free of side effects, mirroring MCP's `readOnlyHint`.
+   * Consumed by `Toolkit.filter({ readOnly: true })` to derive a toolkit safe
+   * for verification and critique passes. Tools are side-effecting unless
+   * annotated, so new tools stay excluded by default.
+   */
+  readOnly?: boolean;
 }

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.112",
+  "version": "0.8.113",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/constructs/1.2.73.md
+++ b/packages/mcp/release-notes/constructs/1.2.73.md
@@ -1,0 +1,24 @@
+---
+version: 1.2.73
+date: 2026-07-26
+summary: JaypieSecret and JaypieEnvSecret fail synth when a declared source produces no secret string
+---
+
+## Fixes
+
+- `JaypieSecret` and `JaypieEnvSecret` throw `ConfigurationError` at synth
+  whenever a declared secret source produces no secret string. Previously the
+  guard fired only for the `envKey` form, so `{ value: process.env.MISSING }`
+  synthesized a blank secret and deferred the failure to runtime as an empty
+  credential.
+- A source is declared by `envKey` or by passing a `value` key. An empty string
+  counts as empty, matching the existing `envKey` semantics.
+- A construct with no declared source still creates an empty secret, preserving
+  the placeholder pattern. `JaypieEnvSecret` skips the guard in consumer
+  environments, where the secret is imported rather than created.
+- The guard now lives in one place, `JaypieSecret.assertSecretValue`, which
+  `JaypieEnvSecret` inherits.
+- `aws-cdk-lib/aws-ssm` added to the rollup external list; it was missing since
+  the `variables` feature landed, and the build warned on every run.
+
+Addresses issue #447.

--- a/packages/mcp/release-notes/fabric/0.3.7.md
+++ b/packages/mcp/release-notes/fabric/0.3.7.md
@@ -1,0 +1,17 @@
+---
+version: 0.3.7
+date: 2026-07-26
+summary: readOnly service attribute propagates through fabricTool to LlmTool
+---
+
+## Features
+
+- `fabricService({ readOnly: true })` declares a service free of side effects.
+  The flag attaches to the handler and survives the service rebuild that
+  `resolveService` performs when adapters apply overrides.
+- `fabricTool` stamps `tool.readOnly` from the service, and
+  `fabricTool({ readOnly })` overrides it.
+- The annotation drives `Toolkit.filter({ readOnly: true })` in `@jaypie/llm`,
+  which derives a toolkit safe for verification passes.
+
+Addresses issue #446.

--- a/packages/mcp/release-notes/jaypie/1.2.72.md
+++ b/packages/mcp/release-notes/jaypie/1.2.72.md
@@ -1,0 +1,12 @@
+---
+version: 1.2.72
+date: 2026-07-26
+summary: Picks up @jaypie/llm 1.3.22 readOnly tools
+---
+
+## Changes
+
+- Picks up `@jaypie/llm` 1.3.22, which adds the `readOnly` tool annotation and
+  `Toolkit.filter()`.
+
+Addresses issue #446.

--- a/packages/mcp/release-notes/llm/1.3.22.md
+++ b/packages/mcp/release-notes/llm/1.3.22.md
@@ -1,0 +1,31 @@
+---
+version: 1.3.22
+date: 2026-07-26
+summary: readOnly tool annotation and Toolkit.filter for side-effect-free toolkits
+---
+
+## Features
+
+- `LlmTool.readOnly` declares a tool free of side effects, mirroring MCP's
+  `readOnlyHint`.
+- `Toolkit.filter()` derives a new Toolkit from the annotation, so a
+  verification or critique pass can re-run `operate()` against the read set
+  without repeating side effects:
+
+  ```typescript
+  const verification = toolkit.filter({ readOnly: true }); // annotated only
+  const effectful = toolkit.filter({ readOnly: false });   // the complement
+  const custom = toolkit.filter((tool) => tool.name.startsWith("search_"));
+  ```
+
+- Tools are side-effecting unless annotated, so new tools stay excluded from
+  the read set by default.
+- The derived Toolkit shares the same tool implementations and inherits
+  `explain`/`log`; extending either toolkit leaves the other unchanged.
+- `readOnly` is stripped from `Toolkit.tools`, so it never reaches a provider
+  payload.
+- The built-in tools (`random`, `roll`, `time`, `weather`) are annotated
+  read-only.
+- `ToolkitFilter`, `ToolkitFilterCriteria`, and `ToolkitOptions` are exported.
+
+Addresses issue #446.

--- a/packages/mcp/release-notes/mcp/0.8.113.md
+++ b/packages/mcp/release-notes/mcp/0.8.113.md
@@ -1,0 +1,17 @@
+---
+version: 0.8.113
+date: 2026-07-26
+summary: Document readOnly tools and the empty secret guard
+---
+
+## Documentation
+
+- `skill("llm")` documents `LlmTool.readOnly` and `Toolkit.filter()`.
+- `skill("fabric")` documents `readOnly` on services and tools.
+- `skill("secrets")` documents the guard that fails synth when a declared
+  secret source produces no secret string.
+- `skill("vocabulary")` lists `readOnly` as a service attribute.
+- `skill("llm")`, `skill("fabric")`, and `skill("tools")` replace the
+  nonexistent `fabricLlmTool(service)` with `fabricTool({ service })`.
+
+Addresses issues #446 and #447.

--- a/packages/mcp/skills/fabric.md
+++ b/packages/mcp/skills/fabric.md
@@ -71,10 +71,24 @@ const server = FabricMcpServer({
 ### LLM Tool
 
 ```typescript
-import { fabricLlmTool } from "@jaypie/fabric";
+import { fabricTool } from "@jaypie/fabric/llm";
 
-const tools = [fabricLlmTool(greetService)];
+const { tool } = fabricTool({ service: greetService });
+const tools = [tool];
 // Available to LLM as function call
+```
+
+Declare `readOnly: true` on a service (or on the `fabricTool` config) when it
+has no side effects. The annotation reaches `LlmTool.readOnly`, so
+`toolkit.filter({ readOnly: true })` derives a toolkit safe for verification
+passes. See `skill("llm")`.
+
+```typescript
+const searchService = fabricService({
+  alias: "search",
+  readOnly: true,
+  service: ({ query }) => findDocuments(query),
+});
 ```
 
 ### Express Middleware

--- a/packages/mcp/skills/llm.md
+++ b/packages/mcp/skills/llm.md
@@ -169,9 +169,9 @@ const toolkit = new JaypieToolkit();
 ### Fabric Services as Tools
 
 ```typescript
-import { fabricLlmTool } from "@jaypie/fabric";
+import { fabricTool } from "@jaypie/fabric/llm";
 
-const greetTool = fabricLlmTool(greetService);
+const { tool: greetTool } = fabricTool({ service: greetService });
 const toolkit = new Toolkit([greetTool]);
 ```
 
@@ -219,6 +219,27 @@ The resolved message surfaces in three places during `operate()`/`stream()`:
 - The `tool_call` progress event as `tool.message` (`operate()` only)
 
 Resolve one directly with `toolkit.resolveMessage({ name, arguments })` — returns the resolved string, or `undefined` when the tool is missing or defines no message; it never throws.
+
+### Read-Only Tools
+
+Tools may declare `readOnly: true` (mirroring MCP's `readOnlyHint`) to state they carry no side effects. `toolkit.filter()` derives a new Toolkit from the annotation, so a verification or critique pass can re-run `operate()` against facts without repeating side effects:
+
+```typescript
+const toolkit = new Toolkit([
+  { name: "search_docs", readOnly: true, /* ... */ },
+  { name: "post_message", /* ... */ },
+]);
+
+const verification = toolkit.filter({ readOnly: true }); // search_docs only
+const effectful = toolkit.filter({ readOnly: false });   // post_message only
+const custom = toolkit.filter((tool) => tool.name.startsWith("search_"));
+```
+
+- A tool is side-effecting unless annotated, so new tools stay excluded from the read-only set by default
+- The derived Toolkit shares the same tool implementations and inherits `explain`/`log`; extending either toolkit leaves the other unchanged
+- `readOnly` never reaches the provider payload
+- The built-in tools (`random`, `roll`, `time`, `weather`) are annotated read-only
+- `fabricService({ readOnly: true })` propagates through `fabricTool` to the tool; `fabricTool({ readOnly })` overrides the service
 
 ## Structured Output
 

--- a/packages/mcp/skills/secrets.md
+++ b/packages/mcp/skills/secrets.md
@@ -64,6 +64,18 @@ When the construct ID is a SCREAMING_SNAKE_CASE string (or matches an environmen
 
 If the shorthand env var is missing at deploy time and no `value` or `generateSecretString` is provided, construction throws `ConfigurationError`. Supply a `value` or `generateSecretString` when the env var may be absent.
 
+### Empty Secret Guard
+
+Synth fails fast whenever a declared secret source produces no secret string, so a blank credential never reaches runtime. A source is declared by `envKey` or by passing a `value` key, and an empty string counts as empty:
+
+```typescript
+new JaypieSecret(this, "ApiKey", { value: process.env.MISSING }); // throws ConfigurationError
+new JaypieSecret(this, "ApiKey", { envKey: "MISSING" });          // throws ConfigurationError
+new JaypieSecret(this, "Placeholder");                            // allowed: empty secret, no source declared
+```
+
+`JaypieEnvSecret` applies the same guard, except in consumer environments, where the secret is imported rather than created.
+
 ### CI/CD Setup
 
 Set secrets as environment variables in your deployment pipeline:

--- a/packages/mcp/skills/tools.md
+++ b/packages/mcp/skills/tools.md
@@ -37,7 +37,7 @@ Define once, use as LLM tool, MCP tool, Lambda handler, or CLI command:
 
 ```typescript
 import { fabricService } from "@jaypie/fabric";
-import { fabricLlmTool } from "@jaypie/fabric";
+import { fabricTool } from "@jaypie/fabric/llm";
 import { Toolkit } from "@jaypie/llm";
 
 const orderService = fabricService({
@@ -50,13 +50,14 @@ const orderService = fabricService({
       description: "Order ID to look up",
     },
   },
+  readOnly: true,
   service: async ({ orderId }) => {
     return getOrder(orderId);
   },
 });
 
 // As LLM tool
-const toolkit = new Toolkit([fabricLlmTool(orderService)]);
+const toolkit = new Toolkit([fabricTool({ service: orderService }).tool]);
 
 // As MCP tool
 fabricMcp({ service: orderService, server });
@@ -118,12 +119,12 @@ export const listOrdersService = fabricService({
 
 ```typescript
 import Llm, { Toolkit } from "@jaypie/llm";
-import { fabricLlmTool } from "@jaypie/fabric";
+import { fabricTool } from "@jaypie/fabric/llm";
 import { getOrderService, listOrdersService } from "./tools/order.js";
 
 const toolkit = new Toolkit([
-  fabricLlmTool(getOrderService),
-  fabricLlmTool(listOrdersService),
+  fabricTool({ service: getOrderService }).tool,
+  fabricTool({ service: listOrdersService }).tool,
 ]);
 
 const response = await Llm.operate("Find all pending orders", {

--- a/packages/mcp/skills/vocabulary.md
+++ b/packages/mcp/skills/vocabulary.md
@@ -123,6 +123,7 @@ Avoid words defined elsewhere (services, terminology)
 - message
 - mock
 - parameters
+- readOnly
 - serializer
 - service
 - setup

--- a/workspaces/documentation/src/content/docs/docs/experimental/fabric.md
+++ b/workspaces/documentation/src/content/docs/docs/experimental/fabric.md
@@ -349,6 +349,20 @@ const llm = new Llm({ toolkit });
 const response = await llm.ask("What's the weather in Tokyo?");
 ```
 
+### Read-Only Tools
+
+Declare `readOnly: true` on a service with no side effects. The annotation reaches `LlmTool.readOnly`, so `toolkit.filter({ readOnly: true })` derives a toolkit safe for verification passes. `fabricTool({ readOnly })` overrides the service.
+
+```typescript
+const searchHandler = fabricService({
+  alias: "search_docs",
+  description: "Search the documentation",
+  input: { query: { type: String } },
+  readOnly: true,
+  service: async ({ query }) => findDocuments(query),
+});
+```
+
 ### Type Mapping
 
 | Fabric Type | JSON Schema |

--- a/workspaces/documentation/src/content/docs/docs/packages/constructs.md
+++ b/workspaces/documentation/src/content/docs/docs/packages/constructs.md
@@ -267,17 +267,16 @@ export default config;
 
 Without this, the Lambda returns a JSON envelope instead of streamed HTML because Lambda's `RESPONSE_STREAM` invoke mode requires the OpenNext streaming wrapper.
 
-## JaypieEnvSecret
+## JaypieSecret
 
-Secret reference for Lambda injection. Supports `removalPolicy` as `boolean` (`true` = RETAIN, `false` = DESTROY) or CDK `RemovalPolicy`.
+Secret reference for Lambda injection. Reads `process.env[envKey]`, an explicit `value`, or `generateSecretString`. Supports `removalPolicy` as `boolean` (`true` = RETAIN, `false` = DESTROY) or CDK `RemovalPolicy`.
 
 ```typescript
-import { JaypieEnvSecret, JaypieLambda } from "@jaypie/constructs";
+import { JaypieSecret, JaypieLambda } from "@jaypie/constructs";
 import { isProductionEnv } from "@jaypie/kit";
 
-const mongoSecret = new JaypieEnvSecret(this, "MongoSecret", {
-  secretName: "prod/mongodb-uri",
-  envName: "MONGODB_URI",
+const mongoSecret = new JaypieSecret(this, "MongoSecret", {
+  envKey: "MONGODB_URI",
   removalPolicy: isProductionEnv(),
 });
 
@@ -285,6 +284,32 @@ new JaypieLambda(this, "Api", {
   secrets: [mongoSecret],
 });
 // Lambda has SECRET_MONGODB_URI env var
+```
+
+A SCREAMING_SNAKE_CASE construct id is shorthand for the `envKey`, so `new JaypieSecret(this, "MONGODB_URI")` is equivalent to the call above.
+
+### Empty Secret Guard
+
+Synth throws `ConfigurationError` whenever a declared secret source produces no secret string, so a blank credential never defers to runtime. A source is declared by `envKey` or by passing a `value` key, and an empty string counts as empty.
+
+```typescript
+new JaypieSecret(this, "ApiKey", { value: process.env.MISSING }); // throws
+new JaypieSecret(this, "ApiKey", { envKey: "MISSING" });          // throws
+new JaypieSecret(this, "Placeholder");                            // empty secret
+```
+
+## JaypieEnvSecret
+
+Extends `JaypieSecret` with an environment-driven provider/consumer pattern for sharing secrets across stacks. Accepted anywhere a `JaypieSecret` is. Deprecated; removed in 2.0. The empty secret guard applies, except in consumer environments, where the secret is imported rather than created.
+
+```typescript
+import { JaypieEnvSecret } from "@jaypie/constructs";
+
+// Sandbox stack provides the secret
+new JaypieEnvSecret(this, "MONGODB_URI", { provider: true });
+
+// Personal build consumes it
+new JaypieEnvSecret(this, "MONGODB_URI");
 ```
 
 ## Stack Classes

--- a/workspaces/documentation/src/content/docs/docs/packages/llm.md
+++ b/workspaces/documentation/src/content/docs/docs/packages/llm.md
@@ -179,6 +179,7 @@ const response = await Llm.operate("What's the weather in NYC?", {
 | `description` | `string` | What the tool does |
 | `parameters` | `JSONSchema \| ZodSchema` | Input schema |
 | `call` | `Function` | Implementation function |
+| `readOnly` | `boolean` | Declares the tool free of side effects |
 
 ### Zod Schema
 
@@ -199,6 +200,27 @@ const toolkit = new Toolkit([
   },
 ]);
 ```
+
+### Read-Only Tools
+
+Tools may declare `readOnly: true` (mirroring MCP's `readOnlyHint`) to state they carry no side effects. `filter` derives a new Toolkit from the annotation, so a verification or critique pass can check facts without repeating side effects.
+
+```typescript
+const toolkit = new Toolkit([
+  { name: "search_docs", readOnly: true, /* ... */ },
+  { name: "post_message", /* ... */ },
+]);
+
+const verification = toolkit.filter({ readOnly: true }); // search_docs only
+const effectful = toolkit.filter({ readOnly: false });   // post_message only
+const custom = toolkit.filter((tool) => tool.name.startsWith("search_"));
+```
+
+- Tools are side-effecting unless annotated, so new tools stay excluded from the read set by default
+- The derived Toolkit shares the same tool implementations and inherits `explain` and `log`; extending either toolkit leaves the other unchanged
+- `readOnly` never reaches the provider payload
+- The built-in tools (`random`, `roll`, `time`, `weather`) are annotated read-only
+- `fabricService({ readOnly: true })` propagates through `fabricTool` to the tool
 
 ### Explain Mode
 


### PR DESCRIPTION
Closes #446
Closes #447

## #447 — `@jaypie/constructs`

The fail-fast guard fired only for the `envKey` form, so `{ value: process.env.MISSING }` synthesized a blank Secrets Manager secret and deferred the failure to runtime as an empty credential.

`JaypieSecret.assertSecretValue` is now the single guard both classes call after resolving the secret string. It throws `ConfigurationError` when no secret string was produced, no `generateSecretString` was given, and a source was declared by `envKey` or by a `value` key on the props. An empty string counts as empty, matching `envKey` semantics.

- A construct with no declared source still creates an empty secret, preserving the placeholder pattern
- `JaypieEnvSecret` skips the guard in consumer environments, where the secret is imported
- Its duplicated inline guard is gone; `className` statics keep the message naming the construct the caller wrote

## #446 — `@jaypie/llm` + `@jaypie/fabric`

`LlmTool.readOnly` declares a tool free of side effects, mirroring MCP's `readOnlyHint`. `Toolkit.filter` derives a new Toolkit from the annotation, so a verification pass can check facts without repeating side effects.

```typescript
const verification = toolkit.filter({ readOnly: true }); // annotated only
const effectful = toolkit.filter({ readOnly: false });   // the complement
const custom = toolkit.filter((tool) => tool.name.startsWith("search_"));
```

- Tools are side-effecting unless annotated, so new tools stay excluded by default
- The derived Toolkit shares the same implementations and inherits `explain`/`log`; extending either leaves the other unchanged
- `readOnly` is stripped from `Toolkit.tools` and never reaches a provider payload
- Built-in tools (`random`, `roll`, `time`, `weather`) annotated read-only
- `fabricService({ readOnly: true })` survives the rebuild `resolveService` performs on override; `fabricTool({ readOnly })` overrides the service

## Adjacent defects fixed

- `packages/constructs/rollup.config.js` was missing `aws-cdk-lib/aws-ssm`, introduced with the `variables` feature; the build warned on every run
- Skills and site docs referenced `fabricLlmTool(service)`, which does not exist — corrected to `fabricTool({ service })`
- The site's constructs page documented `secretName`/`envName` props that do not exist; that section now documents `JaypieSecret` with real props

## Versions

`@jaypie/constructs` 1.2.73, `@jaypie/fabric` 0.3.7, `@jaypie/llm` 1.3.22, `@jaypie/mcp` 0.8.113, `jaypie` 1.2.72, with release notes and the umbrella peer range synced.

## Verification

21 tests added. typecheck, build, test, and format pass for every edited package (llm 1209, fabric 1016, constructs 642); testkit and jaypie suites also pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P1kZyShwWcQJZrN4a5erds