### PR TITLE
feat(constructs): JaypieSesIntake and optional queue DLQ

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14935,7 +14935,7 @@
     },
     "packages/constructs": {
       "name": "@jaypie/constructs",
-      "version": "1.2.74",
+      "version": "1.2.75",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*",
@@ -15545,7 +15545,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.115",
+      "version": "0.8.116",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.3.3",

--- a/packages/constructs/CLAUDE.md
+++ b/packages/constructs/CLAUDE.md
@@ -57,7 +57,7 @@ packages/constructs/
 |-----------|-------------|
 | `JaypieLambda` | Full-featured Lambda with Datadog, secrets, VPC support |
 | `JaypieExpressLambda` | Lambda optimized for Express APIs (30s timeout, API role) |
-| `JaypieQueuedLambda` | Lambda with SQS queue integration (FIFO by default) |
+| `JaypieQueuedLambda` | Lambda with SQS queue integration (FIFO by default, optional DLQ) |
 | `JaypieBucketQueuedLambda` | Lambda triggered by S3 bucket events via queue |
 
 ### Networking & Distribution
@@ -100,6 +100,7 @@ packages/constructs/
 | Construct | Description |
 |-----------|-------------|
 | `JaypieEventsRule` | EventBridge rule |
+| `JaypieSesIntake` | SES inbound email receiving (identity, DKIM, MX, receipt rules) |
 | `JaypieGitHubDeployRole` | GitHub Actions OIDC deploy role |
 | `JaypieNextJs` | Next.js deployment (uses cdk-nextjs-standalone) |
 | `JaypieOrganizationTrail` | CloudTrail for AWS Organizations |
@@ -119,6 +120,8 @@ The `CDK` constant provides standardized values:
 - `CDK.LAMBDA.*` - Lambda defaults (LOG_RETENTION: 90, MEMORY_SIZE: 1024)
 - `CDK.ROLE.*` - Resource role tags (api, deploy, storage, processing, etc.)
 - `CDK.SERVICE.*` - Service tags
+- `CDK.SES.*` - SES intake defaults (DKIM record count/TTL, object key prefix)
+- `CDK.SQS.DLQ.*` - Dead-letter queue defaults (MAX_RECEIVE_COUNT: 3, RETENTION_DAYS: 14)
 - `CDK.TAG.*` - Tag key names
 - `CDK.VARIABLES.*` - Non-secret variables bundle (`ENV` pointer name, `PARAMETER` suffix)
 - `CDK.VENDOR.*` - Third-party vendor tags
@@ -157,6 +160,75 @@ new JaypieLambda(this, "MyLambda", {
   environment: ["NODE_ENV", { DEBUG: "true" }], // Mixed array syntax
 });
 ```
+
+### Queued Lambda with a Dead-Letter Queue
+
+`JaypieQueuedLambda` creates its queue without a redrive policy by default, so a
+poison message retries until retention lapses. `dlq` adds the dead-letter queue
+and redrive policy; `JaypieBucketQueuedLambda` inherits it.
+
+```typescript
+new JaypieQueuedLambda(this, "Worker", { code: "dist", dlq: true }); // maxReceiveCount 3
+new JaypieQueuedLambda(this, "Worker", { code: "dist", dlq: 5 });    // maxReceiveCount 5
+new JaypieQueuedLambda(this, "Worker", {
+  code: "dist",
+  dlq: { maxReceiveCount: 3, retentionPeriod: Duration.days(14) },
+});
+```
+
+`true` uses `CDK.SQS.DLQ` defaults (3 receives, 14-day retention); a number is
+shorthand for `maxReceiveCount`; the object form also accepts an existing
+`queue`. The DLQ matches the source queue's `fifo` setting — SQS rejects a
+redrive policy across the FIFO boundary. Exposed as `.dlq` so consumers can
+alarm on its depth; a dead-letter queue nobody watches is a place messages go to
+be ignored.
+
+`dlq` is distinct from the inherited `deadLetterQueue` prop, which configures
+the Lambda's asynchronous-invocation DLQ and does nothing for SQS event-source
+failures.
+
+### SES Inbound Email
+
+`JaypieSesIntake` packages domain identity, DKIM CNAMEs, MX, a receipt rule set
+writing raw MIME to S3, and rule-set activation.
+
+```typescript
+import { JaypieSesIntake } from "@jaypie/constructs";
+
+// Owns the worker
+new JaypieSesIntake(this, "Intake", {
+  code: "../api/dist",
+  handler: "email.handler",
+  tables: [table],
+  zone: "example.com",
+});
+
+// Attaches to an existing worker
+const worker = new JaypieBucketQueuedLambda(this, "EmailWorker", { ... });
+new JaypieSesIntake(this, "Intake", { bucket: worker, zone: "example.com" });
+```
+
+Encoded specifics, each of which is a silent failure otherwise:
+
+- `Identity.domain(subdomain)` creates no DNS records, and
+  `Identity.publicHostedZone(zone)` verifies the apex instead of the subdomain.
+  The construct creates the three DKIM CNAMEs itself via `CfnRecordSet` (the L2
+  record's name qualification cannot handle the identity's unresolved tokens;
+  the same pattern CDK's `EasyDkim.bind` uses). Those CNAMEs resolving IS SESv2
+  identity verification — no TXT record is involved.
+- `sesActions.S3` must receive the real `s3.Bucket`, not the
+  `JaypieBucketQueuedLambda` wrapper. The action locates the bucket's `Policy`
+  child to attach the `ses.amazonaws.com` + `aws:SourceAccount` grant and the
+  CloudFormation ordering; handed the wrapper it degrades to a warning with no
+  policy and no dependency. `bucket` is unwrapped internally.
+- CloudFormation has no rule-set activation resource, so activation runs through
+  an `AwsCustomResource` whose `onDelete` deactivates. It has to: SES refuses to
+  delete an active rule set. That means tearing the stack down disables SES
+  receiving account/region-wide.
+- One active receipt rule set per account/region. Gate instantiation to one
+  environment per account.
+- SES sandbox mode restricts sending only; receiving needs no production-access
+  request.
 
 ### CloudFront Distribution
 

--- a/packages/constructs/package.json
+++ b/packages/constructs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/constructs",
-  "version": "1.2.74",
+  "version": "1.2.75",
   "description": "CDK constructs for Jaypie applications",
   "repository": {
     "type": "git",

--- a/packages/constructs/rollup.config.js
+++ b/packages/constructs/rollup.config.js
@@ -39,6 +39,8 @@ const external = [
   "aws-cdk-lib/aws-s3-notifications",
   "aws-cdk-lib/aws-sam",
   "aws-cdk-lib/aws-secretsmanager",
+  "aws-cdk-lib/aws-ses",
+  "aws-cdk-lib/aws-ses-actions",
   "aws-cdk-lib/aws-sns",
   "aws-cdk-lib/aws-sqs",
   "aws-cdk-lib/aws-ssm",

--- a/packages/constructs/src/JaypieQueuedLambda.ts
+++ b/packages/constructs/src/JaypieQueuedLambda.ts
@@ -9,16 +9,75 @@ import * as cloudwatch from "aws-cdk-lib/aws-cloudwatch";
 import * as kms from "aws-cdk-lib/aws-kms";
 import { JaypieLambda, JaypieLambdaProps } from "./JaypieLambda.js";
 
+/**
+ * Redrive configuration for the construct's SQS queue.
+ *
+ * Distinct from `deadLetterQueue` on `JaypieLambdaProps`, which configures the
+ * Lambda's asynchronous-invocation DLQ. This one governs the queue feeding the
+ * Lambda: after `maxReceiveCount` failed receives, SQS moves the message to the
+ * dead-letter queue instead of redelivering it until retention lapses.
+ */
+export interface JaypieQueueDlqProps {
+  /**
+   * Receives after which SQS moves a message to the dead-letter queue.
+   * @default CDK.SQS.DLQ.MAX_RECEIVE_COUNT (3)
+   */
+  maxReceiveCount?: number;
+  /**
+   * Use an existing queue instead of creating one. Its `fifo` setting must
+   * match the source queue; SQS rejects a mismatched redrive policy.
+   */
+  queue?: sqs.IQueue;
+  /**
+   * How long the dead-letter queue holds messages.
+   * @default CDK.SQS.DLQ.RETENTION_DAYS (14 days, the SQS maximum)
+   */
+  retentionPeriod?: Duration | number;
+}
+
 export interface JaypieQueuedLambdaProps extends JaypieLambdaProps {
   batchSize?: number;
+  /**
+   * Add a dead-letter queue and redrive policy to the construct's queue.
+   *
+   * - `true` creates a DLQ with `CDK.SQS.DLQ` defaults
+   * - a number is shorthand for `{ maxReceiveCount }`
+   * - an object configures the DLQ, optionally supplying an existing `queue`
+   *
+   * Without this, a poison message retries until retention lapses. The DLQ is
+   * exposed as `.dlq` so consumers can alarm on its depth; a dead-letter queue
+   * nobody watches is a place messages go to be ignored.
+   *
+   * @default undefined (no redrive policy)
+   */
+  dlq?: boolean | number | JaypieQueueDlqProps;
   fifo?: boolean;
   visibilityTimeout?: Duration | number;
+}
+
+function asDuration(
+  value: Duration | number | undefined,
+  fallback: Duration,
+): Duration {
+  if (value === undefined) return fallback;
+  return typeof value === "number" ? Duration.seconds(value) : value;
+}
+
+function resolveDlqProps(
+  dlq: boolean | number | JaypieQueueDlqProps | undefined,
+): JaypieQueueDlqProps | undefined {
+  if (dlq === undefined || dlq === false) return undefined;
+  if (dlq === true) return {};
+  if (typeof dlq === "number") return { maxReceiveCount: dlq };
+  return dlq;
 }
 
 export class JaypieQueuedLambda
   extends Construct
   implements lambda.IFunction, sqs.IQueue
 {
+  private readonly _dlq?: sqs.IQueue;
+  private readonly _ownedDlq?: sqs.Queue;
   private readonly _queue: sqs.Queue;
   private readonly _lambdaConstruct: JaypieLambda;
 
@@ -36,6 +95,7 @@ export class JaypieQueuedLambda
       deadLetterQueueEnabled,
       deadLetterTopic,
       description,
+      dlq,
       environment = {},
       envSecrets = {},
       ephemeralStorageSize,
@@ -73,23 +133,55 @@ export class JaypieQueuedLambda
       vpcSubnets,
     } = props;
 
+    const tagQueue = (queue: sqs.IQueue) => {
+      if (roleTag) {
+        Tags.of(queue).add(CDK.TAG.ROLE, roleTag);
+      }
+      if (serviceTag) {
+        Tags.of(queue).add(CDK.TAG.SERVICE, serviceTag);
+      }
+      if (vendorTag) {
+        Tags.of(queue).add(CDK.TAG.VENDOR, vendorTag);
+      }
+    };
+
+    // Resolve the optional dead-letter queue before the source queue, which
+    // references it in its redrive policy
+    const dlqProps = resolveDlqProps(dlq);
+    if (dlqProps) {
+      if (dlqProps.queue) {
+        this._dlq = dlqProps.queue;
+      } else {
+        // A FIFO queue cannot redrive to a standard queue, or the reverse
+        const dlqQueue = new sqs.Queue(this, "DeadLetterQueue", {
+          fifo,
+          retentionPeriod: asDuration(
+            dlqProps.retentionPeriod,
+            Duration.days(CDK.SQS.DLQ.RETENTION_DAYS),
+          ),
+        });
+        tagQueue(dlqQueue);
+        this._dlq = dlqQueue;
+        this._ownedDlq = dlqQueue;
+      }
+    }
+
     // Create SQS Queue
     this._queue = new sqs.Queue(this, "Queue", {
+      ...(this._dlq && {
+        deadLetterQueue: {
+          maxReceiveCount:
+            dlqProps?.maxReceiveCount ?? CDK.SQS.DLQ.MAX_RECEIVE_COUNT,
+          queue: this._dlq,
+        },
+      }),
       fifo,
-      visibilityTimeout:
-        typeof visibilityTimeout === "number"
-          ? Duration.seconds(visibilityTimeout)
-          : visibilityTimeout,
+      visibilityTimeout: asDuration(
+        visibilityTimeout,
+        Duration.seconds(CDK.DURATION.LAMBDA_WORKER),
+      ),
     });
-    if (roleTag) {
-      Tags.of(this._queue).add(CDK.TAG.ROLE, roleTag);
-    }
-    if (serviceTag) {
-      Tags.of(this._queue).add(CDK.TAG.SERVICE, serviceTag);
-    }
-    if (vendorTag) {
-      Tags.of(this._queue).add(CDK.TAG.VENDOR, vendorTag);
-    }
+    tagQueue(this._queue);
 
     // Create Lambda with JaypieLambda
     this._lambdaConstruct = new JaypieLambda(this, "Function", {
@@ -153,6 +245,14 @@ export class JaypieQueuedLambda
   }
 
   // Public accessors
+  /**
+   * The dead-letter queue receiving messages past `maxReceiveCount`, when
+   * `dlq` was configured. Alarm on its depth.
+   */
+  public get dlq(): sqs.IQueue | undefined {
+    return this._dlq;
+  }
+
   public get queue(): sqs.Queue {
     return this._queue;
   }
@@ -314,6 +414,8 @@ export class JaypieQueuedLambda
   public applyRemovalPolicy(policy: RemovalPolicy): void {
     this._lambdaConstruct.applyRemovalPolicy(policy);
     this._queue.applyRemovalPolicy(policy);
+    // Imported dead-letter queues are owned by another stack
+    this._ownedDlq?.applyRemovalPolicy(policy);
   }
 
   // IQueue implementation

--- a/packages/constructs/src/JaypieSesIntake.ts
+++ b/packages/constructs/src/JaypieSesIntake.ts
@@ -1,0 +1,324 @@
+import { Duration, Stack } from "aws-cdk-lib";
+import * as route53 from "aws-cdk-lib/aws-route53";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import * as ses from "aws-cdk-lib/aws-ses";
+import * as sesActions from "aws-cdk-lib/aws-ses-actions";
+import * as cr from "aws-cdk-lib/custom-resources";
+import { Construct } from "constructs";
+import { ConfigurationError } from "@jaypie/errors";
+
+import { CDK } from "./constants";
+import { envHostname } from "./helpers/envHostname";
+import { resolveHostedZone } from "./helpers/resolveHostedZone";
+import { JaypieDnsRecord } from "./JaypieDnsRecord.js";
+import {
+  JaypieBucketQueuedLambda,
+  JaypieBucketQueuedLambdaProps,
+} from "./JaypieBucketQueuedLambda.js";
+
+export interface JaypieSesIntakeProps extends Partial<JaypieBucketQueuedLambdaProps> {
+  /**
+   * Make this the account/region's active receipt rule set.
+   *
+   * CloudFormation has no activation resource, so activation runs through an
+   * `AwsCustomResource`. Deletion must deactivate: SES refuses to delete an
+   * active rule set, and the stack would otherwise be undeletable. That means
+   * tearing this construct down disables SES receiving for the whole
+   * account/region, not just this domain.
+   *
+   * @default true
+   */
+  activate?: boolean;
+  /**
+   * Destination for received mail. Accepts a `JaypieBucketQueuedLambda` (its
+   * `.bucket` is unwrapped) or a raw `s3.IBucket`. Omit to have the construct
+   * create a `JaypieBucketQueuedLambda` from `code` and `handler`.
+   */
+  bucket?: s3.IBucket | JaypieBucketQueuedLambda;
+  /**
+   * Create the three DKIM CNAME records. Their resolution IS SESv2 domain
+   * verification; no TXT record is involved. Disable only when the records are
+   * managed elsewhere, in which case the identity stays unverified until they
+   * exist and SES rejects mail for the domain.
+   *
+   * @default true
+   */
+  dkim?: boolean;
+  /**
+   * Fully-qualified receiving domain.
+   * @default envHostname({ component: "intake" })
+   */
+  host?: string;
+  /**
+   * Create the MX record pointing at the region's inbound SMTP endpoint.
+   * @default true
+   */
+  mx?: boolean;
+  /**
+   * S3 key prefix for stored messages.
+   * @default CDK.SES.INTAKE.OBJECT_KEY_PREFIX ("inbound/")
+   */
+  objectKeyPrefix?: string;
+  /**
+   * Recipient addresses or domains the receipt rule matches.
+   * @default [host] — every local part on the receiving domain
+   */
+  recipients?: string[];
+  /**
+   * Explicit receipt rule set name.
+   * @default CloudFormation-generated
+   */
+  ruleSetName?: string;
+  /**
+   * Run SES spam and virus scanning, adding the verdict headers.
+   * @default true
+   */
+  scanEnabled?: boolean;
+  /**
+   * TTL for the DKIM CNAME records.
+   * @default CDK.SES.DKIM.TTL (30 minutes)
+   */
+  ttl?: Duration | number;
+  /**
+   * Hosted zone owning the DKIM and MX records.
+   * @default process.env.CDK_ENV_HOSTED_ZONE
+   */
+  zone?: string | route53.IHostedZone;
+}
+
+/**
+ * Unwrap a `JaypieBucketQueuedLambda` to the real `s3.Bucket` it wraps.
+ *
+ * `sesActions.S3` locates the bucket's `Policy` child to attach the
+ * `ses.amazonaws.com` + `aws:SourceAccount` grant and the CloudFormation
+ * ordering dependency. Handed the wrapper construct, that lookup misses and the
+ * action degrades to a warning with no policy and no dependency, so received
+ * mail fails to write. Duck-typed rather than `instanceof` so a duplicated
+ * `@jaypie/constructs` in the dependency tree still unwraps.
+ */
+function unwrapBucketQueuedLambda(
+  bucket: s3.IBucket | JaypieBucketQueuedLambda,
+): JaypieBucketQueuedLambda | undefined {
+  const candidate = (bucket as JaypieBucketQueuedLambda).bucket;
+  if (candidate && (candidate as unknown) !== (bucket as unknown)) {
+    return bucket as JaypieBucketQueuedLambda;
+  }
+  return undefined;
+}
+
+/**
+ * SES inbound email receiving: domain identity, DKIM and MX records, a receipt
+ * rule set writing raw MIME to S3, and rule-set activation.
+ *
+ * ```typescript
+ * // Owns the worker
+ * new JaypieSesIntake(this, "Intake", {
+ *   code: "../api/dist",
+ *   handler: "email.handler",
+ *   tables: [table],
+ *   zone: "example.com",
+ * });
+ *
+ * // Attaches to an existing worker
+ * new JaypieSesIntake(this, "Intake", { bucket: worker, zone: "example.com" });
+ * ```
+ *
+ * SES allows ONE active receipt rule set per account/region. Gate instantiation
+ * so exactly one environment per AWS account owns receiving.
+ *
+ * SES sandbox mode restricts sending only; receiving needs no production-access
+ * request.
+ */
+export class JaypieSesIntake extends Construct {
+  private readonly _bucket: s3.IBucket;
+  private readonly _host: string;
+  private readonly _identity: ses.EmailIdentity;
+  private readonly _rule: ses.ReceiptRule;
+  private readonly _ruleSet: ses.ReceiptRuleSet;
+  private readonly _worker?: JaypieBucketQueuedLambda;
+
+  constructor(scope: Construct, id: string, props: JaypieSesIntakeProps = {}) {
+    super(scope, id);
+
+    const {
+      activate = true,
+      bucket,
+      dkim = true,
+      host,
+      mx = true,
+      objectKeyPrefix = CDK.SES.INTAKE.OBJECT_KEY_PREFIX,
+      recipients,
+      ruleSetName,
+      scanEnabled = true,
+      ttl = CDK.SES.DKIM.TTL,
+      zone,
+      ...workerProps
+    } = props;
+
+    this._host =
+      host ||
+      envHostname({
+        component: CDK.SES.INTAKE.COMPONENT,
+        ...(typeof zone === "string" && { domain: zone }),
+      });
+
+    // =========================================================================
+    // Destination — either the caller's bucket or a worker this construct owns
+    // =========================================================================
+    if (bucket) {
+      this._worker = unwrapBucketQueuedLambda(bucket);
+      this._bucket = this._worker
+        ? this._worker.bucket
+        : (bucket as s3.IBucket);
+    } else {
+      if (!workerProps.code) {
+        throw new ConfigurationError(
+          "JaypieSesIntake requires either `bucket` or `code` to receive mail",
+        );
+      }
+      this._worker = new JaypieBucketQueuedLambda(this, "Worker", {
+        handler: "index.handler",
+        roleTag: CDK.ROLE.PROCESSING,
+        ...workerProps,
+        code: workerProps.code,
+      } as JaypieBucketQueuedLambdaProps);
+      this._bucket = this._worker.bucket;
+    }
+
+    // =========================================================================
+    // Domain identity + DNS
+    //
+    // `Identity.domain()` creates no DNS records, and `Identity.publicHostedZone()`
+    // would verify the apex instead of the subdomain, so the DKIM CNAMEs are
+    // created here. `CfnRecordSet` rather than the L2 record: the L2's name
+    // qualification cannot handle the identity's unresolved tokens (the same
+    // pattern CDK's own `EasyDkim.bind` uses).
+    // =========================================================================
+    this._identity = new ses.EmailIdentity(this, "Identity", {
+      identity: ses.Identity.domain(this._host),
+    });
+
+    if (dkim || mx) {
+      const hostedZone = resolveHostedZone(this, { name: "Zone", zone });
+
+      if (dkim) {
+        const ttlSeconds = (
+          typeof ttl === "number" ? Duration.seconds(ttl) : ttl
+        ).toSeconds();
+        const dkimTokens: Array<[string, string]> = [
+          [this._identity.dkimDnsTokenName1, this._identity.dkimDnsTokenValue1],
+          [this._identity.dkimDnsTokenName2, this._identity.dkimDnsTokenValue2],
+          [this._identity.dkimDnsTokenName3, this._identity.dkimDnsTokenValue3],
+        ];
+        dkimTokens.forEach(([name, value], index) => {
+          new route53.CfnRecordSet(this, `Dkim${index + 1}`, {
+            hostedZoneId: hostedZone.hostedZoneId,
+            name,
+            resourceRecords: [value],
+            ttl: String(ttlSeconds),
+            type: CDK.DNS.RECORD.CNAME,
+          });
+        });
+      }
+
+      if (mx) {
+        new JaypieDnsRecord(this, "Mx", {
+          recordName: this._host,
+          type: CDK.DNS.RECORD.MX,
+          values: [
+            {
+              hostName: `${CDK.SES.SMTP_HOSTNAME_PREFIX}.${Stack.of(this).region}.amazonaws.com`,
+              priority: 10,
+            },
+          ],
+          zone: hostedZone,
+        });
+      }
+    }
+
+    // =========================================================================
+    // Receipt rule set — every matching recipient lands in the bucket
+    // =========================================================================
+    this._ruleSet = new ses.ReceiptRuleSet(this, "RuleSet", {
+      ...(ruleSetName && { receiptRuleSetName: ruleSetName }),
+    });
+    this._rule = this._ruleSet.addRule("Intake", {
+      actions: [
+        new sesActions.S3({
+          bucket: this._bucket,
+          objectKeyPrefix,
+        }),
+      ],
+      recipients: recipients || [this._host],
+      scanEnabled,
+    });
+    // Mail cannot be accepted for an unverified identity
+    this._rule.node.addDependency(this._identity);
+
+    if (activate) {
+      const physicalResourceId = cr.PhysicalResourceId.of(
+        `activate-${this.node.path}`,
+      );
+      const parameters = {
+        RuleSetName: this._ruleSet.receiptRuleSetName,
+      };
+      const activation = new cr.AwsCustomResource(this, "ActivateRuleSet", {
+        onCreate: {
+          action: "setActiveReceiptRuleSet",
+          parameters,
+          physicalResourceId,
+          service: "SES",
+        },
+        onDelete: {
+          action: "setActiveReceiptRuleSet",
+          // No RuleSetName deactivates; an active rule set cannot be deleted
+          parameters: {},
+          service: "SES",
+        },
+        onUpdate: {
+          action: "setActiveReceiptRuleSet",
+          parameters,
+          physicalResourceId,
+          service: "SES",
+        },
+        policy: cr.AwsCustomResourcePolicy.fromSdkCalls({
+          resources: cr.AwsCustomResourcePolicy.ANY_RESOURCE,
+        }),
+      });
+      activation.node.addDependency(this._rule);
+    }
+  }
+
+  /** Bucket receiving raw MIME from the receipt rule */
+  public get bucket(): s3.IBucket {
+    return this._bucket;
+  }
+
+  /** Fully-qualified receiving domain */
+  public get host(): string {
+    return this._host;
+  }
+
+  /** SES domain identity, verified by the DKIM CNAMEs */
+  public get identity(): ses.EmailIdentity {
+    return this._identity;
+  }
+
+  /** The receipt rule writing to the bucket */
+  public get rule(): ses.ReceiptRule {
+    return this._rule;
+  }
+
+  /** The receipt rule set; one per account/region may be active */
+  public get ruleSet(): ses.ReceiptRuleSet {
+    return this._ruleSet;
+  }
+
+  /**
+   * The bucket/queue/Lambda worker, when this construct created one or was
+   * handed a `JaypieBucketQueuedLambda`
+   */
+  public get worker(): JaypieBucketQueuedLambda | undefined {
+    return this._worker;
+  }
+}

--- a/packages/constructs/src/__tests__/issue-454-ses-intake.spec.ts
+++ b/packages/constructs/src/__tests__/issue-454-ses-intake.spec.ts
@@ -1,0 +1,362 @@
+/* eslint-disable vitest/expect-expect */
+// Template.hasResourceProperties and resourceCountIs assert; the rule cannot see it
+
+import { App, Duration, Stack } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import { HostedZone } from "aws-cdk-lib/aws-route53";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ConfigurationError } from "@jaypie/errors";
+
+import { CDK } from "../constants";
+import { JaypieBucketQueuedLambda } from "../JaypieBucketQueuedLambda.js";
+import { JaypieSesIntake } from "../JaypieSesIntake.js";
+
+const CODE = lambda.Code.fromInline("exports.handler = () => {}");
+const HOST = "intake.example.com";
+
+describe("issue 454: JaypieSesIntake", () => {
+  let app: App;
+  let stack: Stack;
+  let zone: HostedZone;
+
+  beforeEach(() => {
+    process.env.CDK_ENV_HOSTED_ZONE = "example.com";
+    app = new App();
+    stack = new Stack(app, "TestStack", {
+      env: { account: "123456789012", region: "us-east-1" },
+    });
+    zone = new HostedZone(stack, "Zone", { zoneName: "example.com" });
+  });
+
+  afterEach(() => {
+    delete process.env.CDK_ENV_HOSTED_ZONE;
+  });
+
+  describe("Base Cases", () => {
+    it("is a Construct", () => {
+      expect(JaypieSesIntake).toBeFunction();
+    });
+
+    it("creates identity, DNS, rule set, and activation", () => {
+      const construct = new JaypieSesIntake(stack, "Intake", {
+        code: CODE,
+        handler: "email.handler",
+        host: HOST,
+        zone,
+      });
+      const template = Template.fromStack(stack);
+
+      expect(construct.host).toBe(HOST);
+      template.hasResourceProperties("AWS::SES::EmailIdentity", {
+        EmailIdentity: HOST,
+      });
+      template.resourceCountIs("AWS::SES::ReceiptRuleSet", 1);
+      template.resourceCountIs("AWS::SES::ReceiptRule", 1);
+      template.resourceCountIs("Custom::AWS", 1);
+      // Three DKIM CNAMEs plus the MX record
+      template.resourceCountIs("AWS::Route53::RecordSet", 4);
+    });
+  });
+
+  describe("Error Conditions", () => {
+    it("throws when neither bucket nor code is provided", () => {
+      expect(
+        () => new JaypieSesIntake(stack, "Intake", { host: HOST, zone }),
+      ).toThrow(ConfigurationError);
+    });
+  });
+
+  describe("Features", () => {
+    it("creates its own worker from code and handler", () => {
+      const construct = new JaypieSesIntake(stack, "Intake", {
+        code: CODE,
+        handler: "email.handler",
+        host: HOST,
+        zone,
+      });
+      const template = Template.fromStack(stack);
+
+      expect(construct.worker).toBeDefined();
+      expect(construct.bucket).toBe(construct.worker!.bucket);
+      template.resourceCountIs("AWS::S3::Bucket", 1);
+      template.resourceCountIs("AWS::SQS::Queue", 1);
+      template.hasResourceProperties("AWS::Lambda::Function", {
+        Handler: "email.handler",
+      });
+    });
+
+    it("passes worker props through, including dlq", () => {
+      const construct = new JaypieSesIntake(stack, "Intake", {
+        code: CODE,
+        dlq: 3,
+        handler: "email.handler",
+        host: HOST,
+        timeout: Duration.seconds(60),
+        zone,
+      });
+      const template = Template.fromStack(stack);
+
+      expect(construct.worker!.dlq).toBeDefined();
+      template.resourceCountIs("AWS::SQS::Queue", 2);
+      template.hasResourceProperties("AWS::Lambda::Function", {
+        Timeout: 60,
+      });
+    });
+
+    it("attaches to an existing JaypieBucketQueuedLambda", () => {
+      const worker = new JaypieBucketQueuedLambda(stack, "Worker", {
+        code: CODE,
+        handler: "email.handler",
+      });
+      const construct = new JaypieSesIntake(stack, "Intake", {
+        bucket: worker,
+        host: HOST,
+        zone,
+      });
+      const template = Template.fromStack(stack);
+
+      expect(construct.worker).toBe(worker);
+      expect(construct.bucket).toBe(worker.bucket);
+      template.resourceCountIs("AWS::S3::Bucket", 1);
+    });
+
+    it("unwraps the wrapper so the S3 action attaches a bucket policy", () => {
+      const worker = new JaypieBucketQueuedLambda(stack, "Worker", {
+        code: CODE,
+        handler: "email.handler",
+      });
+      new JaypieSesIntake(stack, "Intake", {
+        bucket: worker,
+        host: HOST,
+        zone,
+      });
+      const template = Template.fromStack(stack);
+
+      // The action degrades to a warning with no policy when handed the wrapper
+      const [policy] = Object.values(
+        template.findResources("AWS::S3::BucketPolicy"),
+      );
+      const sesStatement = (
+        policy as any
+      ).Properties.PolicyDocument.Statement.find(
+        (statement: any) =>
+          statement.Principal?.Service === CDK.PRINCIPAL.SES ||
+          statement.Principal?.Service?.[0] === CDK.PRINCIPAL.SES,
+      );
+      expect(sesStatement).toBeDefined();
+      expect(sesStatement.Condition.StringEquals["aws:SourceAccount"]).toEqual({
+        Ref: "AWS::AccountId",
+      });
+    });
+
+    it("accepts a raw bucket", () => {
+      const bucket = new s3.Bucket(stack, "Raw");
+      const construct = new JaypieSesIntake(stack, "Intake", {
+        bucket,
+        host: HOST,
+        zone,
+      });
+
+      expect(construct.bucket).toBe(bucket);
+      expect(construct.worker).toBeUndefined();
+    });
+
+    it("writes under the inbound prefix by default", () => {
+      new JaypieSesIntake(stack, "Intake", {
+        code: CODE,
+        host: HOST,
+        zone,
+      });
+      const template = Template.fromStack(stack);
+
+      template.hasResourceProperties("AWS::SES::ReceiptRule", {
+        Rule: {
+          Actions: [
+            {
+              S3Action: {
+                ObjectKeyPrefix: CDK.SES.INTAKE.OBJECT_KEY_PREFIX,
+              },
+            },
+          ],
+          Recipients: [HOST],
+          ScanEnabled: true,
+        },
+      });
+    });
+
+    it("honors objectKeyPrefix, recipients, and scanEnabled", () => {
+      new JaypieSesIntake(stack, "Intake", {
+        code: CODE,
+        host: HOST,
+        objectKeyPrefix: "raw/",
+        recipients: ["support@example.com"],
+        scanEnabled: false,
+        zone,
+      });
+      const template = Template.fromStack(stack);
+
+      template.hasResourceProperties("AWS::SES::ReceiptRule", {
+        Rule: {
+          Actions: [{ S3Action: { ObjectKeyPrefix: "raw/" } }],
+          Recipients: ["support@example.com"],
+          ScanEnabled: false,
+        },
+      });
+    });
+
+    it("creates three DKIM CNAMEs at the configured TTL", () => {
+      new JaypieSesIntake(stack, "Intake", {
+        code: CODE,
+        host: HOST,
+        zone,
+      });
+      const template = Template.fromStack(stack);
+
+      const records = Object.values(
+        template.findResources("AWS::Route53::RecordSet"),
+      );
+      const cnames = records.filter(
+        (record: any) => record.Properties.Type === CDK.DNS.RECORD.CNAME,
+      );
+      expect(cnames).toHaveLength(CDK.SES.DKIM.RECORD_COUNT);
+      cnames.forEach((record: any) => {
+        expect(record.Properties.TTL).toBe(String(CDK.SES.DKIM.TTL));
+      });
+    });
+
+    it("accepts a numeric ttl", () => {
+      new JaypieSesIntake(stack, "Intake", {
+        code: CODE,
+        host: HOST,
+        ttl: 60,
+        zone,
+      });
+      const template = Template.fromStack(stack);
+
+      const cnames = Object.values(
+        template.findResources("AWS::Route53::RecordSet"),
+      ).filter(
+        (record: any) => record.Properties.Type === CDK.DNS.RECORD.CNAME,
+      );
+      cnames.forEach((record: any) => {
+        expect(record.Properties.TTL).toBe("60");
+      });
+    });
+
+    it("points MX at the region inbound SMTP endpoint", () => {
+      new JaypieSesIntake(stack, "Intake", {
+        code: CODE,
+        host: HOST,
+        zone,
+      });
+      const template = Template.fromStack(stack);
+
+      template.hasResourceProperties("AWS::Route53::RecordSet", {
+        Name: `${HOST}.`,
+        ResourceRecords: ["10 inbound-smtp.us-east-1.amazonaws.com"],
+        Type: CDK.DNS.RECORD.MX,
+      });
+    });
+
+    it("skips DKIM and MX when disabled", () => {
+      new JaypieSesIntake(stack, "Intake", {
+        code: CODE,
+        dkim: false,
+        host: HOST,
+        mx: false,
+        zone,
+      });
+      const template = Template.fromStack(stack);
+
+      template.resourceCountIs("AWS::Route53::RecordSet", 0);
+    });
+
+    it("skips activation when activate is false", () => {
+      new JaypieSesIntake(stack, "Intake", {
+        activate: false,
+        code: CODE,
+        host: HOST,
+        zone,
+      });
+      const template = Template.fromStack(stack);
+
+      template.resourceCountIs("Custom::AWS", 0);
+    });
+
+    it("deactivates on delete so the stack can be torn down", () => {
+      new JaypieSesIntake(stack, "Intake", {
+        code: CODE,
+        host: HOST,
+        zone,
+      });
+      const template = Template.fromStack(stack);
+
+      const custom = Object.values(template.findResources("Custom::AWS"))[0];
+      const onDelete = JSON.parse((custom as any).Properties.Delete);
+      expect(onDelete.action).toBe("setActiveReceiptRuleSet");
+      expect(onDelete.parameters).toEqual({});
+    });
+
+    it("names the rule set when ruleSetName is provided", () => {
+      new JaypieSesIntake(stack, "Intake", {
+        code: CODE,
+        host: HOST,
+        ruleSetName: "test-rule-set",
+        zone,
+      });
+      const template = Template.fromStack(stack);
+
+      template.hasResourceProperties("AWS::SES::ReceiptRuleSet", {
+        RuleSetName: "test-rule-set",
+      });
+    });
+
+    it("derives the host from the environment when omitted", () => {
+      const construct = new JaypieSesIntake(stack, "Intake", {
+        code: CODE,
+        zone,
+      });
+
+      expect(construct.host).toBe("intake.example.com");
+    });
+  });
+
+  describe("Specific Scenarios", () => {
+    it("orders the rule after the identity", () => {
+      new JaypieSesIntake(stack, "Intake", {
+        code: CODE,
+        host: HOST,
+        zone,
+      });
+      const template = Template.fromStack(stack);
+
+      const [rule] = Object.values(
+        template.findResources("AWS::SES::ReceiptRule"),
+      );
+      const identityLogicalId = Object.keys(
+        template.findResources("AWS::SES::EmailIdentity"),
+      )[0];
+      expect((rule as any).DependsOn).toContain(identityLogicalId);
+    });
+
+    it("does not double-create the identity when reused across scopes", () => {
+      new JaypieSesIntake(stack, "IntakeOne", {
+        code: CODE,
+        host: HOST,
+        zone,
+      });
+      new JaypieSesIntake(stack, "IntakeTwo", {
+        activate: false,
+        code: CODE,
+        host: "other.example.com",
+        zone,
+      });
+      const template = Template.fromStack(stack);
+
+      template.resourceCountIs("AWS::SES::EmailIdentity", 2);
+      template.resourceCountIs("AWS::SES::ReceiptRuleSet", 2);
+    });
+  });
+});

--- a/packages/constructs/src/__tests__/issue-454-ses-intake.spec.ts
+++ b/packages/constructs/src/__tests__/issue-454-ses-intake.spec.ts
@@ -16,12 +16,27 @@ import { JaypieSesIntake } from "../JaypieSesIntake.js";
 const CODE = lambda.Code.fromInline("exports.handler = () => {}");
 const HOST = "intake.example.com";
 
+// Every input envHostname reads, so the derived host does not depend on
+// whatever the ambient environment happens to set (CI sets PROJECT_ENV)
+const HOSTNAME_ENV_KEYS = [
+  "CDK_ENV_DOMAIN",
+  "CDK_ENV_HOSTED_ZONE",
+  "CDK_ENV_PERSONAL",
+  "CDK_ENV_SUBDOMAIN",
+  "PROJECT_ENV",
+] as const;
+
 describe("issue 454: JaypieSesIntake", () => {
   let app: App;
   let stack: Stack;
   let zone: HostedZone;
+  let priorEnv: Record<string, string | undefined>;
 
   beforeEach(() => {
+    priorEnv = Object.fromEntries(
+      HOSTNAME_ENV_KEYS.map((key) => [key, process.env[key]]),
+    );
+    HOSTNAME_ENV_KEYS.forEach((key) => delete process.env[key]);
     process.env.CDK_ENV_HOSTED_ZONE = "example.com";
     app = new App();
     stack = new Stack(app, "TestStack", {
@@ -31,7 +46,14 @@ describe("issue 454: JaypieSesIntake", () => {
   });
 
   afterEach(() => {
-    delete process.env.CDK_ENV_HOSTED_ZONE;
+    HOSTNAME_ENV_KEYS.forEach((key) => {
+      const value = priorEnv[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    });
   });
 
   describe("Base Cases", () => {
@@ -314,6 +336,26 @@ describe("issue 454: JaypieSesIntake", () => {
     });
 
     it("derives the host from the environment when omitted", () => {
+      const construct = new JaypieSesIntake(stack, "Intake", {
+        code: CODE,
+        zone,
+      });
+
+      expect(construct.host).toBe("intake.example.com");
+    });
+
+    it("includes the environment tier in the derived host", () => {
+      process.env.PROJECT_ENV = CDK.ENV.SANDBOX;
+      const construct = new JaypieSesIntake(stack, "Intake", {
+        code: CODE,
+        zone,
+      });
+
+      expect(construct.host).toBe("intake.sandbox.example.com");
+    });
+
+    it("drops the environment tier in production", () => {
+      process.env.PROJECT_ENV = CDK.ENV.PRODUCTION;
       const construct = new JaypieSesIntake(stack, "Intake", {
         code: CODE,
         zone,

--- a/packages/constructs/src/__tests__/issue-455-queue-dlq.spec.ts
+++ b/packages/constructs/src/__tests__/issue-455-queue-dlq.spec.ts
@@ -1,0 +1,244 @@
+/* eslint-disable vitest/expect-expect */
+// Template.hasResourceProperties and resourceCountIs assert; the rule cannot see it
+
+import { Duration, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as sqs from "aws-cdk-lib/aws-sqs";
+import { describe, expect, it } from "vitest";
+
+import { CDK } from "../constants";
+import { JaypieBucketQueuedLambda } from "../JaypieBucketQueuedLambda.js";
+import { JaypieQueuedLambda } from "../JaypieQueuedLambda.js";
+
+const CODE = lambda.Code.fromInline("exports.handler = () => {}");
+
+function sourceQueue(template: Template) {
+  const queues = Object.values(template.findResources("AWS::SQS::Queue"));
+  const source = queues.find((queue: any) => queue.Properties?.RedrivePolicy);
+  return source as any;
+}
+
+describe("issue 455: JaypieQueuedLambda dead-letter queue", () => {
+  describe("Base Cases", () => {
+    it("creates no dead-letter queue by default", () => {
+      const stack = new Stack();
+      const construct = new JaypieQueuedLambda(stack, "TestConstruct", {
+        code: CODE,
+        handler: "index.handler",
+      });
+      const template = Template.fromStack(stack);
+
+      expect(construct.dlq).toBeUndefined();
+      template.resourceCountIs("AWS::SQS::Queue", 1);
+      const queues = Object.values(template.findResources("AWS::SQS::Queue"));
+      expect((queues[0] as any).Properties.RedrivePolicy).toBeUndefined();
+    });
+  });
+
+  describe("Features", () => {
+    it("creates a dead-letter queue and redrive policy when dlq is true", () => {
+      const stack = new Stack();
+      const construct = new JaypieQueuedLambda(stack, "TestConstruct", {
+        code: CODE,
+        handler: "index.handler",
+        dlq: true,
+      });
+      const template = Template.fromStack(stack);
+
+      expect(construct.dlq).toBeDefined();
+      template.resourceCountIs("AWS::SQS::Queue", 2);
+      expect(sourceQueue(template).Properties.RedrivePolicy).toMatchObject({
+        maxReceiveCount: CDK.SQS.DLQ.MAX_RECEIVE_COUNT,
+      });
+    });
+
+    it("retains dead-letter messages for the SQS maximum by default", () => {
+      const stack = new Stack();
+      new JaypieQueuedLambda(stack, "TestConstruct", {
+        code: CODE,
+        handler: "index.handler",
+        dlq: true,
+      });
+      const template = Template.fromStack(stack);
+
+      template.hasResourceProperties("AWS::SQS::Queue", {
+        MessageRetentionPeriod: Duration.days(
+          CDK.SQS.DLQ.RETENTION_DAYS,
+        ).toSeconds(),
+      });
+    });
+
+    it("treats a number as maxReceiveCount", () => {
+      const stack = new Stack();
+      new JaypieQueuedLambda(stack, "TestConstruct", {
+        code: CODE,
+        handler: "index.handler",
+        dlq: 5,
+      });
+      const template = Template.fromStack(stack);
+
+      expect(sourceQueue(template).Properties.RedrivePolicy).toMatchObject({
+        maxReceiveCount: 5,
+      });
+    });
+
+    it("accepts explicit maxReceiveCount and retentionPeriod", () => {
+      const stack = new Stack();
+      new JaypieQueuedLambda(stack, "TestConstruct", {
+        code: CODE,
+        handler: "index.handler",
+        dlq: { maxReceiveCount: 4, retentionPeriod: Duration.days(7) },
+      });
+      const template = Template.fromStack(stack);
+
+      expect(sourceQueue(template).Properties.RedrivePolicy).toMatchObject({
+        maxReceiveCount: 4,
+      });
+      template.hasResourceProperties("AWS::SQS::Queue", {
+        MessageRetentionPeriod: Duration.days(7).toSeconds(),
+      });
+    });
+
+    it("accepts retentionPeriod as seconds", () => {
+      const stack = new Stack();
+      new JaypieQueuedLambda(stack, "TestConstruct", {
+        code: CODE,
+        handler: "index.handler",
+        dlq: { retentionPeriod: 3600 },
+      });
+      const template = Template.fromStack(stack);
+
+      template.hasResourceProperties("AWS::SQS::Queue", {
+        MessageRetentionPeriod: 3600,
+      });
+    });
+
+    it("matches the source queue fifo setting", () => {
+      const fifoStack = new Stack();
+      new JaypieQueuedLambda(fifoStack, "TestConstruct", {
+        code: CODE,
+        handler: "index.handler",
+        dlq: true,
+      });
+      const fifoQueues = Object.values(
+        Template.fromStack(fifoStack).findResources("AWS::SQS::Queue"),
+      );
+      expect(fifoQueues).toHaveLength(2);
+      fifoQueues.forEach((queue: any) => {
+        expect(queue.Properties.FifoQueue).toBe(true);
+      });
+
+      const standardStack = new Stack();
+      new JaypieQueuedLambda(standardStack, "TestConstruct", {
+        code: CODE,
+        handler: "index.handler",
+        dlq: true,
+        fifo: false,
+      });
+      const standardQueues = Object.values(
+        Template.fromStack(standardStack).findResources("AWS::SQS::Queue"),
+      );
+      expect(standardQueues).toHaveLength(2);
+      standardQueues.forEach((queue: any) => {
+        expect(queue.Properties.FifoQueue).toBeUndefined();
+      });
+    });
+
+    it("uses an existing queue when provided", () => {
+      const stack = new Stack();
+      const existing = new sqs.Queue(stack, "ExistingDlq", { fifo: true });
+      const construct = new JaypieQueuedLambda(stack, "TestConstruct", {
+        code: CODE,
+        handler: "index.handler",
+        dlq: { queue: existing },
+      });
+      const template = Template.fromStack(stack);
+
+      expect(construct.dlq).toBe(existing);
+      // Source queue plus the pre-existing queue; none created by the construct
+      template.resourceCountIs("AWS::SQS::Queue", 2);
+      expect(
+        sourceQueue(template).Properties.RedrivePolicy.deadLetterTargetArn[
+          "Fn::GetAtt"
+        ][0],
+      ).toMatch(/^ExistingDlq/);
+    });
+
+    it("tags the dead-letter queue like the source queue", () => {
+      const stack = new Stack();
+      new JaypieQueuedLambda(stack, "TestConstruct", {
+        code: CODE,
+        handler: "index.handler",
+        dlq: true,
+        roleTag: "TEST_ROLE",
+        serviceTag: "TEST_SERVICE",
+        vendorTag: "TEST_VENDOR",
+      });
+      const template = Template.fromStack(stack);
+
+      const queues = Object.values(template.findResources("AWS::SQS::Queue"));
+      expect(queues).toHaveLength(2);
+      queues.forEach((queue: any) => {
+        expect(queue.Properties.Tags).toEqual(
+          expect.arrayContaining([
+            { Key: CDK.TAG.ROLE, Value: "TEST_ROLE" },
+            { Key: CDK.TAG.SERVICE, Value: "TEST_SERVICE" },
+            { Key: CDK.TAG.VENDOR, Value: "TEST_VENDOR" },
+          ]),
+        );
+      });
+    });
+
+    it("applies the removal policy to the dead-letter queue it owns", () => {
+      const stack = new Stack();
+      const construct = new JaypieQueuedLambda(stack, "TestConstruct", {
+        code: CODE,
+        handler: "index.handler",
+        dlq: true,
+      });
+
+      construct.applyRemovalPolicy(RemovalPolicy.DESTROY);
+      const template = Template.fromStack(stack);
+
+      const queues = Object.values(template.findResources("AWS::SQS::Queue"));
+      expect(queues).toHaveLength(2);
+      queues.forEach((queue: any) => {
+        expect(queue.DeletionPolicy).toBe("Delete");
+      });
+    });
+
+    it("does not preserve the default visibility timeout regression", () => {
+      const stack = new Stack();
+      new JaypieQueuedLambda(stack, "TestConstruct", {
+        code: CODE,
+        handler: "index.handler",
+        visibilityTimeout: 120,
+      });
+      const template = Template.fromStack(stack);
+
+      template.hasResourceProperties("AWS::SQS::Queue", {
+        VisibilityTimeout: 120,
+      });
+    });
+  });
+
+  describe("Specific Scenarios", () => {
+    it("applies to JaypieBucketQueuedLambda by inheritance", () => {
+      const stack = new Stack();
+      const construct = new JaypieBucketQueuedLambda(stack, "TestConstruct", {
+        code: CODE,
+        handler: "index.handler",
+        dlq: 3,
+      });
+      const template = Template.fromStack(stack);
+
+      expect(construct.dlq).toBeDefined();
+      expect(construct.dlq!.fifo).toBe(false);
+      template.resourceCountIs("AWS::SQS::Queue", 2);
+      expect(sourceQueue(template).Properties.RedrivePolicy).toMatchObject({
+        maxReceiveCount: 3,
+      });
+    });
+  });
+});

--- a/packages/constructs/src/constants.ts
+++ b/packages/constructs/src/constants.ts
@@ -91,6 +91,7 @@ export const CDK = {
   },
   PRINCIPAL: {
     ROUTE53: "route53.amazonaws.com",
+    SES: "ses.amazonaws.com",
   },
   PRINCIPAL_TYPE: {
     GROUP: "GROUP",
@@ -117,6 +118,17 @@ export const CDK = {
     STORAGE: "storage",
     TOY: "toy",
   },
+  SES: {
+    DKIM: {
+      RECORD_COUNT: 3,
+      TTL: 1800, // 30 minutes; DKIM CNAMEs change only on identity replacement
+    },
+    INTAKE: {
+      COMPONENT: "intake",
+      OBJECT_KEY_PREFIX: "inbound/",
+    },
+    SMTP_HOSTNAME_PREFIX: "inbound-smtp",
+  },
   SERVICE: {
     DATADOG: "datadog",
     INFRASTRUCTURE: "infrastructure",
@@ -124,6 +136,12 @@ export const CDK = {
     NONE: "none",
     SSO: "sso",
     TRACE: "trace",
+  },
+  SQS: {
+    DLQ: {
+      MAX_RECEIVE_COUNT: 3,
+      RETENTION_DAYS: 14, // SQS maximum; a DLQ should outlive the source queue
+    },
   },
   TAG: {
     BUILD_DATE: "buildDate",

--- a/packages/constructs/src/index.ts
+++ b/packages/constructs/src/index.ts
@@ -7,7 +7,10 @@ export {
 } from "./JaypieAccountLoggingBucket";
 export { JaypieApiGateway, JaypieApiGatewayProps } from "./JaypieApiGateway";
 export { JaypieAppStack } from "./JaypieAppStack";
-export { JaypieBucketQueuedLambda } from "./JaypieBucketQueuedLambda";
+export {
+  JaypieBucketQueuedLambda,
+  JaypieBucketQueuedLambdaProps,
+} from "./JaypieBucketQueuedLambda";
 export { JaypieCertificate, JaypieCertificateProps } from "./JaypieCertificate";
 export {
   JaypieDatadogBucket,
@@ -53,8 +56,13 @@ export {
   JaypieOrganizationTrail,
   JaypieOrganizationTrailProps,
 } from "./JaypieOrganizationTrail";
-export { JaypieQueuedLambda } from "./JaypieQueuedLambda";
+export {
+  JaypieQueueDlqProps,
+  JaypieQueuedLambda,
+  JaypieQueuedLambdaProps,
+} from "./JaypieQueuedLambda";
 export { JaypieSecret, JaypieSecretProps } from "./JaypieSecret";
+export { JaypieSesIntake, JaypieSesIntakeProps } from "./JaypieSesIntake";
 export {
   AccountAssignments,
   JaypieSsoPermissions,

--- a/packages/mcp/CLAUDE.md
+++ b/packages/mcp/CLAUDE.md
@@ -111,10 +111,12 @@ Content...
 When adding new skills:
 1. Create `skills/<alias>.md` with lowercase alphanumeric alias (hyphens/underscores allowed)
 2. Add frontmatter with `description` and optionally `related` (comma-separated aliases)
-3. Run `npm run build -w packages/mcp` to copy skills to dist
-4. Skills are then available via `skill(alias)`
+3. Skills are immediately available via `skill(alias)` — no rebuild needed
 
-**Important**: Always rebuild after editing skills or release notes - files are copied to `dist/` during build.
+Skills and release notes are read from the **package root**, not `dist/`. The
+docs suite resolves `../../../skills` from `dist/suites/docs/`, and `files` in
+`package.json` ships both directories alongside `dist`. Only the per-suite
+`help.md` files are copied into `dist` by rollup.
 
 **Important**: Keep the skill category listings in sync across `skills/skills.md`, `skills/agents.md`, and the root `CLAUDE.md` Skills section. When adding or removing a skill alias, update all three.
 
@@ -148,8 +150,7 @@ summary: Consolidate 26 tools into 6 unified router-style tools
 When adding release notes:
 1. Create `release-notes/<package>/<version>.md` for each version bump
 2. Add frontmatter with `version`, `date`, and `summary`
-3. Run `npm run build -w packages/mcp` to include new notes
-4. Notes are then available via `release_notes("list")` and `release_notes("read", ...)`
+3. Notes are immediately available via `release_notes("list")` and `release_notes("read", ...)` — no rebuild needed
 
 ## Environment Variables
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.115",
+  "version": "0.8.116",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/constructs/1.2.75.md
+++ b/packages/mcp/release-notes/constructs/1.2.75.md
@@ -1,0 +1,66 @@
+---
+version: 1.2.75
+date: 2026-07-30
+summary: JaypieSesIntake construct for SES inbound email; optional DLQ on JaypieQueuedLambda
+---
+
+## Changes
+
+### `JaypieSesIntake` (#454)
+
+New construct packaging SES inbound email receiving: subdomain `EmailIdentity`,
+the three DKIM CNAMEs, an MX record, a `ReceiptRuleSet` with an S3 action, and
+rule-set activation.
+
+```typescript
+// Owns the worker
+new JaypieSesIntake(this, "Intake", {
+  code: "../api/dist",
+  handler: "email.handler",
+  tables: [table],
+  zone: "example.com",
+});
+
+// Attaches to an existing worker
+new JaypieSesIntake(this, "Intake", { bucket: worker, zone: "example.com" });
+```
+
+`bucket` accepts a `JaypieBucketQueuedLambda` or a raw `s3.IBucket`; the wrapper
+is unwrapped so `sesActions.S3` finds the bucket's `Policy` child and attaches
+the `ses.amazonaws.com` grant. Handed the wrapper directly, the action degrades
+to a synth-time warning and received mail fails to write.
+
+Operational constraints, documented in `skill("email")`:
+
+- One active receipt rule set per account/region — gate instantiation to one
+  environment per account.
+- Deleting the stack deactivates the rule set, disabling SES receiving
+  account/region-wide. Deactivation is mandatory: SES refuses to delete an
+  active rule set.
+- SES sandbox mode restricts sending only; receiving needs no production-access
+  request.
+
+### `dlq` on `JaypieQueuedLambda` (#455)
+
+Optional dead-letter queue and redrive policy on the construct's SQS queue.
+Inherited by `JaypieBucketQueuedLambda`.
+
+```typescript
+new JaypieQueuedLambda(this, "Worker", { code: "dist", dlq: true }); // maxReceiveCount 3
+new JaypieQueuedLambda(this, "Worker", { code: "dist", dlq: 5 });    // maxReceiveCount 5
+new JaypieQueuedLambda(this, "Worker", {
+  code: "dist",
+  dlq: { maxReceiveCount: 3, retentionPeriod: Duration.days(14) },
+});
+```
+
+The DLQ matches the source queue's `fifo` setting and is exposed as `.dlq` for
+alarming. `dlq` is distinct from the inherited `deadLetterQueue` prop, which
+configures the Lambda's asynchronous-invocation DLQ and does nothing for SQS
+event-source failures.
+
+### Other
+
+- `CDK.SES.*` and `CDK.SQS.DLQ.*` constants added; `CDK.PRINCIPAL.SES` added.
+- `JaypieBucketQueuedLambdaProps`, `JaypieQueuedLambdaProps`, and
+  `JaypieQueueDlqProps` are now exported from the package index.

--- a/packages/mcp/release-notes/mcp/0.8.116.md
+++ b/packages/mcp/release-notes/mcp/0.8.116.md
@@ -1,0 +1,16 @@
+---
+version: 0.8.116
+date: 2026-07-30
+summary: Add email skill; correct fabricated JaypieQueue and JaypieBucket in cdk and sqs skills
+---
+
+## Changes
+
+- New `email` skill covering `JaypieSesIntake`: props, the one-active-rule-set
+  and teardown constraints, why the DKIM CNAMEs are hand-built, and the
+  bucket-wrapper trap.
+- `sqs` and `cdk` skills documented `JaypieQueue` and `JaypieBucket`, neither of
+  which exists in `@jaypie/constructs`. Replaced with `JaypieQueuedLambda` and
+  `JaypieBucketQueuedLambda`, including the new `dlq` prop and the
+  `deadLetterQueue` naming trap.
+- Registered `email` in the `infrastructure`, `skills`, and `agents` listings.

--- a/packages/mcp/skills/agents.md
+++ b/packages/mcp/skills/agents.md
@@ -34,7 +34,7 @@ Complete stack styles, techniques, and traditions.
 
 Contents: index, releasenotes
 Development: apikey, documentation, errors, llm, logs, mdaml, mocks, monorepo, repokit, style, subpackages, tests, tools
-Infrastructure: apigateway, aws, cdk, cicd, datadog, dns, dynamodb, express, lambda, migrations, ports, secrets, sqs, streaming, variables, waf, web, websockets
+Infrastructure: apigateway, aws, cdk, cicd, datadog, dns, dynamodb, email, express, lambda, migrations, ports, secrets, sqs, streaming, variables, waf, web, websockets
 Patterns: api, fabric, handlers, models, repository, services, vocabulary
 Recipes: recipe-api-server
 Meta: issues, jaypie, mcp, skills

--- a/packages/mcp/skills/cdk.md
+++ b/packages/mcp/skills/cdk.md
@@ -49,34 +49,59 @@ For ESM bundles, use `.mjs` extension or include `package.json` with `"type": "m
 
 **CRITICAL**: When referencing `code: "../package/dist"`, the package must be built **before** CDK synth/deploy. In CI/CD, `npm run build` at the root handles this — but new packages must have a `build` script in their `package.json`. If the package is a build-time dependency of others, add it to `build:core-deps` in the root `package.json`. Without this, CI/CD fails with `"../package/dist" doesn't exist`.
 
-### JaypieQueue
+### JaypieQueuedLambda
 
-SQS queue with DLQ and Lambda trigger:
+SQS queue plus worker Lambda, wired together. FIFO by default. Opt into a
+dead-letter queue with `dlq`:
 
 ```typescript
-import { JaypieQueue } from "@jaypie/constructs";
+import { JaypieQueuedLambda } from "@jaypie/constructs";
 
-const queue = new JaypieQueue(this, "ProcessQueue", {
-  visibilityTimeout: Duration.seconds(60),
-  retentionPeriod: Duration.days(7),
+const worker = new JaypieQueuedLambda(this, "ProcessWorker", {
+  code: "../api/dist",
+  handler: "process.handler",
+  dlq: { maxReceiveCount: 3 },
+  visibilityTimeout: Duration.seconds(360),
 });
-
-// Connect to Lambda
-queue.addEventSource(handler);
 ```
 
-### JaypieBucket
+See `skill("sqs")` for redrive semantics and the `deadLetterQueue` naming trap.
 
-S3 bucket with encryption and lifecycle rules:
+### JaypieBucketQueuedLambda
+
+`JaypieQueuedLambda` plus an S3 bucket whose `OBJECT_CREATED` notifications feed
+the queue. The queue is standard, not FIFO — S3 cannot notify a FIFO queue.
 
 ```typescript
-import { JaypieBucket } from "@jaypie/constructs";
+import { JaypieBucketQueuedLambda } from "@jaypie/constructs";
 
-const bucket = new JaypieBucket(this, "AssetsBucket", {
-  encryption: BucketEncryption.S3_MANAGED,
-  lifecycleRules: [
-    { expiration: Duration.days(90), prefix: "temp/" }
-  ],
+const worker = new JaypieBucketQueuedLambda(this, "IngestWorker", {
+  code: "../api/dist",
+  handler: "ingest.handler",
+  bucketOptions: {
+    lifecycleRules: [{ expiration: Duration.days(365) }],
+  },
+});
+```
+
+`worker.bucket` is the real `s3.Bucket`. The construct itself implements
+`IBucket` by delegation, which is enough for grants but **not** for CDK code
+that reaches for the bucket's `Policy` child — hand those the unwrapped
+`worker.bucket`.
+
+### JaypieSesIntake
+
+SES inbound email receiving: domain identity, DKIM and MX records, a receipt
+rule set writing raw MIME to S3, and rule-set activation. See `skill("email")`.
+
+```typescript
+import { JaypieSesIntake } from "@jaypie/constructs";
+
+new JaypieSesIntake(this, "Intake", {
+  code: "../api/dist",
+  handler: "email.handler",
+  tables: [table],
+  zone: "example.com",
 });
 ```
 

--- a/packages/mcp/skills/email.md
+++ b/packages/mcp/skills/email.md
@@ -1,0 +1,127 @@
+---
+description: SES inbound email receiving with JaypieSesIntake
+related: aws, cdk, dns, lambda, sqs
+---
+
+# Inbound Email
+
+`JaypieSesIntake` packages SES inbound email receiving: a subdomain identity,
+its DKIM CNAMEs, an MX record, a receipt rule set writing raw MIME to S3, and
+rule-set activation.
+
+```typescript
+import { JaypieSesIntake } from "@jaypie/constructs";
+
+new JaypieSesIntake(this, "Intake", {
+  code: "../api/dist",
+  handler: "email.handler",
+  tables: [table],
+  zone: "example.com",
+});
+```
+
+The construct builds a `JaypieBucketQueuedLambda` from the Lambda props it is
+given: SES writes each message to S3, the bucket's `OBJECT_CREATED` notification
+queues it, and the worker parses the MIME.
+
+To attach to a worker built elsewhere, pass `bucket` instead:
+
+```typescript
+const worker = new JaypieBucketQueuedLambda(this, "EmailWorker", { ... });
+
+new JaypieSesIntake(this, "Intake", { bucket: worker, zone: "example.com" });
+```
+
+`bucket` accepts the `JaypieBucketQueuedLambda` wrapper or a raw `s3.IBucket`;
+the wrapper is unwrapped internally (see "The wrapper trap" below).
+
+## Props
+
+| Prop | Default | Description |
+|------|---------|-------------|
+| `activate` | `true` | Make this the account/region's active receipt rule set |
+| `bucket` | — | Existing destination; omit to have the construct build a worker from `code` |
+| `dkim` | `true` | Create the three DKIM CNAMEs |
+| `host` | `envHostname({ component: "intake" })` | Fully-qualified receiving domain |
+| `mx` | `true` | Create the MX record |
+| `objectKeyPrefix` | `"inbound/"` | S3 key prefix for stored messages |
+| `recipients` | `[host]` | Recipients the rule matches |
+| `ruleSetName` | CloudFormation-generated | Explicit rule set name |
+| `scanEnabled` | `true` | Run SES spam and virus scanning |
+| `ttl` | 1800 | TTL for the DKIM CNAMEs |
+| `zone` | `CDK_ENV_HOSTED_ZONE` | Hosted zone owning DKIM and MX |
+
+All `JaypieBucketQueuedLambdaProps` pass through to the worker the construct
+creates (`code`, `handler`, `tables`, `secrets`, `timeout`, `dlq`, and so on).
+
+Accessors: `bucket`, `host`, `identity`, `rule`, `ruleSet`, `worker`.
+
+## Operational Constraints
+
+**One active receipt rule set per account/region.** Gate instantiation so
+exactly one environment per AWS account owns receiving — an environment
+variable checked in `app.ts` is the usual approach. A second stack that
+activates its own rule set silently takes over from the first.
+
+**Teardown disables receiving account-wide.** CloudFormation has no rule-set
+activation resource, so activation runs through an `AwsCustomResource` whose
+`onDelete` deactivates. It has to: SES refuses to delete an active rule set, so
+without deactivation the stack is undeletable. The consequence is that deleting
+this stack turns off SES receiving for the whole account/region, not just this
+domain.
+
+**SES sandbox mode restricts sending only.** Receiving needs no
+production-access request.
+
+## Why the DNS Records Are Hand-Built
+
+`Identity.domain(subdomain)` creates no DNS records. `Identity.publicHostedZone(zone)`
+does, but it verifies the zone apex rather than the subdomain, which is the
+wrong identity. So the construct creates the three DKIM CNAMEs itself.
+
+They are `CfnRecordSet`, not the L2 `CnameRecord`: the L2's name qualification
+cannot handle the identity's unresolved tokens. This is the same pattern CDK's
+own `EasyDkim.bind` uses.
+
+Those CNAMEs resolving **is** SESv2 identity verification. There is no TXT
+record in this flow. Until they resolve, SES rejects mail for the domain.
+
+## The Wrapper Trap
+
+`sesActions.S3` must receive the real `s3.Bucket`. It locates the bucket's
+`Policy` child to attach the `ses.amazonaws.com` + `aws:SourceAccount` grant and
+the CloudFormation ordering dependency. Handed a `JaypieBucketQueuedLambda` (an
+`IBucket` by delegation, but not the bucket itself), the lookup misses and the
+action degrades to a synth-time warning with no policy and no dependency —
+received mail then fails to write.
+
+`JaypieSesIntake` unwraps `bucket` for you. Reaching for `sesActions.S3`
+directly means passing `worker.bucket`, never `worker`.
+
+## Handler
+
+The worker receives SQS records wrapping S3 event notifications. Read the object
+to get raw MIME, then parse.
+
+```typescript
+import { getMessages } from "@jaypie/aws";
+
+export const handler = lambdaHandler(async ({ event }) => {
+  for (const message of getMessages(event)) {
+    for (const record of message.Records ?? []) {
+      const key = decodeURIComponent(record.s3.object.key.replace(/\+/g, " "));
+      // fetch from process.env.CDK_ENV_BUCKET_NAME, parse MIME, file the message
+    }
+  }
+});
+```
+
+Pair `dlq` with the worker so unparseable MIME stops after `maxReceiveCount`
+instead of retrying until retention lapses. Without it, per-record `try/catch`
+is the only defense, and it swallows transient failures too. See `skill("sqs")`.
+
+## See Also
+
+- **`skill("cdk")`** — construct catalog
+- **`skill("dns")`** — hosted zones and record management
+- **`skill("sqs")`** — queue constructs and dead-letter queues

--- a/packages/mcp/skills/infrastructure.md
+++ b/packages/mcp/skills/infrastructure.md
@@ -1,6 +1,6 @@
 ---
 description: AWS, CDK, CI/CD, and observability
-related: aws, cdk, cicd, cicd-actions, cicd-deploy, cicd-environments, datadog, dns, dynamodb, secrets, variables, web, websockets
+related: aws, cdk, cicd, cicd-actions, cicd-deploy, cicd-environments, datadog, dns, dynamodb, email, secrets, variables, web, websockets
 ---
 
 # Infrastructure
@@ -20,6 +20,7 @@ Cloud infrastructure and deployment patterns.
 | `datadog` | Datadog and observability |
 | `dns` | DNS and domain configuration |
 | `dynamodb` | DynamoDB patterns and queries |
+| `email` | SES inbound email receiving |
 | `migrations` | DynamoDB migration custom resources |
 | `secrets` | AWS Secrets Manager |
 | `variables` | Environment variables reference |

--- a/packages/mcp/skills/skills.md
+++ b/packages/mcp/skills/skills.md
@@ -17,7 +17,7 @@ Look up skills by alias: `mcp__jaypie__skill(alias)`
 |----------|--------|
 | contents | index, releasenotes |
 | development | apikey, documentation, errors, llm, logs, mdaml, mocks, monorepo, repokit, style, subpackages, tests, tools |
-| infrastructure | apigateway, aws, cdk, cicd, datadog, dns, dynamodb, express, lambda, migrations, ports, secrets, sqs, streaming, variables, waf, web, websockets |
+| infrastructure | apigateway, aws, cdk, cicd, datadog, dns, dynamodb, email, express, lambda, migrations, ports, secrets, sqs, streaming, variables, waf, web, websockets |
 | patterns | api, fabric, handlers, models, repository, services, vocabulary |
 | recipes | recipe-api-server |
 | meta | issues, jaypie, mcp, skills |

--- a/packages/mcp/skills/sqs.md
+++ b/packages/mcp/skills/sqs.md
@@ -44,37 +44,87 @@ const messages = getMessages(event); // Returns array of parsed bodies
 const message = getSingletonMessage(event);
 ```
 
-## CDK: JaypieQueue
+## CDK: JaypieQueuedLambda
 
-SQS queue with DLQ and Lambda trigger:
+Queue and worker Lambda in one construct. FIFO by default; the queue URL is
+injected as `CDK_ENV_QUEUE_URL` and the Lambda is granted send and consume.
 
 ```typescript
-import { JaypieQueue } from "@jaypie/constructs";
+import { JaypieQueuedLambda } from "@jaypie/constructs";
 
-const queue = new JaypieQueue(this, "ProcessQueue", {
-  visibilityTimeout: Duration.seconds(60),
-  retentionPeriod: Duration.days(7),
+const worker = new JaypieQueuedLambda(this, "ProcessWorker", {
+  code: "../api/dist",
+  handler: "process.handler",
+  batchSize: 1,
+  visibilityTimeout: Duration.seconds(360),
 });
-
-// Connect to Lambda
-queue.addEventSource(handler);
 ```
 
-### Wiring Queue URL to Lambda
+`JaypieBucketQueuedLambda` extends it with an S3 bucket whose `OBJECT_CREATED`
+notifications feed the queue (standard, not FIFO — S3 cannot notify a FIFO
+queue).
+
+### Dead-Letter Queue
+
+Without a redrive policy a poison message retries until retention lapses, which
+pushes consumers into swallowing per-record errors in-handler. That conflates
+"this record is bad" with "this record failed transiently", and the transient
+case then drops silently. `dlq` adds the dead-letter queue and redrive policy:
 
 ```typescript
-import { JaypieLambda, JaypieQueue } from "@jaypie/constructs";
+new JaypieQueuedLambda(this, "Worker", { code: "dist", dlq: true }); // maxReceiveCount 3
+new JaypieQueuedLambda(this, "Worker", { code: "dist", dlq: 5 });    // maxReceiveCount 5
+new JaypieQueuedLambda(this, "Worker", {
+  code: "dist",
+  dlq: { maxReceiveCount: 3, retentionPeriod: Duration.days(14) },
+});
+```
 
-const queue = new JaypieQueue(this, "ProcessQueue");
+| Value | Meaning |
+|-------|---------|
+| `true` | Create a DLQ with `maxReceiveCount` 3 and 14-day retention |
+| number | Shorthand for `{ maxReceiveCount }` |
+| object | `maxReceiveCount`, `retentionPeriod`, or an existing `queue` |
 
-const handler = new JaypieLambda(this, "Handler", {
-  entry: "src/handler.ts",
-  environment: {
-    CDK_ENV_QUEUE_URL: queue.queueUrl,
-  },
+The DLQ matches the source queue's `fifo` setting; SQS rejects a redrive policy
+across the FIFO boundary. An existing `queue` must match too.
+
+Alarm on it. A dead-letter queue nobody watches is a place messages go to be
+ignored:
+
+```typescript
+new cloudwatch.Alarm(this, "WorkerDlqDepth", {
+  metric: worker.dlq!.metricApproximateNumberOfMessagesVisible(),
+  threshold: 1,
+  evaluationPeriods: 1,
+});
+```
+
+**Naming trap**: `dlq` governs the *queue feeding the Lambda*. The separate
+`deadLetterQueue` prop, inherited from `JaypieLambdaProps`, is the Lambda's
+*asynchronous-invocation* DLQ and does nothing for SQS event-source failures.
+
+`maxReceiveCount` guidance: pick a number that expires before the work does.
+Discord interaction tokens expire in 15 minutes, so 3-5 fits; unlimited
+redelivery burns invocations for nothing.
+
+### Wiring Queue URL to a Separate Lambda
+
+```typescript
+import { JaypieLambda, JaypieQueuedLambda } from "@jaypie/constructs";
+
+const worker = new JaypieQueuedLambda(this, "ProcessWorker", {
+  code: "../api/dist",
+  handler: "process.handler",
 });
 
-queue.grantSendMessages(handler);
+const api = new JaypieLambda(this, "Api", {
+  code: "../api/dist",
+  handler: "index.handler",
+  environment: { CDK_ENV_QUEUE_URL: worker.queueUrl },
+});
+
+worker.grantSendMessages(api);
 ```
 
 ### Resource Naming


### PR DESCRIPTION
Closes #454, closes #455.

## `JaypieSesIntake` (#454)

New construct packaging SES inbound email receiving: subdomain `EmailIdentity`, three DKIM `CfnRecordSet` CNAMEs, an MX record, a `ReceiptRuleSet` with an S3 action, and rule-set activation via `AwsCustomResource`.

```typescript
// Owns the worker
new JaypieSesIntake(this, "Intake", {
  code: "../api/dist",
  handler: "email.handler",
  tables: [table],
  zone: "example.com",
});

// Attaches to an existing worker
new JaypieSesIntake(this, "Intake", { bucket: worker, zone: "example.com" });
```

`bucket` accepts a `JaypieBucketQueuedLambda` or a raw `s3.IBucket`. The wrapper is unwrapped so `sesActions.S3` finds the bucket's `Policy` child and attaches the `ses.amazonaws.com` + `aws:SourceAccount` grant; handed the wrapper directly, the action degrades to a synth-time warning and received mail fails to write. A test asserts the resulting bucket policy, so the unwrap cannot regress silently.

Toggles for `activate`, `dkim`, and `mx` exist because each carries an operational cost. Defaults match the deployed reference stack.

Operational constraints, documented in the new `skill("email")`:

- One active receipt rule set per account/region — gate instantiation to one environment per account.
- Deleting the stack deactivates the rule set, disabling SES receiving account/region-wide. Deactivation is mandatory: SES refuses to delete an active rule set.
- SES sandbox mode restricts sending only; receiving needs no production-access request.

## `dlq` on `JaypieQueuedLambda` (#455)

```typescript
dlq: true                                        // maxReceiveCount 3, 14d retention
dlq: 5                                           // shorthand for maxReceiveCount
dlq: { maxReceiveCount, retentionPeriod, queue }  // full control
worker.dlq                                        // sqs.IQueue | undefined
```

The DLQ matches the source queue's `fifo` setting (SQS rejects a redrive policy across that boundary), carries the same role/service/vendor tags, and participates in `applyRemovalPolicy` only when the construct owns it. `JaypieBucketQueuedLambda` inherits it.

Named `dlq` rather than `deadLetterQueue` because `JaypieLambdaProps` already defines `deadLetterQueue` as the Lambda async-invoke DLQ. Both now coexist with distinct meanings, documented at each declaration.

## Documentation

- New `skill("email")` covering props, the operational constraints above, why the DKIM records are hand-built, and the wrapper trap.
- `skill("cdk")` and `skill("sqs")` documented `JaypieQueue` and `JaypieBucket`, neither of which exists in the package. Replaced with the real constructs plus the `dlq` prop.
- `packages/mcp/CLAUDE.md` claimed skills and release notes are copied to `dist` during build. Rollup copies only per-suite `help.md`; the docs suite reads both from the package root. Corrected and verified against the built server.

## Verification

32 new tests. Full suite: 4050 passed, 80 skipped, 7 todo. Typecheck, build, and lint clean.

Versions: `@jaypie/constructs` 1.2.75, `@jaypie/mcp` 0.8.116, with release notes and lockfile updated. `jaypie` does not depend on `@jaypie/constructs`, so no umbrella bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ybb2kSpiVsqoWJCy9R5Av8