### PR TITLE
Multi-host JaypieDistribution and status-driven caught-error logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14935,7 +14935,7 @@
     },
     "packages/constructs": {
       "name": "@jaypie/constructs",
-      "version": "1.2.73",
+      "version": "1.2.74",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*",
@@ -15090,7 +15090,7 @@
     },
     "packages/errors": {
       "name": "@jaypie/errors",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "MIT",
       "devDependencies": {
         "@jaypie/types": "*",
@@ -15145,7 +15145,7 @@
     },
     "packages/express": {
       "name": "@jaypie/express",
-      "version": "1.2.29",
+      "version": "1.2.30",
       "license": "MIT",
       "dependencies": {
         "@jaypie/datadog": "*",
@@ -15302,15 +15302,15 @@
       "license": "MIT"
     },
     "packages/jaypie": {
-      "version": "1.2.73",
+      "version": "1.2.74",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "^1.2.11",
         "@jaypie/core": "^1.2.4",
         "@jaypie/datadog": "^1.2.6",
-        "@jaypie/errors": "^1.2.3",
-        "@jaypie/express": "^1.2.29",
-        "@jaypie/kit": "^1.2.12",
+        "@jaypie/errors": "^1.2.4",
+        "@jaypie/express": "^1.2.30",
+        "@jaypie/kit": "^1.2.14",
         "@jaypie/lambda": "^1.2.12",
         "@jaypie/logger": "^1.2.21"
       },
@@ -15354,7 +15354,7 @@
     },
     "packages/kit": {
       "name": "@jaypie/kit",
-      "version": "1.2.13",
+      "version": "1.2.14",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*",
@@ -15545,7 +15545,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.114",
+      "version": "0.8.115",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.3.3",

--- a/packages/constructs/CLAUDE.md
+++ b/packages/constructs/CLAUDE.md
@@ -171,6 +171,21 @@ new JaypieDistribution(this, "Distribution", {
 });
 ```
 
+#### Multiple Hosts
+
+`host` accepts a string, a `HostConfig`, or an array of either. The first entry is primary: it supplies `PROJECT_BASE_URL`, the certificate's `domainName`, and the un-suffixed DNS record construct IDs. Remaining entries become certificate subject alternative names. Every entry lands in `domainNames` and gets its own A and AAAA record. Duplicates collapse. `construct.hosts` exposes the resolved list; `construct.host` stays the primary.
+
+```typescript
+new JaypieDistribution(this, "Distribution", {
+  handler: api,
+  host: ["api0.example.com", "api.example.com"],
+  zone: "example.com",
+  deleteExistingRecord: ["api.example.com"], // reclaim only this name
+});
+```
+
+`deleteExistingRecord` accepts `true` (every host), a hostname, or an array of hostnames. With several hosts, name the hosts being reclaimed from another owner: `true` also force-deletes records this construct already owns, and CloudFormation does not recreate an otherwise-unchanged record, leaving that hostname dark until the next deploy that touches it.
+
 #### Service Attribution
 
 `serviceTag` (parallel to `roleTag`, matching `JaypieLambda`) attributes the distribution to a service. When set, the distribution is tagged with `CDK.TAG.SERVICE` (so metrics carry `service:<value>` instead of `service:N/A`) and the created access-log and WAF-log buckets are tagged with the same value, so the Datadog forwarder attributes their forwarded logs to the service instead of the generic `cloudfront`/source default. Omit to preserve current behavior; external/imported log buckets are not tagged.

--- a/packages/constructs/package.json
+++ b/packages/constructs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/constructs",
-  "version": "1.2.73",
+  "version": "1.2.74",
   "description": "CDK constructs for Jaypie applications",
   "repository": {
     "type": "git",

--- a/packages/constructs/src/JaypieDistribution.ts
+++ b/packages/constructs/src/JaypieDistribution.ts
@@ -33,6 +33,13 @@ const DEFAULT_MANAGED_RULES = [
 ];
 
 /**
+ * Reduces a hostname to characters legal in a CDK construct ID.
+ */
+function sanitizeHostForId(host: string): string {
+  return host.replace(/\./g, "-").replace(/[^a-zA-Z0-9-]/g, "");
+}
+
+/**
  * One entry in a `waf.allow` list. Names one or more URL paths and, for each
  * managed rule group key, the sub-rule names to flip from `block` to `count`
  * on that path set. See JaypieWafConfig.allow.
@@ -177,9 +184,23 @@ export interface JaypieDistributionProps extends Omit<
    * construct (e.g., JaypieApiGateway) that already owns the same hostname,
    * where the default CloudFormation create-before-delete ordering would
    * otherwise collide on the record name.
+   *
+   * - `true`: force-delete for every host
+   * - hostname or array of hostnames: force-delete only those hosts
+   *
+   * Naming hosts matters when serving several: pointing this at a host whose
+   * record this construct already owns deletes the live record without
+   * recreating it, because CloudFormation sees no change to the record itself.
+   * Name only the hosts being reclaimed from another owner.
+   *
    * @default false
+   *
+   * @example
+   * // Reclaim api. from an API Gateway custom domain while api0. keeps serving
+   * host: ["api0.example.com", "api.example.com"],
+   * deleteExistingRecord: ["api.example.com"],
    */
-  deleteExistingRecord?: boolean;
+  deleteExistingRecord?: boolean | string | string[];
   /**
    * Log destination configuration for CloudFront access logs
    * - LambdaDestination: Use a specific Lambda destination for S3 notifications
@@ -203,12 +224,16 @@ export interface JaypieDistributionProps extends Omit<
    */
   handler?: cloudfront.IOrigin | lambda.IFunctionUrl | lambda.IFunction;
   /**
-   * The domain name for the distribution.
+   * The domain name or names for the distribution.
    *
-   * Supports both string and config object:
+   * Supports string, config object, or an array of either:
    * - String: used directly as the domain name (e.g., "api.example.com")
    * - Object: passed to envHostname() to construct the domain name
    *   - { subdomain, domain, env, component }
+   * - Array: every entry is served by the distribution. The first entry is
+   *   primary: it supplies `PROJECT_BASE_URL` and the certificate's
+   *   `domainName`, with the rest becoming subject alternative names. Every
+   *   entry gets an A and AAAA record.
    *
    * @default mergeDomain(CDK_ENV_API_SUBDOMAIN, CDK_ENV_API_HOSTED_ZONE || CDK_ENV_HOSTED_ZONE)
    *
@@ -219,8 +244,12 @@ export interface JaypieDistributionProps extends Omit<
    * @example
    * // Config object - resolves using envHostname()
    * host: { subdomain: "api" }
+   *
+   * @example
+   * // Multiple hosts for a zero-downtime domain cutover
+   * host: ["api0.example.com", "api.example.com"]
    */
-  host?: string | HostConfig;
+  host?: string | HostConfig | Array<string | HostConfig>;
   /**
    * Enable response streaming for Lambda Function URLs.
    * Use with createLambdaStreamHandler for SSE/streaming responses.
@@ -291,7 +320,10 @@ export class JaypieDistribution
   public readonly distributionId: string;
   public readonly domainName: string;
   public readonly functionUrl?: lambda.FunctionUrl;
+  /** The primary host, equal to `hosts[0]` */
   public readonly host?: string;
+  /** Every host served by the distribution; empty when no host resolves */
+  public readonly hosts: string[];
   public readonly logBucket?: s3.IBucket;
   public readonly responseHeadersPolicy?: cloudfront.IResponseHeadersPolicy;
   public readonly wafLogBucket?: s3.IBucket;
@@ -341,39 +373,57 @@ export class JaypieDistribution
       throw new Error("CDK_ENV_HOSTED_ZONE is not a valid hostname");
     }
 
-    // Determine host from props or environment
-    let host: string | undefined;
-    if (typeof propsHost === "string") {
-      host = propsHost;
-    } else if (typeof propsHost === "object") {
-      // Resolve host from HostConfig using envHostname()
-      try {
-        host = envHostname(propsHost);
-      } catch {
-        host = undefined;
+    // Determine hosts from props or environment
+    // The first entry is primary: PROJECT_BASE_URL, certificate domainName,
+    // and the un-suffixed DNS record construct IDs all come from it
+    const hosts: string[] = [];
+    if (propsHost !== undefined) {
+      const hostEntries = Array.isArray(propsHost) ? propsHost : [propsHost];
+      for (const entry of hostEntries) {
+        let resolved: string | undefined;
+        if (typeof entry === "string") {
+          resolved = entry;
+        } else if (typeof entry === "object" && entry !== null) {
+          // Resolve host from HostConfig using envHostname()
+          try {
+            resolved = envHostname(entry);
+          } catch {
+            resolved = undefined;
+          }
+        }
+        if (resolved && !hosts.includes(resolved)) {
+          hosts.push(resolved);
+        }
       }
     } else {
       try {
         if (process.env.CDK_ENV_API_HOST_NAME) {
-          host = process.env.CDK_ENV_API_HOST_NAME;
+          hosts.push(process.env.CDK_ENV_API_HOST_NAME);
         } else if (process.env.CDK_ENV_API_SUBDOMAIN) {
-          host = mergeDomain(
-            process.env.CDK_ENV_API_SUBDOMAIN,
-            process.env.CDK_ENV_API_HOSTED_ZONE ||
-              process.env.CDK_ENV_HOSTED_ZONE ||
-              "",
+          hosts.push(
+            mergeDomain(
+              process.env.CDK_ENV_API_SUBDOMAIN,
+              process.env.CDK_ENV_API_HOSTED_ZONE ||
+                process.env.CDK_ENV_HOSTED_ZONE ||
+                "",
+            ),
           );
         }
       } catch {
-        host = undefined;
+        // No host from environment
       }
     }
 
-    if (host && !isValidHostname(host)) {
-      throw new Error("Host is not a valid hostname");
+    for (const candidate of hosts) {
+      if (!isValidHostname(candidate)) {
+        throw new Error("Host is not a valid hostname");
+      }
     }
 
+    const host = hosts[0];
+
     this.host = host;
+    this.hosts = hosts;
 
     // Determine zone from props or environment
     const zone = propsZone || process.env.CDK_ENV_HOSTED_ZONE;
@@ -528,6 +578,7 @@ export class JaypieDistribution
         certificate: certificateProp,
         domainName: host,
         roleTag,
+        subjectAlternativeNames: hosts.slice(1),
         zone: hostedZone,
       });
 
@@ -591,7 +642,7 @@ export class JaypieDistribution
         ...(host && certificateToUse
           ? {
               certificate: certificateToUse,
-              domainNames: [host],
+              domainNames: hosts,
             }
           : {}),
         ...(logBucket
@@ -877,27 +928,47 @@ export class JaypieDistribution
       }
     }
 
-    // Create DNS records if we have host and zone
-    if (host && hostedZone) {
-      const aRecord = new route53.ARecord(this, "AliasRecord", {
-        deleteExisting: deleteExistingRecord,
-        recordName: host,
-        target: route53.RecordTarget.fromAlias(
-          new route53Targets.CloudFrontTarget(this.distribution),
-        ),
-        zone: hostedZone,
-      });
-      Tags.of(aRecord).add(CDK.TAG.ROLE, CDK.ROLE.NETWORKING);
+    // Create DNS records if we have hosts and zone
+    // The primary host keeps the un-suffixed construct IDs so adding a second
+    // host does not replace records an existing deployment already owns
+    if (hostedZone) {
+      const deleteExistingHosts =
+        typeof deleteExistingRecord === "string"
+          ? [deleteExistingRecord]
+          : Array.isArray(deleteExistingRecord)
+            ? deleteExistingRecord
+            : undefined;
 
-      const aaaaRecord = new route53.AaaaRecord(this, "AaaaAliasRecord", {
-        deleteExisting: deleteExistingRecord,
-        recordName: host,
-        target: route53.RecordTarget.fromAlias(
-          new route53Targets.CloudFrontTarget(this.distribution),
-        ),
-        zone: hostedZone,
+      hosts.forEach((recordHost, index) => {
+        const suffix = index === 0 ? "" : `-${sanitizeHostForId(recordHost)}`;
+        const deleteExisting = deleteExistingHosts
+          ? deleteExistingHosts.includes(recordHost)
+          : deleteExistingRecord === true;
+
+        const aRecord = new route53.ARecord(this, `AliasRecord${suffix}`, {
+          deleteExisting,
+          recordName: recordHost,
+          target: route53.RecordTarget.fromAlias(
+            new route53Targets.CloudFrontTarget(this.distribution),
+          ),
+          zone: hostedZone,
+        });
+        Tags.of(aRecord).add(CDK.TAG.ROLE, CDK.ROLE.NETWORKING);
+
+        const aaaaRecord = new route53.AaaaRecord(
+          this,
+          `AaaaAliasRecord${suffix}`,
+          {
+            deleteExisting,
+            recordName: recordHost,
+            target: route53.RecordTarget.fromAlias(
+              new route53Targets.CloudFrontTarget(this.distribution),
+            ),
+            zone: hostedZone,
+          },
+        );
+        Tags.of(aaaaRecord).add(CDK.TAG.ROLE, CDK.ROLE.NETWORKING);
       });
-      Tags.of(aaaaRecord).add(CDK.TAG.ROLE, CDK.ROLE.NETWORKING);
     }
   }
 

--- a/packages/constructs/src/__tests__/JaypieDistribution.spec.ts
+++ b/packages/constructs/src/__tests__/JaypieDistribution.spec.ts
@@ -2410,4 +2410,283 @@ describe("JaypieDistribution", () => {
       });
     });
   });
+
+  describe("Multiple Hosts", () => {
+    function stackWithZone() {
+      const stack = new Stack(undefined, "TestStack", {
+        env: { account: "123456789012", region: "us-east-1" },
+      });
+      const zone = route53.HostedZone.fromHostedZoneAttributes(stack, "Zone", {
+        hostedZoneId: "Z123456789",
+        zoneName: "example.com",
+      });
+      const bucket = new s3.Bucket(stack, "TestBucket");
+      const origin = origins.S3BucketOrigin.withOriginAccessControl(bucket);
+      return { origin, stack, zone };
+    }
+
+    it("exposes the first host as primary and all hosts on hosts", () => {
+      const { origin, stack, zone } = stackWithZone();
+
+      const construct = new JaypieDistribution(stack, "TestDistribution", {
+        handler: origin,
+        host: ["api0.example.com", "api.example.com"],
+        zone,
+      });
+
+      expect(construct.host).toBe("api0.example.com");
+      expect(construct.hosts).toEqual(["api0.example.com", "api.example.com"]);
+    });
+
+    it("lists every host in the distribution aliases", () => {
+      const { origin, stack, zone } = stackWithZone();
+
+      new JaypieDistribution(stack, "TestDistribution", {
+        handler: origin,
+        host: ["api0.example.com", "api.example.com"],
+        zone,
+      });
+      const template = Template.fromStack(stack);
+
+      const distribution = findDistribution(template);
+      expect(distribution.Properties.DistributionConfig.Aliases).toEqual([
+        "api0.example.com",
+        "api.example.com",
+      ]);
+    });
+
+    it("covers secondary hosts with certificate subject alternative names", () => {
+      const { origin, stack, zone } = stackWithZone();
+
+      new JaypieDistribution(stack, "TestDistribution", {
+        handler: origin,
+        host: ["api0.example.com", "api.example.com"],
+        zone,
+      });
+      const template = Template.fromStack(stack);
+
+      template.hasResourceProperties("AWS::CertificateManager::Certificate", {
+        DomainName: "api0.example.com",
+        SubjectAlternativeNames: ["api.example.com"],
+      });
+    });
+
+    it("creates an A and AAAA record for every host", () => {
+      const { origin, stack, zone } = stackWithZone();
+
+      new JaypieDistribution(stack, "TestDistribution", {
+        handler: origin,
+        host: ["api0.example.com", "api.example.com"],
+        zone,
+      });
+      const template = Template.fromStack(stack);
+
+      template.resourceCountIs("AWS::Route53::RecordSet", 4);
+      template.hasResourceProperties("AWS::Route53::RecordSet", {
+        Name: "api0.example.com.",
+        Type: "A",
+      });
+      template.hasResourceProperties("AWS::Route53::RecordSet", {
+        Name: "api.example.com.",
+        Type: "A",
+      });
+      template.hasResourceProperties("AWS::Route53::RecordSet", {
+        Name: "api0.example.com.",
+        Type: "AAAA",
+      });
+      template.hasResourceProperties("AWS::Route53::RecordSet", {
+        Name: "api.example.com.",
+        Type: "AAAA",
+      });
+    });
+
+    it("keeps the primary host record logical ids stable across the array form", () => {
+      const single = new Stack(undefined, "TestStack", {
+        env: { account: "123456789012", region: "us-east-1" },
+      });
+      const singleZone = route53.HostedZone.fromHostedZoneAttributes(
+        single,
+        "Zone",
+        { hostedZoneId: "Z123456789", zoneName: "example.com" },
+      );
+      const singleBucket = new s3.Bucket(single, "TestBucket");
+      new JaypieDistribution(single, "TestDistribution", {
+        handler: origins.S3BucketOrigin.withOriginAccessControl(singleBucket),
+        host: "api0.example.com",
+        zone: singleZone,
+      });
+      const singleIds = Object.keys(
+        Template.fromStack(single).findResources("AWS::Route53::RecordSet"),
+      );
+
+      const { origin, stack, zone } = stackWithZone();
+      new JaypieDistribution(stack, "TestDistribution", {
+        handler: origin,
+        host: ["api0.example.com", "api.example.com"],
+        zone,
+      });
+      const multipleIds = Object.keys(
+        Template.fromStack(stack).findResources("AWS::Route53::RecordSet"),
+      );
+
+      for (const id of singleIds) {
+        expect(multipleIds).toContain(id);
+      }
+    });
+
+    it("sets PROJECT_BASE_URL from the primary host", () => {
+      const stack = new Stack();
+      const fn = new lambda.Function(stack, "TestFunction", {
+        code: lambda.Code.fromInline("exports.handler = () => {}"),
+        handler: "index.handler",
+        runtime: lambda.Runtime.NODEJS_20_X,
+      });
+
+      new JaypieDistribution(stack, "TestDistribution", {
+        handler: fn,
+        host: ["api0.example.com", "api.example.com"],
+      });
+      const template = Template.fromStack(stack);
+
+      template.hasResourceProperties("AWS::Lambda::Function", {
+        Environment: {
+          Variables: {
+            PROJECT_BASE_URL: "https://api0.example.com",
+          },
+        },
+      });
+    });
+
+    it("resolves HostConfig entries in the array", () => {
+      delete process.env.CDK_ENV_PERSONAL;
+      delete process.env.CDK_ENV_SUBDOMAIN;
+      process.env.PROJECT_ENV = "sandbox";
+
+      const { origin, stack, zone } = stackWithZone();
+
+      const construct = new JaypieDistribution(stack, "TestDistribution", {
+        handler: origin,
+        host: ["api0.example.com", { domain: "example.com", subdomain: "api" }],
+        zone,
+      });
+
+      expect(construct.hosts).toEqual([
+        "api0.example.com",
+        "api.sandbox.example.com",
+      ]);
+    });
+
+    it("throws when a host in the array is not a valid hostname", () => {
+      const { origin, stack, zone } = stackWithZone();
+
+      expect(() => {
+        new JaypieDistribution(stack, "TestDistribution", {
+          handler: origin,
+          host: ["api0.example.com", "invalid hostname with spaces"],
+          zone,
+        });
+      }).toThrow("Host is not a valid hostname");
+    });
+
+    it("deduplicates repeated hosts", () => {
+      const { origin, stack, zone } = stackWithZone();
+
+      const construct = new JaypieDistribution(stack, "TestDistribution", {
+        handler: origin,
+        host: ["api0.example.com", "api0.example.com"],
+        zone,
+      });
+      const template = Template.fromStack(stack);
+
+      expect(construct.hosts).toEqual(["api0.example.com"]);
+      template.resourceCountIs("AWS::Route53::RecordSet", 2);
+    });
+
+    it("force-deletes existing records for every host when deleteExistingRecord is true", () => {
+      const { origin, stack, zone } = stackWithZone();
+
+      new JaypieDistribution(stack, "TestDistribution", {
+        deleteExistingRecord: true,
+        handler: origin,
+        host: ["api0.example.com", "api.example.com"],
+        zone,
+      });
+      const template = Template.fromStack(stack);
+
+      template.resourceCountIs("Custom::DeleteExistingRecordSet", 4);
+    });
+
+    it("force-deletes existing records for only the named host", () => {
+      const { origin, stack, zone } = stackWithZone();
+
+      new JaypieDistribution(stack, "TestDistribution", {
+        deleteExistingRecord: ["api.example.com"],
+        handler: origin,
+        host: ["api0.example.com", "api.example.com"],
+        zone,
+      });
+      const template = Template.fromStack(stack);
+
+      template.resourceCountIs("AWS::Route53::RecordSet", 4);
+      template.resourceCountIs("Custom::DeleteExistingRecordSet", 2);
+      const deletions = Object.values(
+        template.findResources("Custom::DeleteExistingRecordSet"),
+      );
+      for (const deletion of deletions) {
+        expect(deletion.Properties.RecordName).toBe("api.example.com.");
+      }
+    });
+
+    it("accepts a single hostname string for deleteExistingRecord", () => {
+      const { origin, stack, zone } = stackWithZone();
+
+      new JaypieDistribution(stack, "TestDistribution", {
+        deleteExistingRecord: "api.example.com",
+        handler: origin,
+        host: ["api0.example.com", "api.example.com"],
+        zone,
+      });
+      const template = Template.fromStack(stack);
+
+      template.resourceCountIs("Custom::DeleteExistingRecordSet", 2);
+    });
+
+    it("force-deletes nothing when deleteExistingRecord names no served host", () => {
+      const { origin, stack, zone } = stackWithZone();
+
+      new JaypieDistribution(stack, "TestDistribution", {
+        deleteExistingRecord: ["other.example.com"],
+        handler: origin,
+        host: ["api0.example.com", "api.example.com"],
+        zone,
+      });
+      const template = Template.fromStack(stack);
+
+      template.resourceCountIs("Custom::DeleteExistingRecordSet", 0);
+    });
+
+    it("exposes hosts as a single-entry array for a scalar host", () => {
+      const { origin, stack, zone } = stackWithZone();
+
+      const construct = new JaypieDistribution(stack, "TestDistribution", {
+        handler: origin,
+        host: "api.example.com",
+        zone,
+      });
+
+      expect(construct.hosts).toEqual(["api.example.com"]);
+    });
+
+    it("exposes hosts as an empty array when no host resolves", () => {
+      const stack = new Stack();
+      const bucket = new s3.Bucket(stack, "TestBucket");
+      const origin = origins.S3BucketOrigin.withOriginAccessControl(bucket);
+
+      const construct = new JaypieDistribution(stack, "TestDistribution", {
+        handler: origin,
+      });
+
+      expect(construct.hosts).toEqual([]);
+    });
+  });
 });

--- a/packages/constructs/src/helpers/resolveCertificate.ts
+++ b/packages/constructs/src/helpers/resolveCertificate.ts
@@ -18,6 +18,11 @@ export interface ResolveCertificateOptions {
   name?: string;
   /** Role tag for tagging (defaults to CDK.ROLE.API) */
   roleTag?: string;
+  /**
+   * Additional domain names the certificate must cover. Only used when
+   * certificate is true. Entries equal to `domainName` are ignored.
+   */
+  subjectAlternativeNames?: string[];
   /** Hosted zone for DNS validation (required if certificate is true) */
   zone: route53.IHostedZone;
 }
@@ -67,6 +72,7 @@ export function resolveCertificate(
     domainName,
     name = "Certificate",
     roleTag = CDK.ROLE.API,
+    subjectAlternativeNames = [],
     zone,
   } = options;
 
@@ -101,8 +107,22 @@ export function resolveCertificate(
     certificateCache.set(stack, stackCache);
   }
 
-  // Return cached certificate if one exists for this domain
-  const cached = stackCache.get(domainName);
+  // Alternative names beyond the primary domain, deduplicated and stable-ordered
+  const alternativeNames = subjectAlternativeNames.filter(
+    (alternativeName, index) =>
+      alternativeName !== domainName &&
+      subjectAlternativeNames.indexOf(alternativeName) === index,
+  );
+
+  // Cache key covers the full name set: two callers wanting the same primary
+  // domain with different alternative names need different certificates. The
+  // construct ID stays keyed on the primary domain only, so a caller adding
+  // alternative names updates the existing certificate resource rather than
+  // orphaning it — and two conflicting name sets collide loudly at synth.
+  const cacheKey = [domainName, ...alternativeNames].join(",");
+
+  // Return cached certificate if one exists for this name set
+  const cached = stackCache.get(cacheKey);
   if (cached) {
     return cached;
   }
@@ -113,12 +133,15 @@ export function resolveCertificate(
   const sanitizedDomain = sanitizeDomainForId(domainName);
   const cert = new acm.Certificate(stack, `${name}-${sanitizedDomain}`, {
     domainName,
+    ...(alternativeNames.length > 0
+      ? { subjectAlternativeNames: alternativeNames }
+      : {}),
     validation: acm.CertificateValidation.fromDns(zone),
   });
   Tags.of(cert).add(CDK.TAG.ROLE, roleTag);
 
   // Cache for future requests
-  stackCache.set(domainName, cert);
+  stackCache.set(cacheKey, cert);
 
   return cert;
 }

--- a/packages/errors/CLAUDE.md
+++ b/packages/errors/CLAUDE.md
@@ -80,7 +80,21 @@ if (isJaypieError(error)) {
 
 // Create error from HTTP status code
 const error = jaypieErrorFromStatus(404, "User not found");
+
+// Omit the message for the generic strings of that status
+jaypieErrorFromStatus(500).detail;
+// "An unexpected error occurred and the request was unable to complete"
 ```
+
+`jaypieErrorFromStatus` covers every status carried by an error class in this
+package (400, 401, 403, 404, 405, 409, 410, 418, 429, 500, 502, 503, 504). An
+unmapped 4xx falls to `BadRequestError`; anything else falls to `InternalError`.
+
+`@jaypie/kit`'s handler uses the no-message form to scrub a caught error's
+`detail` and `title`, and only substitutes within the same status class, so an
+unmapped 4xx keeps its own status while carrying the bad request strings. Add a
+case when adding an error class with a new status, or that status answers with
+`BadRequestError`'s wording.
 
 ## Use in Other Packages
 
@@ -101,3 +115,6 @@ This package is foundational and used throughout the monorepo:
 - Use `isJaypieError()` to check before accessing Jaypie-specific properties
 - Prefer specific error types over generic `InternalError`
 - Custom messages are optional; defaults are user-friendly
+- A custom message is for the logs, not the caller. Handlers scrub `detail` and
+  `title` to the generic strings for the status before the error reaches a
+  response body

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/errors",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Error utilities for Jaypie applications",
   "repository": {
     "type": "git",

--- a/packages/errors/src/__tests__/errorFromStatusCode.spec.ts
+++ b/packages/errors/src/__tests__/errorFromStatusCode.spec.ts
@@ -38,11 +38,38 @@ describe("errorFromStatusCode", () => {
       expect(jaypieErrorFromStatus(401).title).toBe("Service Unauthorized");
       expect(jaypieErrorFromStatus(403).title).toBe("Forbidden");
       expect(jaypieErrorFromStatus(404).title).toBe("Not Found");
+      expect(jaypieErrorFromStatus(405).title).toBe("Method Not Allowed");
       expect(jaypieErrorFromStatus(409).title).toBe("Conflict");
+      expect(jaypieErrorFromStatus(429).title).toBe("Too Many Requests");
       expect(jaypieErrorFromStatus(500).title).toBe(
         "Internal Application Error",
       );
       expect(jaypieErrorFromStatus(503).title).toBe("Service Unavailable");
+    });
+
+    it("preserves the status of every error class it maps", () => {
+      for (const status of [
+        400, 401, 403, 404, 405, 409, 410, 418, 429, 500, 502, 503, 504,
+      ]) {
+        expect(jaypieErrorFromStatus(status).status).toBe(status);
+      }
+    });
+
+    it("falls to BadRequestError for an unmapped 4xx", () => {
+      // An unmapped 4xx described as an InternalError would blame the
+      // application for a caller error
+      for (const status of [402, 406, 412, 415, 422, 451, 499]) {
+        const error = jaypieErrorFromStatus(status);
+        expect(error.status).toBe(400);
+        expect(error.title).toBe("Bad Request");
+        expect(error.detail).toBe("The request was not properly formatted");
+      }
+    });
+
+    it("falls to InternalError outside 4xx", () => {
+      for (const status of [200, 302, 501, 505, 999]) {
+        expect(jaypieErrorFromStatus(status).status).toBe(500);
+      }
     });
   });
 });

--- a/packages/errors/src/jaypieErrorFromStatus.ts
+++ b/packages/errors/src/jaypieErrorFromStatus.ts
@@ -7,11 +7,16 @@ import {
   GatewayTimeoutError,
   GoneError,
   InternalError,
+  MethodNotAllowedError,
   NotFoundError,
   TeapotError,
+  TooManyRequestsError,
   UnauthorizedError,
   UnavailableError,
 } from "./errors";
+
+// One past the last client-error status
+const CLIENT_MAX = 500;
 
 export function jaypieErrorFromStatus(
   statusCode: number,
@@ -26,12 +31,16 @@ export function jaypieErrorFromStatus(
       return new ForbiddenError(message);
     case HTTP.CODE.NOT_FOUND:
       return new NotFoundError(message);
+    case HTTP.CODE.METHOD_NOT_ALLOWED:
+      return new MethodNotAllowedError(message);
     case HTTP.CODE.CONFLICT:
       return new ConflictError(message);
     case HTTP.CODE.GONE:
       return new GoneError(message);
     case HTTP.CODE.TEAPOT:
       return new TeapotError(message);
+    case HTTP.CODE.TOO_MANY_REQUESTS:
+      return new TooManyRequestsError(message);
     case HTTP.CODE.BAD_GATEWAY:
       return new BadGatewayError(message);
     case HTTP.CODE.UNAVAILABLE:
@@ -39,7 +48,13 @@ export function jaypieErrorFromStatus(
     case HTTP.CODE.GATEWAY_TIMEOUT:
       return new GatewayTimeoutError(message);
     case HTTP.CODE.INTERNAL_ERROR:
+      return new InternalError(message);
     default:
+      // An unmapped 4xx is still a caller error: falling to InternalError would
+      // describe it as an application fault
+      if (statusCode >= HTTP.CODE.BAD_REQUEST && statusCode < CLIENT_MAX) {
+        return new BadRequestError(message);
+      }
       return new InternalError(message);
   }
 }

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/express",
-  "version": "1.2.29",
+  "version": "1.2.30",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"

--- a/packages/express/src/__tests__/issue-452-error-log-level.spec.ts
+++ b/packages/express/src/__tests__/issue-452-error-log-level.spec.ts
@@ -1,0 +1,60 @@
+import { ConfigurationError, NotFoundError } from "@jaypie/errors";
+import { log } from "@jaypie/logger";
+import { restoreLog, spyLog } from "@jaypie/testkit";
+import express from "express";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Subject
+import expressHandler from "../expressHandler.js";
+
+//
+//
+// Mock modules
+//
+
+vi.mock("../getCurrentInvokeUuid.adapter.js");
+
+beforeEach(() => {
+  spyLog(log);
+});
+
+afterEach(() => {
+  restoreLog(log);
+  vi.clearAllMocks();
+});
+
+//
+//
+// Run tests
+//
+
+describe("Issue 452: expressHandler error log level", () => {
+  it("Logs error when the handler throws a 500-class Jaypie error", async () => {
+    const app = express();
+    app.use(
+      expressHandler(() => {
+        throw new ConfigurationError("Model not registered");
+      }),
+    );
+
+    const res = await request(app).get("/");
+
+    expect(res.status).toBe(500);
+    expect(log.error).toHaveBeenCalled();
+  });
+
+  it("Does not log error when the handler throws a 4xx Jaypie error", async () => {
+    const app = express();
+    app.use(
+      expressHandler(() => {
+        throw new NotFoundError();
+      }),
+    );
+
+    const res = await request(app).get("/");
+
+    expect(res.status).toBe(404);
+    expect(log.error).not.toHaveBeenCalled();
+  });
+});

--- a/packages/jaypie/package.json
+++ b/packages/jaypie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jaypie",
-  "version": "1.2.73",
+  "version": "1.2.74",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"
@@ -40,9 +40,9 @@
     "@jaypie/aws": "^1.2.11",
     "@jaypie/core": "^1.2.4",
     "@jaypie/datadog": "^1.2.6",
-    "@jaypie/errors": "^1.2.3",
-    "@jaypie/express": "^1.2.29",
-    "@jaypie/kit": "^1.2.12",
+    "@jaypie/errors": "^1.2.4",
+    "@jaypie/express": "^1.2.30",
+    "@jaypie/kit": "^1.2.14",
     "@jaypie/lambda": "^1.2.12",
     "@jaypie/logger": "^1.2.21"
   },

--- a/packages/kit/CLAUDE.md
+++ b/packages/kit/CLAUDE.md
@@ -66,6 +66,14 @@ src/
   - `teardown[]` - Post-handler cleanup (always runs)
   - `chaos` - Chaos engineering mode (from `PROJECT_CHAOS` env)
 
+  Caught Jaypie errors log by status: 4xx at warn, 500 and above at error, both
+  with `log.var({ jaypieError: { detail, status, title } })`. The error's
+  `detail` and `title` are then replaced with the generic strings for its status
+  so a constructor message never reaches a response body; `status`, `message`,
+  and `stack` are untouched. An unmapped 4xx status takes the bad request
+  strings and keeps its own status; a status outside 4xx and 5xx is not scrubbed.
+  Non-Jaypie errors log at fatal and become `UnhandledError`.
+
 ### Type Coercion
 
 - `force(value, type, options)` - Coerce values to specified types

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/kit",
-  "version": "1.2.13",
+  "version": "1.2.14",
   "description": "Utility functions for Jaypie applications",
   "repository": {
     "type": "git",

--- a/packages/kit/src/__tests__/jaypieHandler.module.spec.ts
+++ b/packages/kit/src/__tests__/jaypieHandler.module.spec.ts
@@ -2,7 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { spyLog, restoreLog } from "@jaypie/testkit";
 
 import { log } from "../core.js";
-import { InternalError } from "@jaypie/errors";
+import {
+  BadRequestError,
+  ConfigurationError,
+  InternalError,
+  JaypieError,
+  NotFoundError,
+} from "@jaypie/errors";
 import HTTP from "../lib/http.lib.js";
 
 // Subject
@@ -89,7 +95,39 @@ describe("Jaypie Handler Module", () => {
       expect(log.error).not.toHaveBeenCalled();
       expect(log.fatal).not.toHaveBeenCalled();
     });
-    it("Logs debug if a Jaypie error is caught", async () => {
+    it("Logs warn if a 4xx Jaypie error is caught", async () => {
+      // Arrange
+      const handler = jaypieHandler(() => {
+        throw new BadRequestError("Sorpresa!");
+      });
+      // Act
+      try {
+        await handler();
+      } catch {
+        // Assert
+        expect(log.warn).toHaveBeenCalledTimes(1);
+        expect(log.debug).not.toHaveBeenCalled();
+        expect(log.error).not.toHaveBeenCalled();
+      }
+      expect.assertions(3);
+    });
+    it("Logs error if a 500-class Jaypie error is caught", async () => {
+      // Arrange
+      const handler = jaypieHandler(() => {
+        throw new ConfigurationError("Sorpresa!");
+      });
+      // Act
+      try {
+        await handler();
+      } catch {
+        // Assert
+        expect(log.error).toHaveBeenCalledTimes(1);
+        expect(log.debug).not.toHaveBeenCalled();
+        expect(log.warn).not.toHaveBeenCalled();
+      }
+      expect.assertions(3);
+    });
+    it("Logs the error detail, status, and title of a 500-class Jaypie error", async () => {
       // Arrange
       const handler = jaypieHandler(() => {
         throw new InternalError("Sorpresa!");
@@ -99,7 +137,204 @@ describe("Jaypie Handler Module", () => {
         await handler();
       } catch {
         // Assert
-        expect(log.debug).toHaveBeenCalledTimes(1);
+        expect(log.var).toHaveBeenCalledWith({
+          jaypieError: {
+            detail: "Sorpresa!",
+            status: HTTP.CODE.INTERNAL_ERROR,
+            title: expect.any(String),
+          },
+        });
+      }
+      expect.assertions(1);
+    });
+    it("Logs the error detail, status, and title of a 4xx Jaypie error", async () => {
+      // Arrange
+      const handler = jaypieHandler(() => {
+        throw new NotFoundError("User 12345 not found");
+      });
+      // Act
+      try {
+        await handler();
+      } catch {
+        // Assert
+        expect(log.var).toHaveBeenCalledWith({
+          jaypieError: {
+            detail: "User 12345 not found",
+            status: HTTP.CODE.NOT_FOUND,
+            title: "Not Found",
+          },
+        });
+      }
+      expect.assertions(1);
+    });
+    it("Logs error if a 500-class Jaypie error is caught during validate", async () => {
+      // Arrange
+      const handler = jaypieHandler(() => {}, {
+        validate: [
+          () => {
+            throw new ConfigurationError("Sorpresa!");
+          },
+        ],
+      });
+      // Act
+      try {
+        await handler();
+      } catch {
+        // Assert
+        expect(log.error).toHaveBeenCalledTimes(1);
+        expect(log.debug).not.toHaveBeenCalled();
+      }
+      expect.assertions(2);
+    });
+    it("Logs error if a 500-class Jaypie error is caught during teardown", async () => {
+      // Arrange
+      const handler = jaypieHandler(() => {}, {
+        teardown: [
+          () => {
+            throw new ConfigurationError("Sorpresa!");
+          },
+        ],
+      });
+      // Act
+      await handler();
+      // Assert
+      expect(log.error).toHaveBeenCalledTimes(1);
+      expect(log.debug).not.toHaveBeenCalled();
+    });
+    it("Replaces the detail and title of a caught Jaypie error with the generic strings for its status", async () => {
+      // Arrange
+      const handler = jaypieHandler(() => {
+        throw new ConfigurationError("Fabric model chat is not registered");
+      });
+      // Act
+      try {
+        await handler();
+      } catch (error) {
+        // Assert
+        const jaypieError = error as InstanceType<typeof ConfigurationError>;
+        expect(jaypieError.detail).toBe(
+          "An unexpected error occurred and the request was unable to complete",
+        );
+        expect(jaypieError.title).toBe("Internal Application Error");
+        expect(jaypieError.body()).toEqual({
+          errors: [
+            {
+              detail:
+                "An unexpected error occurred and the request was unable to complete",
+              status: HTTP.CODE.INTERNAL_ERROR,
+              title: "Internal Application Error",
+            },
+          ],
+        });
+      }
+      expect.assertions(3);
+    });
+    it("Replaces the detail and title of a caught 4xx Jaypie error", async () => {
+      // Arrange
+      const handler = jaypieHandler(() => {
+        throw new NotFoundError("User 12345 not found");
+      });
+      // Act
+      try {
+        await handler();
+      } catch (error) {
+        // Assert
+        const jaypieError = error as InstanceType<typeof NotFoundError>;
+        expect(jaypieError.detail).toBe("The requested resource was not found");
+        expect(jaypieError.title).toBe("Not Found");
+      }
+      expect.assertions(2);
+    });
+    it("Scrubs an unmapped 4xx to the bad request strings, keeping its status", async () => {
+      // Arrange
+      const handler = jaypieHandler(() => {
+        throw new JaypieError("Field ssn failed validation", {
+          status: 422,
+          title: "Unprocessable Entity",
+        });
+      });
+      // Act
+      try {
+        await handler();
+      } catch (error) {
+        // Assert
+        const jaypieError = error as JaypieError;
+        expect(jaypieError.status).toBe(422);
+        expect(jaypieError.detail).toBe(
+          "The request was not properly formatted",
+        );
+        expect(jaypieError.title).toBe("Bad Request");
+      }
+      expect.assertions(3);
+    });
+    it("Logs warn for an unmapped 4xx", async () => {
+      // Arrange
+      const handler = jaypieHandler(() => {
+        throw new JaypieError("Field ssn failed validation", { status: 422 });
+      });
+      // Act
+      try {
+        await handler();
+      } catch {
+        // Assert
+        expect(log.warn).toHaveBeenCalledTimes(1);
+        expect(log.error).not.toHaveBeenCalled();
+      }
+      expect.assertions(2);
+    });
+    it("Does not scrub a status outside 4xx and 5xx", async () => {
+      // Arrange
+      const handler = jaypieHandler(() => {
+        throw new JaypieError("Moved along", {
+          status: 302,
+          title: "Found",
+        });
+      });
+      // Act
+      try {
+        await handler();
+      } catch (error) {
+        // Assert
+        const jaypieError = error as JaypieError;
+        expect(jaypieError.detail).toBe("Moved along");
+        expect(jaypieError.title).toBe("Found");
+      }
+      expect.assertions(2);
+    });
+    it("Preserves the status, message, and stack of a scrubbed error", async () => {
+      // Arrange
+      const handler = jaypieHandler(() => {
+        throw new ConfigurationError("Fabric model chat is not registered");
+      });
+      // Act
+      try {
+        await handler();
+      } catch (error) {
+        // Assert
+        const jaypieError = error as InstanceType<typeof ConfigurationError>;
+        expect(jaypieError.status).toBe(HTTP.CODE.INTERNAL_ERROR);
+        expect(jaypieError.message).toBe("Fabric model chat is not registered");
+        expect(jaypieError.stack).toBeString();
+      }
+      expect.assertions(3);
+    });
+    it("Scrubs an error caught during validate", async () => {
+      // Arrange
+      const handler = jaypieHandler(() => {}, {
+        validate: [
+          () => {
+            throw new NotFoundError("Account 999 does not exist");
+          },
+        ],
+      });
+      // Act
+      try {
+        await handler();
+      } catch (error) {
+        // Assert
+        expect((error as InstanceType<typeof NotFoundError>).detail).toBe(
+          "The requested resource was not found",
+        );
       }
       expect.assertions(1);
     });

--- a/packages/kit/src/jaypieHandler.module.ts
+++ b/packages/kit/src/jaypieHandler.module.ts
@@ -2,12 +2,14 @@ import { JAYPIE, log as publicLogger } from "./core.js";
 
 import {
   BadRequestError,
+  jaypieErrorFromStatus,
   UnavailableError,
   UnhandledError,
 } from "@jaypie/errors";
 
 import { envBoolean } from "./lib/functions.lib.js";
 import invokeChaos from "./lib/functions/invokeChaos.function.js";
+import HTTP from "./lib/http.lib.js";
 
 //
 //
@@ -28,7 +30,20 @@ interface JaypieHandlerOptions {
 }
 
 interface JaypieError extends Error {
+  detail?: string;
   isProjectError?: boolean;
+  status?: number;
+  title?: string;
+}
+
+//
+//
+// Helpers
+//
+
+// The leading digit of an HTTP status: 4 for client errors, 5 for server errors
+function errorClass(status: number): number {
+  return Math.floor(status / 100);
 }
 
 //
@@ -78,6 +93,43 @@ const jaypieHandler = (
     lib: JAYPIE.LIB.KIT,
   });
 
+  // Report a caught Jaypie error, then scrub it.
+  //
+  // Level follows status: 500-class is an infrastructure or application fault
+  // and logs at error so monitors filtering on error status see the outage;
+  // 4xx is a caller mistake and logs at warn.
+  //
+  // The error's own `detail` and `title` are logged and then replaced with the
+  // generic strings for its status, so whatever the application passed to the
+  // error constructor never reaches a response body. `message` and `stack` are
+  // left intact for logs and for handlers configured to rethrow.
+  const reportJaypieError = (error: JaypieError, message: string): void => {
+    const { detail, status, title } = error;
+
+    if (typeof status === "number" && status >= HTTP.CODE.INTERNAL_ERROR) {
+      log.error(message);
+    } else if (typeof status === "number" && status >= HTTP.CODE.BAD_REQUEST) {
+      log.warn(message);
+    } else {
+      log.debug(message);
+    }
+    log.var({ jaypieError: { detail, status, title } });
+
+    if (typeof status !== "number") {
+      return;
+    }
+    const generic = jaypieErrorFromStatus(status);
+    // An unmapped status resolves to the generic for its class: a 4xx to
+    // BadRequestError, anything else to InternalError. Scrub only when the
+    // substitute belongs to the same class, so a status outside 4xx/5xx is not
+    // described as an application fault
+    if (errorClass(generic.status) !== errorClass(status)) {
+      return;
+    }
+    error.detail = generic.detail;
+    error.title = generic.title;
+  };
+
   libLogger.trace("[jaypie] Handler init");
   return async (...args: unknown[]): Promise<unknown> => {
     libLogger.trace("[jaypie] Handler execution");
@@ -119,7 +171,10 @@ const jaypieHandler = (
     } catch (error) {
       // Log and re-throw
       if ((error as JaypieError).isProjectError) {
-        log.debug("[handler] Caught Jaypie error");
+        reportJaypieError(
+          error as JaypieError,
+          "[handler] Caught Jaypie error",
+        );
         throw error;
       } else {
         // otherwise, respond as unhandled
@@ -160,7 +215,10 @@ const jaypieHandler = (
     } catch (error) {
       // Log and re-throw
       if ((error as JaypieError).isProjectError) {
-        log.debug("[handler] Caught Jaypie error");
+        reportJaypieError(
+          error as JaypieError,
+          "[handler] Caught Jaypie error",
+        );
         throw error;
       } else {
         // otherwise, respond as unhandled
@@ -186,7 +244,10 @@ const jaypieHandler = (
               await teardownFunction(...args);
             } catch (error) {
               if ((error as JaypieError).isProjectError) {
-                log.debug("[handler] Teardown error");
+                reportJaypieError(
+                  error as JaypieError,
+                  "[handler] Teardown error",
+                );
               } else {
                 log.error("[handler] Unhandled teardown error");
                 log.var({ unhandedError: (error as Error).message });

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.114",
+  "version": "0.8.115",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/constructs/1.2.74.md
+++ b/packages/mcp/release-notes/constructs/1.2.74.md
@@ -1,0 +1,27 @@
+---
+version: 1.2.74
+date: 2026-07-29
+summary: JaypieDistribution serves multiple hosts for a zero-downtime domain cutover
+---
+
+## Features
+
+- `JaypieDistribution` accepts `host` as an array of strings or `HostConfig`
+  objects. The first entry is primary: it supplies `PROJECT_BASE_URL`, the
+  certificate's `domainName`, and the un-suffixed DNS record construct IDs.
+  Remaining entries become certificate subject alternative names. Every entry
+  lands in `domainNames` and receives its own A and AAAA record. Duplicates
+  collapse.
+- `JaypieDistribution.hosts` exposes the resolved host list. `host` remains the
+  primary hostname.
+- `deleteExistingRecord` accepts a hostname or an array of hostnames in addition
+  to `true`. Selecting hosts is required when serving several: `true`
+  force-deletes records the construct already owns, and CloudFormation does not
+  recreate an otherwise-unchanged record, which would leave that hostname dark
+  until the next deploy that touches it.
+- `resolveCertificate` accepts `subjectAlternativeNames`. The stack-level cache
+  key covers the full name set while the construct ID stays keyed on the primary
+  domain, so adding a name updates the existing certificate resource rather than
+  orphaning it.
+
+Addresses issue #449.

--- a/packages/mcp/release-notes/errors/1.2.4.md
+++ b/packages/mcp/release-notes/errors/1.2.4.md
@@ -1,0 +1,17 @@
+---
+version: 1.2.4
+date: 2026-07-29
+summary: jaypieErrorFromStatus maps 405 and 429 and falls to BadRequestError for an unmapped 4xx
+---
+
+## Fixes
+
+- `jaypieErrorFromStatus` returns `MethodNotAllowedError` for 405 and
+  `TooManyRequestsError` for 429. Both previously fell through to the
+  `InternalError` default, which returned internal-error strings under a 4xx
+  status. Every status carried by an error class in this package is now mapped.
+- An unmapped 4xx (402, 422, 451, …) falls to `BadRequestError` rather than
+  `InternalError`, so a caller error is no longer described as an application
+  fault. Statuses outside 4xx still fall to `InternalError`.
+
+Supports the error scrubbing added in `@jaypie/kit` 1.2.14 for issue #452.

--- a/packages/mcp/release-notes/express/1.2.30.md
+++ b/packages/mcp/release-notes/express/1.2.30.md
@@ -1,0 +1,11 @@
+---
+version: 1.2.30
+date: 2026-07-29
+summary: Regression coverage for 500-class error log level
+---
+
+## Tests
+
+- Added a regression spec asserting `expressHandler` emits `log.error` when the
+  handler throws a 500-class Jaypie error and stays quiet for 4xx. The behavior
+  itself lives in `@jaypie/kit` 1.2.14.

--- a/packages/mcp/release-notes/jaypie/1.2.74.md
+++ b/packages/mcp/release-notes/jaypie/1.2.74.md
@@ -1,0 +1,16 @@
+---
+version: 1.2.74
+date: 2026-07-29
+summary: Update to @jaypie/kit 1.2.14 with status-driven error logging and detail scrubbing
+---
+
+## Dependencies
+
+- Updated `@jaypie/errors` to ^1.2.4
+- Updated `@jaypie/express` to ^1.2.30
+- Updated `@jaypie/kit` to ^1.2.14
+
+## Breaking
+
+- Caught Jaypie errors no longer carry their constructor message into the
+  response body. See the `@jaypie/kit` 1.2.14 notes.

--- a/packages/mcp/release-notes/kit/1.2.14.md
+++ b/packages/mcp/release-notes/kit/1.2.14.md
@@ -1,0 +1,35 @@
+---
+version: 1.2.14
+date: 2026-07-29
+summary: Handler logs caught Jaypie errors by status and scrubs detail and title
+---
+
+## Fixes
+
+- `jaypieHandler` selects the log level for a caught Jaypie error from its
+  status. Errors at 500 and above (`ConfigurationError`, `InternalError`,
+  `BadGatewayError`, `GatewayTimeoutError`, `UnavailableError`) log at error
+  level; 4xx logs at warn. Previously every Jaypie error logged at debug, so a
+  full outage produced zero error-level logs and monitors filtering on error
+  status stayed silent.
+- Every caught Jaypie error emits
+  `log.var({ jaypieError: { detail, status, title } })` carrying the error as
+  thrown.
+
+## Breaking
+
+- After logging, the handler replaces the error's `detail` and `title` with the
+  generic strings for its status, so a message passed to an error constructor no
+  longer reaches a response body. `NotFoundError("User 12345 not found")` now
+  answers `"The requested resource was not found"`. Applications that used error
+  messages to communicate with callers must return a normal response body
+  instead.
+- `status`, `message`, and `stack` are untouched, so logs and handlers configured
+  with `throw: true` still see the original.
+- A status with no error class of its own takes the generic for its class: an
+  unmapped 4xx keeps its own status and carries the bad request strings, and
+  500-class takes internal error. A status outside 4xx and 5xx is logged without
+  scrubbing.
+- Applies to errors caught during `validate`, the handler itself, and `teardown`.
+
+Addresses issue #452.

--- a/packages/mcp/release-notes/mcp/0.8.115.md
+++ b/packages/mcp/release-notes/mcp/0.8.115.md
@@ -1,0 +1,20 @@
+---
+version: 0.8.115
+date: 2026-07-29
+summary: Document multi-host distributions and caught-error logging and scrubbing
+---
+
+## Documentation
+
+- `skill("cdk")` gains a "Multiple Hosts" section for `JaypieDistribution`.
+- `skill("apigateway")` gains a "Zero-Downtime Hostname Reclaim" section covering
+  the multi-host cutover, why `deleteExistingRecord` must name the reclaimed host
+  instead of being set to `true`, and the certificate replacement that comes with
+  promoting a secondary host to primary.
+- `skill("logs")` gains a "Caught Jaypie Errors" section: 4xx logs at warn, 500
+  and above at error, and the error's `detail` and `title` are scrubbed to the
+  generic strings for the status after logging.
+- `skill("handlers")` error handling list updated for the new levels and the
+  scrubbing.
+
+Addresses issues #449 and #452.

--- a/packages/mcp/rollup.config.js
+++ b/packages/mcp/rollup.config.js
@@ -64,6 +64,7 @@ export default [
       "@jaypie/errors",
       "@jaypie/fabric",
       "@jaypie/fabric/mcp",
+      "@jaypie/kit",
       "@jaypie/tildeskill",
       "@modelcontextprotocol/sdk/server/mcp.js",
       "@modelcontextprotocol/sdk/server/stdio.js",

--- a/packages/mcp/skills/apigateway.md
+++ b/packages/mcp/skills/apigateway.md
@@ -166,7 +166,7 @@ new JaypieDistribution(this, "Dist", {
 });
 ```
 
-You only need `deleteExistingRecord` on the deploy that performs the swap. Drop it back to the default (`false`) on the next change.
+You only need `deleteExistingRecord` on the deploy that performs the swap. Drop it back to the default (`false`) on the next change. On `JaypieDistribution` it also accepts a hostname or array of hostnames, which is required when the distribution serves several hosts — see "Zero-Downtime Hostname Reclaim" below.
 
 If you need to skip the prop entirely (older Jaypie, or you'd rather not run a custom resource), the alternative is a two-phase deploy:
 
@@ -174,6 +174,34 @@ If you need to skip the prop entirely (older Jaypie, or you'd rather not run a c
 2. Deploy 2: add `JaypieDistribution` with the target `host` — new record created
 
 This costs a brief downtime window between deploys; the cert is preserved across both because it's at stack scope.
+
+### Zero-Downtime Hostname Reclaim (multiple hosts)
+
+`deleteExistingRecord` closes the gap on a same-name swap, but reclaiming a hostname from a *regional* API Gateway custom domain is different: the gateway holds the name as its own regional endpoint, not as a CloudFront alternate domain name. Serve both names from the distribution during the cutover by passing an array to `host`. The first entry is primary (`PROJECT_BASE_URL`, certificate `domainName`, un-suffixed record construct IDs); the rest become certificate subject alternative names, and every entry gets an A and AAAA record.
+
+```typescript
+// Deploy 1 — distribution serves both names, reclaiming api. from the gateway
+new JaypieDistribution(this, "Dist", {
+  handler,
+  host: ["api0.example.com", "api.example.com"],
+  zone: "example.com",
+  deleteExistingRecord: ["api.example.com"], // only the reclaimed name
+});
+
+// Deploy 2 — gateway removed, api0. dropped
+new JaypieDistribution(this, "Dist", {
+  handler,
+  host: "api.example.com",
+  zone: "example.com",
+});
+```
+
+Between the deploys both hostnames resolve to CloudFront, so callers migrate at their own pace.
+
+Two things to plan for:
+
+- **Name the reclaimed host, never pass `true`.** `deleteExistingRecord: true` applies to every host. Pointing it at `api0.` — a record this construct already owns — deletes the live record while CloudFormation sees no change to the record resource and so never recreates it, taking `api0.` down until the next deploy that touches it.
+- **Promoting a secondary host to primary replaces the certificate.** The certificate's logical ID derives from the primary host, so deploy 2 above provisions a new ACM cert and re-validates DNS. Keeping the original primary avoids the replacement; pay the cost when the old name is finally retired.
 
 ### Key Differences to Plan For
 

--- a/packages/mcp/skills/cdk.md
+++ b/packages/mcp/skills/cdk.md
@@ -349,6 +349,22 @@ new JaypieNextJs(this, "App", {
 
 **Streaming Note:** When `streaming: true`, also create `open-next.config.ts` in your Next.js app with `wrapper: "aws-lambda-streaming"`. See `skill("streaming")` for details.
 
+## Multiple Hosts
+
+`JaypieDistribution` serves any number of hostnames. Pass an array to `host`; the first entry is primary and supplies `PROJECT_BASE_URL`, the certificate's `domainName`, and the un-suffixed DNS record construct IDs. The rest become certificate subject alternative names. Every entry gets its own A and AAAA record, and all appear in `domainNames`.
+
+```typescript
+new JaypieDistribution(this, "Dist", {
+  handler,
+  host: ["api0.example.com", "api.example.com"],
+  zone: "example.com",
+});
+```
+
+Entries accept the same shapes as a scalar `host` (string or `HostConfig`), duplicates collapse, and `construct.hosts` exposes the resolved list (`construct.host` stays the primary). Adding a host to an existing deployment leaves the primary's records and certificate logical IDs untouched; the certificate resource gains the new name as a SAN, which ACM performs as a replacement.
+
+The main use is a zero-downtime hostname cutover, where `deleteExistingRecord` must name the reclaimed host rather than being set to `true` — see `skill("apigateway")`.
+
 ## Security Headers
 
 `JaypieDistribution` ships with default security response headers via a `ResponseHeadersPolicy` (analogous to `helmet` for Express):

--- a/packages/mcp/skills/handlers.md
+++ b/packages/mcp/skills/handlers.md
@@ -154,9 +154,12 @@ fabricMcp({ service: greetService, server });
 
 All handlers catch errors and format responses:
 
-- **Jaypie errors** (`isProjectError: true`): Return error body, log at debug level
+- **Jaypie errors under 500** (`isProjectError: true`): Return error body, log at warn level
+- **Jaypie errors 500 and above**: Return error body, log at error level
 - **Unhandled errors**: Wrap in `UnhandledError`, log at fatal level
 - **With `throw: true`**: Re-throw instead of formatting (for custom handling)
+
+Every caught Jaypie error is logged as `log.var({ jaypieError: { detail, status, title } })` and then scrubbed: `detail` and `title` are replaced with the generic strings for the status, so a constructor message never reaches a response body. Do not use an error message to tell the caller anything — see `skill("logs")`.
 
 ```typescript
 import { NotFoundError, BadRequestError } from "jaypie";

--- a/packages/mcp/skills/logs.md
+++ b/packages/mcp/skills/logs.md
@@ -65,6 +65,33 @@ log.var({ Processing: {
 
 Log any important, even scalar, data and filter with `var` in Datadog
 
+## Caught Jaypie Errors
+
+The handler lifecycle picks the level from the error's status, so an outage is visible to monitors filtering on error status without the application logging anything itself:
+
+- **4xx** (`BadRequestError`, `NotFoundError`, …) → `log.warn("[handler] Caught Jaypie error")`
+- **500-class** (`ConfigurationError`, `InternalError`, `BadGatewayError`, `GatewayTimeoutError`, `UnavailableError`, …) → `log.error("[handler] Caught Jaypie error")`
+
+Either way the handler emits `log.var({ jaypieError: { detail, status, title } })` carrying the error as thrown. The same applies to errors thrown during `validate` and `teardown`. Non-Jaypie errors remain `log.fatal` plus `log.error`.
+
+### Detail is logged, then scrubbed
+
+After logging, the handler replaces the error's `detail` and `title` with the generic strings for its status. The message an application passes to an error constructor reaches the logs and never reaches a response body.
+
+```typescript
+throw new ConfigurationError("Fabric model chat is not registered");
+// log.error("[handler] Caught Jaypie error")
+// log.var({ jaypieError: { detail: "Fabric model chat is not registered", status: 500, title: "Internal Configuration Error" } })
+// response: { errors: [{ status: 500, title: "Internal Application Error",
+//   detail: "An unexpected error occurred and the request was unable to complete" }] }
+```
+
+This applies to 4xx as well, so `NotFoundError("User 12345 not found")` answers `"The requested resource was not found"`. Do not use the error message to communicate with the caller. Return a normal response body when the caller needs specifics.
+
+`status`, `message`, and `stack` are untouched, so logs and handlers configured with `throw: true` still see the original.
+
+A status with no error class of its own falls to the generic for its class: an unmapped 4xx (422, 451, …) answers the bad request strings while keeping its own status, and 500-class falls to internal error. A status outside 4xx and 5xx has no correct substitute and is logged without scrubbing.
+
 ## Session Management
 
 Handlers automatically call `log.setup()` and `log.teardown()` to bookend each request. On teardown, a report is emitted as `log.info.var({ report })` containing accumulated data and warn/error counts.

--- a/workspaces/documentation/src/content/docs/docs/core/error-handling.md
+++ b/workspaces/documentation/src/content/docs/docs/core/error-handling.md
@@ -81,6 +81,14 @@ Returns:
 }
 ```
 
+:::caution
+A handler scrubs the error before it reaches the response. The message passed to
+the constructor is logged, then `detail` and `title` are replaced with the
+generic strings for the status, so the same error thrown inside a handler answers
+`"The requested resource was not found"`. See
+[Handler Lifecycle](/docs/core/handler-lifecycle/).
+:::
+
 ### Type Guard
 
 Use `isJaypieError` to safely check error type:
@@ -185,6 +193,10 @@ log.error("Database query failed");
 log.var({ error: dbError.message });
 throw InternalError();
 ```
+
+Handlers enforce this: an error message reaches the logs, never a response body.
+An error message is therefore not a way to tell the caller anything. Return a
+normal response body when the caller needs specifics.
 
 ## Testing Errors
 

--- a/workspaces/documentation/src/content/docs/docs/core/handler-lifecycle.md
+++ b/workspaces/documentation/src/content/docs/docs/core/handler-lifecycle.md
@@ -117,6 +117,31 @@ Handler return values are automatically converted to HTTP responses:
 | `false` | 204 | No content |
 | Thrown error | Error status | JSON:API error |
 
+## Caught Errors
+
+A caught Jaypie error is logged by status and then scrubbed:
+
+| Error | Log level | Response `detail` and `title` |
+|-------|-----------|-------------------------------|
+| 4xx (`BadRequestError`, `NotFoundError`, …) | `log.warn` | Generic strings for the status |
+| 500-class (`ConfigurationError`, `InternalError`, …) | `log.error` | Generic strings for the status |
+| Non-Jaypie error | `log.fatal` | `UnhandledError` |
+
+Either way the handler emits `log.var({ jaypieError: { detail, status, title } })`
+carrying the error as thrown, then replaces `detail` and `title` with the generic
+strings for the status. `status`, `message`, and `stack` are untouched.
+
+```typescript
+throw new ConfigurationError("Fabric model chat is not registered");
+// logs the detail, responds with:
+// { errors: [{ status: 500, title: "Internal Application Error",
+//   detail: "An unexpected error occurred and the request was unable to complete" }] }
+```
+
+An error message never reaches the caller, including on 4xx. A status with no
+error class of its own takes the generic for its class: an unmapped 4xx (422,
+451, …) keeps its own status and carries the bad request strings.
+
 ## Usage Examples
 
 ### Express Handler

--- a/workspaces/documentation/src/content/docs/docs/packages/constructs.md
+++ b/workspaces/documentation/src/content/docs/docs/packages/constructs.md
@@ -148,6 +148,66 @@ new JaypieApiGateway(this, "Gateway", {
 | `host` | `string` | Custom domain hostname |
 | `zone` | `string` | Route53 hosted zone |
 
+## JaypieDistribution
+
+CloudFront distribution over a Lambda Function URL or any origin, with ACM
+certificate, Route53 records, security headers, WAFv2, and access logging by
+default.
+
+```typescript
+import { JaypieDistribution, JaypieExpressLambda } from "@jaypie/constructs";
+
+const api = new JaypieExpressLambda(this, "Api", {
+  code: "../api/dist",
+  handler: "handler.handler",
+});
+
+new JaypieDistribution(this, "Distribution", {
+  handler: api,
+  host: "api.example.com",
+  zone: "example.com",
+});
+```
+
+### Multiple Hosts
+
+`host` accepts an array. The first entry is primary: it supplies
+`PROJECT_BASE_URL` and the certificate's `domainName`, and the rest become
+subject alternative names. Every entry gets an A and AAAA record, which serves a
+zero-downtime hostname cutover.
+
+```typescript
+new JaypieDistribution(this, "Distribution", {
+  handler: api,
+  host: ["api0.example.com", "api.example.com"],
+  zone: "example.com",
+  deleteExistingRecord: ["api.example.com"],
+});
+```
+
+`deleteExistingRecord` force-deletes a conflicting Route53 record before the
+alias is created. It accepts `true` (every host), a hostname, or an array of
+hostnames.
+
+:::caution
+With several hosts, name the hosts being reclaimed from another owner rather than
+passing `true`. `true` also force-deletes records this construct already owns,
+and CloudFormation does not recreate an otherwise-unchanged record, leaving that
+hostname dark until the next deploy that touches it.
+:::
+
+### Options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `handler` | `IOrigin` \| `IFunctionUrl` \| `IFunction` | Origin; an `IFunction` gets a Function URL |
+| `host` | `string` \| `HostConfig` \| array of either | Domain name or names; first entry is primary |
+| `zone` | `string` \| `IHostedZone` | Route53 hosted zone |
+| `deleteExistingRecord` | `boolean` \| `string` \| `string[]` | Force-delete conflicting records |
+| `streaming` | `boolean` | Lambda response streaming |
+| `waf` | `boolean` \| `JaypieWafConfig` | WAFv2 WebACL (default enabled) |
+| `securityHeaders` | `boolean` \| overrides | Security response headers (default enabled) |
+
 ## JaypieWebDeploymentBucket
 
 Static site on S3 fronted by CloudFront, ACM, and Route53. Ships with default security headers, WAFv2, and CloudFront access logging — same override mechanisms as `JaypieDistribution` (`securityHeaders`, `responseHeadersPolicy`, `waf`, `logBucket`, `destination`). When `CDK_ENV_REPO` is set, also provisions a scoped GitHub OIDC deploy role with `cloudfront:CreateInvalidation` on the distribution.


### PR DESCRIPTION
Closes #449
Closes #452

## #449 — `JaypieDistribution` serves multiple hosts

`host` accepts `string | HostConfig | Array<string | HostConfig>`. The first entry is primary: `PROJECT_BASE_URL`, the certificate `domainName`, and the un-suffixed DNS record construct IDs come from it, so adding a host to a live deployment does not replace records it already owns. The rest become certificate subject alternative names. Every entry lands in `domainNames` and gets an A and AAAA record. `construct.hosts` exposes the resolved list.

`resolveCertificate` gains `subjectAlternativeNames`. Its cache key covers the full name set while the construct ID stays keyed on the primary domain, so adding a name updates the existing certificate rather than orphaning it.

`deleteExistingRecord` now also accepts a hostname or array of hostnames. Selecting hosts is required when serving several: `true` also force-deletes records the construct already owns, and CloudFormation does not recreate an otherwise-unchanged record, which would leave that hostname dark until the next deploy that touches it.

```ts
new JaypieDistribution(this, "Dist", {
  handler,
  host: ["api0.example.com", "api.example.com"],
  zone: "example.com",
  deleteExistingRecord: ["api.example.com"],
});
```

## #452 — caught Jaypie errors log by status, detail and title scrubbed

Level follows status: 500-class logs at `log.error`, 4xx at `log.warn`. Previously everything logged at debug, so a full outage produced zero error-level logs.

Every caught Jaypie error emits `log.var({ jaypieError: { detail, status, title } })` carrying the error as thrown, then `detail` and `title` are replaced with the generic strings for the status. `status`, `message`, and `stack` are untouched.

`jaypieErrorFromStatus` gains 405 and 429 cases, and an unmapped 4xx falls to `BadRequestError` instead of `InternalError`. The handler substitutes only within a status class, so an unmapped 4xx keeps its own status while carrying the bad request wording; a status outside 4xx and 5xx is logged without scrubbing.

### Breaking

An error constructor message no longer reaches a response body, on 4xx as well as 5xx. `NotFoundError("User 12345 not found")` answers `"The requested resource was not found"`. Applications that used error messages to communicate with callers must return a normal response body instead.

## Versions

constructs 1.2.74, errors 1.2.4, express 1.2.30, kit 1.2.14, mcp 0.8.115, jaypie 1.2.74. Umbrella ranges synced, lockfile updated, release notes added for each.

## Verification

4018 tests pass repo-wide. Typecheck, build, lint, and format clean across every touched package plus the documentation site. Also fixes an unrelated `@jaypie/kit` unresolved-dependency warning in the mcp rollup build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ybb2kSpiVsqoWJCy9R5Av8