### PR TITLE
fix(llm): recurse into anyOf/oneOf/allOf in Gemini schema converter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15302,7 +15302,7 @@
       "license": "MIT"
     },
     "packages/jaypie": {
-      "version": "1.2.72",
+      "version": "1.2.73",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "^1.2.11",
@@ -15327,7 +15327,7 @@
         "typescript-eslint": "^8.46.1"
       },
       "peerDependencies": {
-        "@jaypie/llm": "^1.3.22"
+        "@jaypie/llm": "^1.3.23"
       },
       "peerDependenciesMeta": {
         "@jaypie/llm": {
@@ -15459,7 +15459,7 @@
     },
     "packages/llm": {
       "name": "@jaypie/llm",
-      "version": "1.3.22",
+      "version": "1.3.23",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "*",
@@ -15545,7 +15545,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.113",
+      "version": "0.8.114",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.3.3",

--- a/packages/jaypie/package.json
+++ b/packages/jaypie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jaypie",
-  "version": "1.2.72",
+  "version": "1.2.73",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"
@@ -59,7 +59,7 @@
     "typescript-eslint": "^8.46.1"
   },
   "peerDependencies": {
-    "@jaypie/llm": "^1.3.22"
+    "@jaypie/llm": "^1.3.23"
   },
   "peerDependenciesMeta": {
     "@jaypie/llm": {

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/llm",
-  "version": "1.3.22",
+  "version": "1.3.23",
   "description": "Large language model utilities",
   "repository": {
     "type": "git",

--- a/packages/llm/src/operate/adapters/__tests__/GoogleAdapter.spec.ts
+++ b/packages/llm/src/operate/adapters/__tests__/GoogleAdapter.spec.ts
@@ -283,6 +283,54 @@ describe("GoogleAdapter", () => {
         ).toBeUndefined();
       });
 
+      it("strips additionalProperties inside anyOf branches (issue #450)", () => {
+        const request: OperateRequest = {
+          model: PROVIDER.GOOGLE.MODEL.SMALL,
+          messages: [],
+          format: {
+            $schema: "https://json-schema.org/draft/2020-12/schema",
+            type: "object",
+            properties: {
+              totals: {
+                anyOf: [
+                  {
+                    type: "object",
+                    properties: { amount: { type: "number" } },
+                    required: ["amount"],
+                    additionalProperties: false,
+                  },
+                  { type: "null" },
+                ],
+              },
+            },
+            required: ["totals"],
+            additionalProperties: false,
+          },
+        };
+
+        const result = googleAdapter.buildRequest(request);
+
+        expect(result.config?.responseSchema).toEqual({
+          type: "object",
+          properties: {
+            totals: {
+              anyOf: [
+                {
+                  type: "object",
+                  properties: { amount: { type: "number" } },
+                  required: ["amount"],
+                },
+                { type: "null" },
+              ],
+            },
+          },
+          required: ["totals"],
+        });
+        expect(JSON.stringify(result.config?.responseSchema)).not.toContain(
+          "additionalProperties",
+        );
+      });
+
       describe("maxOutputTokens resolution (issue #402)", () => {
         it("defaults non-streaming requests to the non-streaming maximum", () => {
           const request: OperateRequest = {

--- a/packages/llm/src/util/__tests__/jsonSchemaToOpenApi3.spec.ts
+++ b/packages/llm/src/util/__tests__/jsonSchemaToOpenApi3.spec.ts
@@ -99,6 +99,105 @@ describe("jsonSchemaToOpenApi3", () => {
     expect(pages.items.required).toEqual(["pageNumber", "extractedText"]);
   });
 
+  it("recursively converts anyOf branches", () => {
+    const result = jsonSchemaToOpenApi3({
+      type: "object",
+      properties: {
+        totals: {
+          anyOf: [
+            {
+              type: "object",
+              properties: { amount: { type: "number" } },
+              required: ["amount"],
+              additionalProperties: false,
+            },
+            { type: "null" },
+          ],
+        },
+      },
+      required: ["totals"],
+      additionalProperties: false,
+    });
+
+    const totals = (result.properties as any).totals;
+    expect(totals.anyOf[0].additionalProperties).toBeUndefined();
+    expect(totals.anyOf[0].type).toBe("object");
+    expect(totals.anyOf[0].required).toEqual(["amount"]);
+    expect(totals.anyOf[1]).toEqual({ type: "null" });
+  });
+
+  it("recursively converts oneOf branches", () => {
+    const result = jsonSchemaToOpenApi3({
+      oneOf: [
+        {
+          type: "object",
+          properties: { kind: { type: "string" } },
+          additionalProperties: false,
+        },
+        { type: "null" },
+      ],
+    });
+
+    expect((result.oneOf as any)[0].additionalProperties).toBeUndefined();
+    expect((result.oneOf as any)[0].type).toBe("object");
+  });
+
+  it("recursively converts allOf branches", () => {
+    const result = jsonSchemaToOpenApi3({
+      allOf: [
+        {
+          type: "object",
+          properties: { kind: { type: "string" } },
+          additionalProperties: false,
+        },
+      ],
+    });
+
+    expect((result.allOf as any)[0].additionalProperties).toBeUndefined();
+    expect((result.allOf as any)[0].type).toBe("object");
+  });
+
+  it("recursively converts nested combinator branches", () => {
+    const result = jsonSchemaToOpenApi3({
+      type: "object",
+      properties: {
+        entries: {
+          anyOf: [
+            {
+              type: "array",
+              items: {
+                anyOf: [
+                  {
+                    type: "object",
+                    properties: { id: { type: "string" } },
+                    additionalProperties: false,
+                  },
+                  { type: "null" },
+                ],
+              },
+            },
+            { type: "null" },
+          ],
+        },
+      },
+      additionalProperties: false,
+    });
+
+    const entries = (result.properties as any).entries;
+    expect(
+      entries.anyOf[0].items.anyOf[0].additionalProperties,
+    ).toBeUndefined();
+    expect(entries.anyOf[0].items.anyOf[0].type).toBe("object");
+  });
+
+  it("leaves non-schema combinator entries as-is", () => {
+    const result = jsonSchemaToOpenApi3({
+      anyOf: ["not-a-schema", 42, null],
+    });
+
+    expect(result.anyOf).toEqual(["not-a-schema", 42, null]);
+  });
+
   it("preserves required, type, enum, description", () => {
     const result = jsonSchemaToOpenApi3({
       type: "object",

--- a/packages/llm/src/util/jsonSchemaToOpenApi3.ts
+++ b/packages/llm/src/util/jsonSchemaToOpenApi3.ts
@@ -7,6 +7,10 @@ import { JsonObject } from "@jaypie/types";
  *
  * Strips: $schema, additionalProperties, $defs, $ref (inlines where possible), const
  * Preserves: type, properties, required, items, enum, description, nullable
+ *
+ * Recurses through properties, items, and the anyOf/oneOf/allOf combinator
+ * branches Zod emits for `.nullable()` and unions, so stripped keywords do not
+ * leak inside a branch.
  */
 export function jsonSchemaToOpenApi3(schema: JsonObject): JsonObject {
   if (typeof schema !== "object" || schema === null || Array.isArray(schema)) {
@@ -42,6 +46,15 @@ export function jsonSchemaToOpenApi3(schema: JsonObject): JsonObject {
       result[key] = convertedProps;
     } else if (key === "items" && typeof value === "object" && value !== null) {
       result[key] = jsonSchemaToOpenApi3(value as JsonObject);
+    } else if (
+      (key === "anyOf" || key === "oneOf" || key === "allOf") &&
+      Array.isArray(value)
+    ) {
+      result[key] = value.map((entry) =>
+        typeof entry === "object" && entry !== null && !Array.isArray(entry)
+          ? jsonSchemaToOpenApi3(entry as JsonObject)
+          : entry,
+      );
     } else {
       result[key] = value;
     }

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.113",
+  "version": "0.8.114",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/jaypie/1.2.73.md
+++ b/packages/mcp/release-notes/jaypie/1.2.73.md
@@ -1,0 +1,12 @@
+---
+version: 1.2.73
+date: 2026-07-29
+summary: Picks up @jaypie/llm 1.3.23 Gemini anyOf schema fix
+---
+
+## Changes
+
+- Picks up `@jaypie/llm` 1.3.23, which strips `additionalProperties` inside
+  `anyOf` / `oneOf` / `allOf` branches of a Gemini `responseSchema`.
+
+Addresses issue #450.

--- a/packages/mcp/release-notes/llm/1.3.23.md
+++ b/packages/mcp/release-notes/llm/1.3.23.md
@@ -1,0 +1,26 @@
+---
+version: 1.3.23
+date: 2026-07-29
+summary: Gemini responseSchema converter recurses into anyOf/oneOf/allOf branches
+---
+
+## Fixes
+
+- `jsonSchemaToOpenApi3`, the Gemini `responseSchema` converter, recurses into
+  `anyOf` / `oneOf` / `allOf` branches instead of copying them verbatim.
+- Zod `.nullable()` object and array properties convert to
+  `anyOf: [<schema>, { type: "null" }]`, so the object branch previously reached
+  Gemini with `additionalProperties` intact and the API rejected the request:
+
+  ```
+  Invalid JSON payload received. Unknown name "additionalProperties" at
+  'generation_config.response_schema.properties[3].value.any_of[0]'
+  ```
+
+  The failure was non-retryable, so `operate()` calls with such a format failed
+  terminally on the Google provider.
+- Non-schema entries inside a combinator array pass through unchanged.
+- The same converter builds Google tool parameters, so nullable object
+  parameters are fixed as well.
+
+Addresses issue #450.

--- a/packages/mcp/release-notes/mcp/0.8.114.md
+++ b/packages/mcp/release-notes/mcp/0.8.114.md
@@ -1,0 +1,11 @@
+---
+version: 0.8.114
+date: 2026-07-29
+summary: Release notes for the Gemini anyOf schema fix
+---
+
+## Documentation
+
+- Adds release notes for `@jaypie/llm` 1.3.23 and `jaypie` 1.2.73.
+
+Addresses issue #450.


### PR DESCRIPTION
Closes #450

## Problem

`jsonSchemaToOpenApi3`, the Gemini `responseSchema` converter, recursed into `properties` and `items` only. Combinator arrays fell through to a verbatim copy, so `additionalProperties: false` survived inside a branch.

Zod `.nullable()` object and array properties convert to `anyOf: [<schema>, { type: "null" }]`, so the object branch reached Gemini intact:

```
Invalid JSON payload received. Unknown name "additionalProperties" at
'generation_config.response_schema.properties[3].value.any_of[0]': Cannot find field.
```

The failure is non-retryable, so `operate()` failed terminally on the Google provider. Nullable scalars were unaffected.

## Change

`packages/llm/src/util/jsonSchemaToOpenApi3.ts` maps `anyOf` / `oneOf` / `allOf` entries through the converter; non-schema entries pass through unchanged. This mirrors the sibling `sanitizeJsonSchemaForAnthropic`. The same converter builds Google tool parameters, so nullable object parameters are covered as well.

## Tests

Five cases in `jsonSchemaToOpenApi3.spec.ts` (anyOf, oneOf, allOf, a combinator nested inside `items` inside `anyOf`, non-schema entries) and one adapter-level case in `GoogleAdapter.spec.ts` asserting the built `responseSchema` for the reported shape carries no `additionalProperties`. Four of the five unit cases failed before the change.

`@jaypie/llm` 1215 passed, 80 skipped. Typecheck, build, lint clean across llm, mcp, jaypie.

## Versioning

`@jaypie/llm` 1.3.23, `@jaypie/mcp` 0.8.114, `jaypie` 1.2.73, with release notes and the umbrella peer range synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PbWKnf6e8fJnLfBy8gj98B