### PR TITLE
feat(constructs)!: default waf to false

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14935,7 +14935,7 @@
     },
     "packages/constructs": {
       "name": "@jaypie/constructs",
-      "version": "1.2.75",
+      "version": "1.2.76",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*",
@@ -15545,7 +15545,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.117",
+      "version": "0.8.118",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.3.3",

--- a/packages/constructs/CLAUDE.md
+++ b/packages/constructs/CLAUDE.md
@@ -302,14 +302,14 @@ new JaypieDistribution(this, "Dist", {
 
 #### WAF (Web Application Firewall)
 
-`JaypieDistribution` attaches a WAFv2 WebACL by default with AWSManagedRulesCommonRuleSet, AWSManagedRulesKnownBadInputsRuleSet, IP rate limiting (2000/5min), and WAF logging to S3 with Datadog forwarding.
+`JaypieDistribution` attaches a WAFv2 WebACL when `waf` is set. WAF is off by default; `waf: true` enables AWSManagedRulesCommonRuleSet, AWSManagedRulesKnownBadInputsRuleSet, IP rate limiting (2000/5min), and WAF logging to S3 with Datadog forwarding. `JaypieWebDeploymentBucket` follows the same default.
 
 ```typescript
-// Default: WAF enabled with logging
+// Default: no WAF
 new JaypieDistribution(this, "Dist", { handler });
 
-// Disable WAF
-new JaypieDistribution(this, "Dist", { handler, waf: false });
+// Enable WAF with logging
+new JaypieDistribution(this, "Dist", { handler, waf: true });
 
 // Customize
 new JaypieDistribution(this, "Dist", {

--- a/packages/constructs/package.json
+++ b/packages/constructs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/constructs",
-  "version": "1.2.75",
+  "version": "1.2.76",
   "description": "CDK constructs for Jaypie applications",
   "repository": {
     "type": "git",

--- a/packages/constructs/src/JaypieDistribution.ts
+++ b/packages/constructs/src/JaypieDistribution.ts
@@ -58,7 +58,7 @@ export interface JaypieWafConfig {
    * so multiple JaypieDistribution instances can coexist in the same
    * account/env without S3/WAFv2 name collisions.
    *
-   * Pass `waf: true` (or omit) to retain the legacy, non-namespaced names.
+   * Pass `waf: true` to retain the legacy, non-namespaced names.
    */
   name: string;
 
@@ -296,10 +296,10 @@ export interface JaypieDistributionProps extends Omit<
   serviceTag?: string;
   /**
    * WAF WebACL configuration for the CloudFront distribution.
-   * - true/undefined: create and attach a WebACL with sensible defaults
-   * - false: disable WAF
+   * - true: create and attach a WebACL with sensible defaults
+   * - false/undefined: disable WAF
    * - JaypieWafConfig: customize WAF behavior
-   * @default true
+   * @default false
    */
   waf?: boolean | JaypieWafConfig;
   /**
@@ -346,7 +346,7 @@ export class JaypieDistribution
       securityHeaders: securityHeadersProp,
       serviceTag,
       streaming = false,
-      waf: wafProp = true,
+      waf: wafProp = false,
       zone: propsZone,
       ...distributionProps
     } = props;

--- a/packages/constructs/src/JaypieWebDeploymentBucket.ts
+++ b/packages/constructs/src/JaypieWebDeploymentBucket.ts
@@ -130,12 +130,12 @@ export interface JaypieWebDeploymentBucketProps extends s3.BucketProps {
   securityHeaders?: boolean | SecurityHeadersOverrides;
   /**
    * WAF WebACL configuration for the CloudFront distribution.
-   * - true/undefined: create and attach a WebACL with sensible defaults; the
-   *   construct id is used to namespace the WebACL and WAF log bucket
-   * - false: disable WAF
+   * - true: create and attach a WebACL with sensible defaults; the construct
+   *   id is used to namespace the WebACL and WAF log bucket
+   * - false/undefined: disable WAF
    * - JaypieWebDeploymentBucketWafConfig: customize WAF behavior; if `name`
    *   is omitted the construct id is used
-   * @default true
+   * @default false
    */
   waf?: boolean | JaypieWebDeploymentBucketWafConfig;
   /**
@@ -183,7 +183,7 @@ export class JaypieWebDeploymentBucket extends Construct implements s3.IBucket {
       responseHeadersPolicy: responseHeadersPolicyProp,
       roleTag: roleTagProp,
       securityHeaders: securityHeadersProp,
-      waf: wafProp = true,
+      waf: wafProp = false,
       zone: propsZone,
       ...bucketProps
     } = props;

--- a/packages/constructs/src/__tests__/JaypieDistribution.spec.ts
+++ b/packages/constructs/src/__tests__/JaypieDistribution.spec.ts
@@ -736,8 +736,8 @@ describe("JaypieDistribution", () => {
       const template = Template.fromStack(stack);
 
       expect(construct.logBucket).toBeDefined();
-      // Should have three S3 buckets: the origin bucket, the CF log bucket, and the WAF log bucket
-      template.resourceCountIs("AWS::S3::Bucket", 3);
+      // Should have two S3 buckets: the origin bucket and the CF log bucket
+      template.resourceCountIs("AWS::S3::Bucket", 2);
     });
 
     it("configures distribution with logging enabled", () => {
@@ -818,8 +818,8 @@ describe("JaypieDistribution", () => {
       const template = Template.fromStack(stack);
 
       expect(construct.logBucket).toBeUndefined();
-      // Should have the origin bucket and the WAF log bucket, no CF log bucket
-      template.resourceCountIs("AWS::S3::Bucket", 2);
+      // Should have only the origin bucket, no CF log bucket
+      template.resourceCountIs("AWS::S3::Bucket", 1);
 
       const distribution = findDistribution(template);
       expect(
@@ -866,8 +866,8 @@ describe("JaypieDistribution", () => {
         });
         const template = Template.fromStack(stack);
 
-        // Should have origin bucket + WAF log bucket (CF log bucket is imported)
-        template.resourceCountIs("AWS::S3::Bucket", 2);
+        // Should have only the origin bucket (CF log bucket is imported)
+        template.resourceCountIs("AWS::S3::Bucket", 1);
 
         // logBucket should be set
         expect(construct.logBucket).toBeDefined();
@@ -890,8 +890,8 @@ describe("JaypieDistribution", () => {
         });
         const template = Template.fromStack(stack);
 
-        // Origin bucket + WAF log bucket (CF log bucket imported by name)
-        template.resourceCountIs("AWS::S3::Bucket", 2);
+        // Origin bucket only (CF log bucket imported by name)
+        template.resourceCountIs("AWS::S3::Bucket", 1);
 
         // logBucket should be set
         expect(construct.logBucket).toBeDefined();
@@ -914,8 +914,8 @@ describe("JaypieDistribution", () => {
         });
         const template = Template.fromStack(stack);
 
-        // Origin bucket + WAF log bucket (CF log bucket imported by export)
-        template.resourceCountIs("AWS::S3::Bucket", 2);
+        // Origin bucket only (CF log bucket imported by export)
+        template.resourceCountIs("AWS::S3::Bucket", 1);
 
         // logBucket should be set
         expect(construct.logBucket).toBeDefined();
@@ -942,8 +942,8 @@ describe("JaypieDistribution", () => {
         });
         const template = Template.fromStack(stack);
 
-        // Should have three buckets: origin, external log bucket, and WAF log bucket
-        template.resourceCountIs("AWS::S3::Bucket", 3);
+        // Should have two buckets: origin and external log bucket
+        template.resourceCountIs("AWS::S3::Bucket", 2);
 
         // logBucket should be the external bucket
         expect(construct.logBucket).toBe(externalLogBucket);
@@ -987,8 +987,8 @@ describe("JaypieDistribution", () => {
         });
         const template = Template.fromStack(stack);
 
-        // Origin bucket + WAF log bucket (CF log bucket imported, no new CF log bucket)
-        template.resourceCountIs("AWS::S3::Bucket", 2);
+        // Origin bucket only (CF log bucket imported, no new CF log bucket)
+        template.resourceCountIs("AWS::S3::Bucket", 1);
 
         // logBucket should still be set (external bucket)
         expect(construct.logBucket).toBeDefined();
@@ -1431,13 +1431,28 @@ describe("JaypieDistribution", () => {
   });
 
   describe("WAF", () => {
-    it("creates a WebACL by default", () => {
+    it("creates no WebACL by default", () => {
       const stack = new Stack();
       const bucket = new s3.Bucket(stack, "TestBucket");
       const origin = origins.S3BucketOrigin.withOriginAccessControl(bucket);
 
       const construct = new JaypieDistribution(stack, "TestDistribution", {
         handler: origin,
+      });
+      const template = Template.fromStack(stack);
+
+      expect(construct.webAcl).toBeUndefined();
+      template.resourceCountIs("AWS::WAFv2::WebACL", 0);
+    });
+
+    it("creates a WebACL with waf: true", () => {
+      const stack = new Stack();
+      const bucket = new s3.Bucket(stack, "TestBucket");
+      const origin = origins.S3BucketOrigin.withOriginAccessControl(bucket);
+
+      const construct = new JaypieDistribution(stack, "TestDistribution", {
+        handler: origin,
+        waf: true,
       });
       const template = Template.fromStack(stack);
 
@@ -1452,6 +1467,7 @@ describe("JaypieDistribution", () => {
 
       new JaypieDistribution(stack, "TestDistribution", {
         handler: origin,
+        waf: true,
       });
       const template = Template.fromStack(stack);
 
@@ -1466,6 +1482,7 @@ describe("JaypieDistribution", () => {
 
       new JaypieDistribution(stack, "TestDistribution", {
         handler: origin,
+        waf: true,
       });
       const template = Template.fromStack(stack);
 
@@ -1491,6 +1508,7 @@ describe("JaypieDistribution", () => {
 
       new JaypieDistribution(stack, "TestDistribution", {
         handler: origin,
+        waf: true,
       });
       const template = Template.fromStack(stack);
 
@@ -1510,6 +1528,7 @@ describe("JaypieDistribution", () => {
 
       new JaypieDistribution(stack, "TestDistribution", {
         handler: origin,
+        waf: true,
       });
       const template = Template.fromStack(stack);
 
@@ -1535,6 +1554,7 @@ describe("JaypieDistribution", () => {
 
       new JaypieDistribution(stack, "TestDistribution", {
         handler: origin,
+        waf: true,
       });
       const template = Template.fromStack(stack);
 
@@ -2257,7 +2277,22 @@ describe("JaypieDistribution", () => {
   });
 
   describe("WAF Logging", () => {
-    it("creates WAF logging bucket and config by default", () => {
+    it("creates WAF logging bucket and config when WAF is enabled", () => {
+      const stack = new Stack();
+      const bucket = new s3.Bucket(stack, "TestBucket");
+      const origin = origins.S3BucketOrigin.withOriginAccessControl(bucket);
+
+      const construct = new JaypieDistribution(stack, "TestDistribution", {
+        handler: origin,
+        waf: true,
+      });
+      const template = Template.fromStack(stack);
+
+      expect(construct.wafLogBucket).toBeDefined();
+      template.resourceCountIs("AWS::WAFv2::LoggingConfiguration", 1);
+    });
+
+    it("creates no WAF logging bucket when WAF is disabled by default", () => {
       const stack = new Stack();
       const bucket = new s3.Bucket(stack, "TestBucket");
       const origin = origins.S3BucketOrigin.withOriginAccessControl(bucket);
@@ -2267,8 +2302,8 @@ describe("JaypieDistribution", () => {
       });
       const template = Template.fromStack(stack);
 
-      expect(construct.wafLogBucket).toBeDefined();
-      template.resourceCountIs("AWS::WAFv2::LoggingConfiguration", 1);
+      expect(construct.wafLogBucket).toBeUndefined();
+      template.resourceCountIs("AWS::WAFv2::LoggingConfiguration", 0);
     });
 
     it("creates bucket with aws-waf-logs- prefix", () => {
@@ -2278,6 +2313,7 @@ describe("JaypieDistribution", () => {
 
       new JaypieDistribution(stack, "TestDistribution", {
         handler: origin,
+        waf: true,
       });
       const template = Template.fromStack(stack);
 

--- a/packages/constructs/src/__tests__/JaypieWebDeploymentBucket.spec.ts
+++ b/packages/constructs/src/__tests__/JaypieWebDeploymentBucket.spec.ts
@@ -59,7 +59,7 @@ describe("JaypieWebDeploymentBucket", () => {
       template.resourceCountIs("AWS::WAFv2::WebACL", 0);
     });
 
-    it("creates distribution, headers, log bucket, and WAF with host+zone", () => {
+    it("creates distribution, headers, and log bucket with host+zone", () => {
       const { stack, zone } = makeStack();
 
       const construct = new JaypieWebDeploymentBucket(stack, "Web", {
@@ -71,11 +71,28 @@ describe("JaypieWebDeploymentBucket", () => {
       expect(construct.distribution).toBeDefined();
       expect(construct.responseHeadersPolicy).toBeDefined();
       expect(construct.logBucket).toBeDefined();
-      expect(construct.webAcl).toBeDefined();
-      expect(construct.wafLogBucket).toBeDefined();
+      expect(construct.webAcl).toBeUndefined();
+      expect(construct.wafLogBucket).toBeUndefined();
 
       template.hasResource("AWS::CloudFront::Distribution", {});
       template.hasResource("AWS::CloudFront::ResponseHeadersPolicy", {});
+      template.resourceCountIs("AWS::WAFv2::WebACL", 0);
+      template.resourceCountIs("AWS::WAFv2::LoggingConfiguration", 0);
+    });
+
+    it("creates WAF with host+zone and waf: true", () => {
+      const { stack, zone } = makeStack();
+
+      const construct = new JaypieWebDeploymentBucket(stack, "Web", {
+        host: "app.example.com",
+        waf: true,
+        zone,
+      });
+      const template = Template.fromStack(stack);
+
+      expect(construct.webAcl).toBeDefined();
+      expect(construct.wafLogBucket).toBeDefined();
+
       template.hasResource("AWS::WAFv2::WebACL", {});
       template.hasResource("AWS::WAFv2::LoggingConfiguration", {});
     });
@@ -168,11 +185,12 @@ describe("JaypieWebDeploymentBucket", () => {
   });
 
   describe("WAF", () => {
-    it("creates a WebACL named after the construct id by default", () => {
+    it("creates a WebACL named after the construct id with waf: true", () => {
       const { stack, zone } = makeStack();
 
       new JaypieWebDeploymentBucket(stack, "MyWeb", {
         host: "app.example.com",
+        waf: true,
         zone,
       });
       const template = Template.fromStack(stack);
@@ -182,6 +200,19 @@ describe("JaypieWebDeploymentBucket", () => {
           Name: Match.stringLikeRegexp("MyWeb-WebAcl"),
         }),
       ).not.toThrow();
+    });
+
+    it("creates no WebACL by default", () => {
+      const { stack, zone } = makeStack();
+
+      const construct = new JaypieWebDeploymentBucket(stack, "Web", {
+        host: "app.example.com",
+        zone,
+      });
+      const template = Template.fromStack(stack);
+
+      expect(construct.webAcl).toBeUndefined();
+      template.resourceCountIs("AWS::WAFv2::WebACL", 0);
     });
 
     it("disables WAF when waf is false", () => {
@@ -282,6 +313,7 @@ describe("JaypieWebDeploymentBucket", () => {
 
       new JaypieWebDeploymentBucket(stack, "DocumentationBucket", {
         host: "app.example.com",
+        waf: true,
         zone,
       });
       const template = Template.fromStack(stack);
@@ -348,8 +380,8 @@ describe("JaypieWebDeploymentBucket", () => {
       const template = Template.fromStack(stack);
 
       expect(construct.logBucket).toBeDefined();
-      // DestinationBucket + access LogBucket + WafLogBucket
-      template.resourceCountIs("AWS::S3::Bucket", 3);
+      // DestinationBucket + access LogBucket
+      template.resourceCountIs("AWS::S3::Bucket", 2);
     });
 
     it("skips creating an access log bucket when destination is false", () => {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.117",
+  "version": "0.8.118",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/constructs/1.2.76.md
+++ b/packages/mcp/release-notes/constructs/1.2.76.md
@@ -1,0 +1,25 @@
+---
+version: 1.2.76
+date: 2026-07-31
+summary: WAF now defaults to false on JaypieDistribution and JaypieWebDeploymentBucket
+---
+
+## Changes
+
+- `JaypieDistribution` and `JaypieWebDeploymentBucket` no longer create a WAFv2
+  WebACL by default. `waf` defaults to `false`.
+- Set `waf: true` (or pass a config object) to restore the previous behavior:
+  AWSManagedRulesCommonRuleSet, AWSManagedRulesKnownBadInputsRuleSet, IP rate
+  limiting at 2000 requests per 5 minutes, and WAF logging to S3 with Datadog
+  forwarding.
+
+## Migration
+
+Stacks relying on the previous default lose the WebACL, the WAF log bucket, and
+the logging configuration on the next deploy. Add `waf: true` to every
+distribution that should keep its firewall:
+
+```typescript
+new JaypieDistribution(this, "Dist", { handler, waf: true });
+new JaypieWebDeploymentBucket(this, "Web", { host, waf: true, zone });
+```

--- a/packages/mcp/release-notes/mcp/0.8.118.md
+++ b/packages/mcp/release-notes/mcp/0.8.118.md
@@ -1,0 +1,11 @@
+---
+version: 0.8.118
+date: 2026-07-31
+summary: Document WAF defaulting to false in the cdk, waf, web, and apigateway skills
+---
+
+## Changes
+
+- `skill("waf")`, `skill("cdk")`, `skill("web")`, and `skill("apigateway")` now
+  describe WAF as opt-in via `waf: true` on `JaypieDistribution` and
+  `JaypieWebDeploymentBucket`.

--- a/packages/mcp/skills/apigateway.md
+++ b/packages/mcp/skills/apigateway.md
@@ -95,7 +95,7 @@ If neither resolves, no custom domain, certificate, or DNS record is created and
 
 `JaypieDistribution` is the preferred front door for new Jaypie APIs. It fronts the Lambda with CloudFront + Lambda Function URLs instead of API Gateway, and ships with capabilities `JaypieApiGateway` lacks:
 
-- **WAFv2 WebACL** (managed rules + IP rate limiting + logging) by default — see `skill("cdk")`
+- **WAFv2 WebACL** (managed rules + IP rate limiting + logging) via `waf: true` — see `skill("cdk")`
 - **Security response headers** (HSTS, CSP, X-Frame-Options, etc.) by default
 - **Response streaming** via `streaming: true` (requires Lambda Function URL, not API Gateway) — see `skill("streaming")`
 - **CloudFront access logs** with Datadog forwarding
@@ -211,7 +211,7 @@ Two things to plan for:
 | Host env fallback | `CDK_ENV_API_HOST_NAME` → `CDK_ENV_API_SUBDOMAIN`+`CDK_ENV_API_HOSTED_ZONE` | Same, plus falls back to `CDK_ENV_HOSTED_ZONE` |
 | Zone env fallback | `CDK_ENV_API_HOSTED_ZONE` | `CDK_ENV_HOSTED_ZONE` |
 | DNS | A record only | A + AAAA records |
-| WAF | Not built in | Enabled by default (`waf: false` to disable) |
+| WAF | Not built in | Opt-in (`waf: true` to enable) |
 | Security headers | Not built in | Enabled by default (`securityHeaders: false` to disable) |
 | Streaming | Not supported | `streaming: true` |
 | Request timeout | API Gateway 29s hard cap | CloudFront `originReadTimeout` up to 120s |
@@ -221,9 +221,9 @@ Two things to plan for:
 
 ### Gotchas
 
-- **Lambda permissions** — `LambdaRestApi` auto-grants invoke from API Gateway; `JaypieDistribution` creates a Function URL with `authType: NONE`, so the WAF is your front-line auth/rate-limiter. Keep `waf` enabled unless you have a replacement.
+- **Lambda permissions** — `LambdaRestApi` auto-grants invoke from API Gateway; `JaypieDistribution` creates a Function URL with `authType: NONE`, so nothing rate-limits the origin unless the app does. Set `waf: true` when the API needs a front-line rate limiter.
 - **DNS record collision** — see "DNS Records" above. Set `deleteExistingRecord: true` on the new construct (or do a two-phase deploy) or the swap fails on Route53.
-- **Large request bodies** — the default `AWSManagedRulesCommonRuleSet` blocks bodies over 8KB. If your API accepts larger payloads, override `SizeRestrictions_BODY` — see `skill("cdk")` WAF section.
+- **Large request bodies** — with WAF enabled, `AWSManagedRulesCommonRuleSet` blocks bodies over 8KB. If your API accepts larger payloads, override `SizeRestrictions_BODY` — see `skill("cdk")` WAF section.
 - **`LambdaRestApiProps`-only features** — usage plans, API keys, request validators, and stage variables have no CloudFront equivalent. Keep `JaypieApiGateway` if you rely on them, or move that logic into the Lambda.
 - **CORS** — `defaultCorsPreflightOptions` on API Gateway is replaced by handling CORS in the Express app (see `skill("cors")`).
 

--- a/packages/mcp/skills/cdk.md
+++ b/packages/mcp/skills/cdk.md
@@ -428,9 +428,10 @@ new JaypieDistribution(this, "Dist", {
 
 ## WAF (Web Application Firewall)
 
-`JaypieDistribution` and `JaypieWebDeploymentBucket` attach a WAFv2 WebACL by
-default (CommonRuleSet, KnownBadInputsRuleSet, IP rate limiting, and WAF logging
-to S3 with Datadog forwarding).
+`JaypieDistribution` and `JaypieWebDeploymentBucket` attach a WAFv2 WebACL when
+`waf` is set. WAF is off by default; `waf: true` enables CommonRuleSet,
+KnownBadInputsRuleSet, IP rate limiting, and WAF logging to S3 with Datadog
+forwarding.
 
 See **`skill("waf")`** for configuration: `rateLimitPerIp`, `webAclArn`,
 `logBucket`, `managedRuleOverrides`, `managedRuleScopeDowns`, the `allow`

--- a/packages/mcp/skills/waf.md
+++ b/packages/mcp/skills/waf.md
@@ -5,8 +5,8 @@ related: aws, cdk, web
 
 # WAF (Web Application Firewall)
 
-`JaypieDistribution` (and `JaypieWebDeploymentBucket`) attach a WAFv2 WebACL by
-default with:
+`JaypieDistribution` (and `JaypieWebDeploymentBucket`) attach a WAFv2 WebACL
+when `waf` is set. WAF is **off by default**; `waf: true` enables it with:
 
 - **AWSManagedRulesCommonRuleSet** — OWASP top 10 (SQLi, XSS, etc.)
 - **AWSManagedRulesKnownBadInputsRuleSet** — known bad patterns (Log4j, etc.)
@@ -14,11 +14,11 @@ default with:
 - **WAF logging** — S3 bucket with Datadog forwarder notifications
 
 ```typescript
-// Default: WAF enabled with logging
+// Default: no WAF
 new JaypieDistribution(this, "Dist", { handler });
 
-// Disable WAF entirely
-new JaypieDistribution(this, "Dist", { handler, waf: false });
+// Enable WAF with logging
+new JaypieDistribution(this, "Dist", { handler, waf: true });
 
 // Customize rate limit (name required on any waf config object)
 new JaypieDistribution(this, "Dist", {
@@ -50,8 +50,8 @@ new JaypieDistribution(this, "Dist", {
 });
 ```
 
-Cost: $5/month per WebACL + $1/month per rule + $0.60 per million requests. Use
-`waf: false` to opt out.
+Cost: $5/month per WebACL + $1/month per rule + $0.60 per million requests. That
+cost is why WAF is opt-in; set `waf: true` (or a config object) to opt in.
 
 ## Override specific managed rule actions
 

--- a/packages/mcp/skills/web.md
+++ b/packages/mcp/skills/web.md
@@ -44,7 +44,7 @@ new JaypieWebDeploymentBucket(this, "Web", {
 | `responseHeadersPolicy` | `IResponseHeadersPolicy` | undefined — full override; bypasses default security headers |
 | `roleTag` | `string` | `CDK.ROLE.HOSTING` |
 | `securityHeaders` | `boolean \| SecurityHeadersOverrides` | `true` |
-| `waf` | `boolean \| JaypieWebDeploymentBucketWafConfig` | `true` (WAF name defaults to construct id) |
+| `waf` | `boolean \| JaypieWebDeploymentBucketWafConfig` | `false` (when enabled, WAF name defaults to construct id) |
 
 Also accepts all `s3.BucketProps` — the bucket defaults to `autoDeleteObjects: true`, `publicReadAccess: true`, `websiteIndexDocument: "index.html"`, `websiteErrorDocument: "index.html"` (SPA-friendly).
 
@@ -77,14 +77,14 @@ new JaypieWebDeploymentBucket(this, "Web", { host, zone, responseHeadersPolicy: 
 
 ### WAF
 
-Same defaults as `JaypieDistribution` (AWSManagedRulesCommonRuleSet, AWSManagedRulesKnownBadInputsRuleSet, IP rate limit 2000/5min, WAF logging to S3 with Datadog forwarding). The WebACL and WAF log bucket are namespaced with the construct id by default so multiple instances coexist without collision:
+Off by default, matching `JaypieDistribution`. When enabled it uses the same settings (AWSManagedRulesCommonRuleSet, AWSManagedRulesKnownBadInputsRuleSet, IP rate limit 2000/5min, WAF logging to S3 with Datadog forwarding). The WebACL and WAF log bucket are namespaced with the construct id so multiple instances coexist without collision:
 
 ```typescript
-// Default — WAF named after construct id ("MyWeb-WebAcl")
-new JaypieWebDeploymentBucket(this, "MyWeb", { host, zone });
+// Default — no WAF
+new JaypieWebDeploymentBucket(this, "Web", { host, zone });
 
-// Disable
-new JaypieWebDeploymentBucket(this, "Web", { host, zone, waf: false });
+// Enable — WAF named after construct id ("MyWeb-WebAcl")
+new JaypieWebDeploymentBucket(this, "MyWeb", { host, zone, waf: true });
 
 // Custom name + rate limit
 new JaypieWebDeploymentBucket(this, "Web", {
@@ -177,7 +177,7 @@ See `skill("variables")` for the `PROJECT_ENV` / `CDK_ENV_*` variables involved.
 
 ## JaypieDistribution (dynamic origins)
 
-For CloudFront in front of an Express Lambda, Function URL, or custom origin — not a static S3 site — reach for `JaypieDistribution`. It ships with ACM, Route53 alias, WAF, and security headers by default.
+For CloudFront in front of an Express Lambda, Function URL, or custom origin — not a static S3 site — reach for `JaypieDistribution`. It ships with ACM, Route53 alias, and security headers by default; WAF is opt-in via `waf: true`.
 
 ```typescript
 import { JaypieDistribution, JaypieExpressLambda } from "@jaypie/constructs";

--- a/workspaces/documentation/src/content/docs/docs/guides/cdk-infrastructure.md
+++ b/workspaces/documentation/src/content/docs/docs/guides/cdk-infrastructure.md
@@ -181,7 +181,7 @@ new JaypieApiGateway(this, "Gateway", {
 
 ### JaypieWebDeploymentBucket
 
-Static site hosting on S3 with CloudFront, ACM, Route53, and (when `CDK_ENV_REPO` is set) a GitHub OIDC deploy role. Ships with security headers, WAFv2, and CloudFront access logging by default — same override mechanisms as `JaypieDistribution`.
+Static site hosting on S3 with CloudFront, ACM, Route53, and (when `CDK_ENV_REPO` is set) a GitHub OIDC deploy role. Ships with security headers and CloudFront access logging by default, plus opt-in WAFv2 (`waf: true`) — same override mechanisms as `JaypieDistribution`.
 
 ```typescript
 new JaypieWebDeploymentBucket(this, "Web", {

--- a/workspaces/documentation/src/content/docs/docs/packages/constructs.md
+++ b/workspaces/documentation/src/content/docs/docs/packages/constructs.md
@@ -151,8 +151,8 @@ new JaypieApiGateway(this, "Gateway", {
 ## JaypieDistribution
 
 CloudFront distribution over a Lambda Function URL or any origin, with ACM
-certificate, Route53 records, security headers, WAFv2, and access logging by
-default.
+certificate, Route53 records, security headers, and access logging by default.
+WAFv2 is opt-in via `waf: true`.
 
 ```typescript
 import { JaypieDistribution, JaypieExpressLambda } from "@jaypie/constructs";
@@ -205,12 +205,12 @@ hostname dark until the next deploy that touches it.
 | `zone` | `string` \| `IHostedZone` | Route53 hosted zone |
 | `deleteExistingRecord` | `boolean` \| `string` \| `string[]` | Force-delete conflicting records |
 | `streaming` | `boolean` | Lambda response streaming |
-| `waf` | `boolean` \| `JaypieWafConfig` | WAFv2 WebACL (default enabled) |
+| `waf` | `boolean` \| `JaypieWafConfig` | WAFv2 WebACL (default disabled) |
 | `securityHeaders` | `boolean` \| overrides | Security response headers (default enabled) |
 
 ## JaypieWebDeploymentBucket
 
-Static site on S3 fronted by CloudFront, ACM, and Route53. Ships with default security headers, WAFv2, and CloudFront access logging — same override mechanisms as `JaypieDistribution` (`securityHeaders`, `responseHeadersPolicy`, `waf`, `logBucket`, `destination`). When `CDK_ENV_REPO` is set, also provisions a scoped GitHub OIDC deploy role with `cloudfront:CreateInvalidation` on the distribution.
+Static site on S3 fronted by CloudFront, ACM, and Route53. Ships with default security headers and CloudFront access logging, and opt-in WAFv2 — same override mechanisms as `JaypieDistribution` (`securityHeaders`, `responseHeadersPolicy`, `waf`, `logBucket`, `destination`). When `CDK_ENV_REPO` is set, also provisions a scoped GitHub OIDC deploy role with `cloudfront:CreateInvalidation` on the distribution.
 
 ```typescript
 import { JaypieWebDeploymentBucket } from "@jaypie/constructs";


### PR DESCRIPTION
## Summary

WAF costs roughly \$12/month per distribution before request charges, and every consumer paid it whether or not the distribution needed a firewall. `JaypieDistribution` and `JaypieWebDeploymentBucket` now default `waf` to `false`.

`waf: true` (or a config object) restores the previous behavior: `AWSManagedRulesCommonRuleSet`, `AWSManagedRulesKnownBadInputsRuleSet`, a 2000/5min per-IP rate limit, and WAF logging to S3 with Datadog forwarding. Callers already passing `waf` are unaffected.

## Breaking

Stacks relying on the old default lose the WebACL, the WAF log bucket, and the logging configuration on the next deploy. Migration:

```typescript
new JaypieDistribution(this, "Dist", { handler, waf: true });
new JaypieWebDeploymentBucket(this, "Web", { host, waf: true, zone });
```

## Changes

- `waf` default flipped in both constructs, with prop docs updated
- Tests: default paths assert zero `AWS::WAFv2::WebACL`; rule-content tests pass `waf: true` explicitly; bucket counts adjusted
- Docs: `packages/constructs/CLAUDE.md`, skills `waf` / `cdk` / `web` / `apigateway`, and both jaypie.net pages
- Versions: `@jaypie/constructs` 1.2.76, `@jaypie/mcp` 0.8.118, release notes for both

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ybb2kSpiVsqoWJCy9R5Av8