### PR TITLE
fix(kit): preserve 4xx error detail; feat(fabric): ServiceSuite tags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15145,7 +15145,7 @@
     },
     "packages/express": {
       "name": "@jaypie/express",
-      "version": "1.2.30",
+      "version": "1.2.31",
       "license": "MIT",
       "dependencies": {
         "@jaypie/datadog": "*",
@@ -15192,7 +15192,7 @@
     },
     "packages/fabric": {
       "name": "@jaypie/fabric",
-      "version": "0.3.7",
+      "version": "0.3.8",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*"
@@ -15302,16 +15302,16 @@
       "license": "MIT"
     },
     "packages/jaypie": {
-      "version": "1.2.75",
+      "version": "1.2.76",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "^1.2.11",
         "@jaypie/core": "^1.2.4",
         "@jaypie/datadog": "^1.2.6",
         "@jaypie/errors": "^1.2.4",
-        "@jaypie/express": "^1.2.30",
-        "@jaypie/kit": "^1.2.14",
-        "@jaypie/lambda": "^1.2.13",
+        "@jaypie/express": "^1.2.31",
+        "@jaypie/kit": "^1.2.15",
+        "@jaypie/lambda": "^1.2.14",
         "@jaypie/logger": "^1.2.22"
       },
       "devDependencies": {
@@ -15354,7 +15354,7 @@
     },
     "packages/kit": {
       "name": "@jaypie/kit",
-      "version": "1.2.14",
+      "version": "1.2.15",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*",
@@ -15424,7 +15424,7 @@
     },
     "packages/lambda": {
       "name": "@jaypie/lambda",
-      "version": "1.2.13",
+      "version": "1.2.14",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-typescript": "^12.1.2",
@@ -15545,7 +15545,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.119",
+      "version": "0.8.120",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.3.3",

--- a/packages/errors/CLAUDE.md
+++ b/packages/errors/CLAUDE.md
@@ -92,9 +92,10 @@ unmapped 4xx falls to `BadRequestError`; anything else falls to `InternalError`.
 
 `@jaypie/kit`'s handler uses the no-message form to scrub a caught error's
 `detail` and `title`, and only substitutes within the same status class, so an
-unmapped 4xx keeps its own status while carrying the bad request strings. Add a
-case when adding an error class with a new status, or that status answers with
-`BadRequestError`'s wording.
+unmapped 4xx keeps its own status while carrying the bad request strings. The
+handler scrubs 500-class by default and 4xx only when configured with `scrub`.
+Add a case when adding an error class with a new status, or that status answers
+with `BadRequestError`'s wording.
 
 ## Use in Other Packages
 
@@ -115,6 +116,8 @@ This package is foundational and used throughout the monorepo:
 - Use `isJaypieError()` to check before accessing Jaypie-specific properties
 - Prefer specific error types over generic `InternalError`
 - Custom messages are optional; defaults are user-friendly
-- A custom message is for the logs, not the caller. Handlers scrub `detail` and
-  `title` to the generic strings for the status before the error reaches a
-  response body
+- A 4xx custom message is for the caller: it reaches the response body, so say
+  what to correct
+- A 500-class custom message is for the logs, not the caller. Handlers scrub
+  `detail` and `title` to the generic strings for the status before a 500-class
+  error reaches a response body

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/express",
-  "version": "1.2.30",
+  "version": "1.2.31",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"

--- a/packages/express/src/__tests__/issue-467-scrub-detail.spec.ts
+++ b/packages/express/src/__tests__/issue-467-scrub-detail.spec.ts
@@ -1,0 +1,104 @@
+import { BadRequestError, ConfigurationError } from "@jaypie/errors";
+import { log } from "@jaypie/logger";
+import { restoreLog, spyLog } from "@jaypie/testkit";
+import express from "express";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Subject
+import expressHandler from "../expressHandler.js";
+
+//
+//
+// Mock modules
+//
+
+vi.mock("../getCurrentInvokeUuid.adapter.js");
+
+beforeEach(() => {
+  spyLog(log);
+});
+
+afterEach(() => {
+  restoreLog(log);
+  vi.clearAllMocks();
+});
+
+//
+//
+// Constants
+//
+
+const CLIENT_DETAIL = "data.confirm must match the API key id, name, or label";
+const SERVER_DETAIL = "Fabric model chat is not registered";
+
+//
+//
+// Run tests
+//
+
+describe("Issue 467: expressHandler error detail scrubbing", () => {
+  it("Responds with the detail of a 4xx error as thrown", async () => {
+    const app = express();
+    app.use(
+      expressHandler(() => {
+        throw new BadRequestError(CLIENT_DETAIL);
+      }),
+    );
+
+    const res = await request(app).get("/");
+
+    expect(res.status).toBe(400);
+    expect(res.body.errors[0].detail).toBe(CLIENT_DETAIL);
+  });
+
+  it("Scrubs the detail of a 4xx error when scrub is true", async () => {
+    const app = express();
+    app.use(
+      expressHandler(
+        () => {
+          throw new BadRequestError(CLIENT_DETAIL);
+        },
+        { scrub: true },
+      ),
+    );
+
+    const res = await request(app).get("/");
+
+    expect(res.status).toBe(400);
+    expect(res.body.errors[0].detail).toBe(
+      "The request was not properly formatted",
+    );
+  });
+
+  it("Scrubs the detail of a 5xx error by default", async () => {
+    const app = express();
+    app.use(
+      expressHandler(() => {
+        throw new ConfigurationError(SERVER_DETAIL);
+      }),
+    );
+
+    const res = await request(app).get("/");
+
+    expect(res.status).toBe(500);
+    expect(res.body.errors[0].detail).not.toBe(SERVER_DETAIL);
+  });
+
+  it("Responds with the detail of a 5xx error when scrub is false", async () => {
+    const app = express();
+    app.use(
+      expressHandler(
+        () => {
+          throw new ConfigurationError(SERVER_DETAIL);
+        },
+        { scrub: false },
+      ),
+    );
+
+    const res = await request(app).get("/");
+
+    expect(res.status).toBe(500);
+    expect(res.body.errors[0].detail).toBe(SERVER_DETAIL);
+  });
+});

--- a/packages/express/src/expressHandler.ts
+++ b/packages/express/src/expressHandler.ts
@@ -2,6 +2,7 @@ import type { Request, Response } from "express";
 import { loadEnvSecrets, loadEnvVariables } from "@jaypie/aws";
 import { BadRequestError, UnhandledError } from "@jaypie/errors";
 import { force, getHeaderFrom, HTTP, JAYPIE, jaypieHandler } from "@jaypie/kit";
+import type { ScrubOption } from "@jaypie/kit";
 import { log as publicLogger } from "@jaypie/logger";
 import {
   DATADOG,
@@ -99,6 +100,7 @@ export interface ExpressHandlerOptions {
   fabric?: boolean;
   locals?: Record<string, unknown | ExpressHandlerLocals>;
   name?: string;
+  scrub?: ScrubOption;
   secrets?: string[];
   setup?: JaypieHandlerSetup[] | JaypieHandlerSetup;
   teardown?: JaypieHandlerTeardown[] | JaypieHandlerTeardown;
@@ -322,6 +324,7 @@ function expressHandler<T>(
     fabric,
     locals,
     name,
+    scrub,
     secrets,
     setup = [],
     teardown = [],
@@ -531,6 +534,7 @@ function expressHandler<T>(
         {
           chaos,
           name,
+          scrub,
           setup: requestSetup,
           teardown,
           unavailable,

--- a/packages/express/src/expressStreamHandler.ts
+++ b/packages/express/src/expressStreamHandler.ts
@@ -8,6 +8,7 @@ import {
 import type { StreamFormat } from "@jaypie/aws";
 import { BadRequestError, UnhandledError } from "@jaypie/errors";
 import { force, getHeaderFrom, JAYPIE, jaypieHandler } from "@jaypie/kit";
+import type { ScrubOption } from "@jaypie/kit";
 import { log as publicLogger } from "@jaypie/logger";
 import { DATADOG, hasDatadogEnv, submitMetric } from "@jaypie/datadog";
 
@@ -90,6 +91,7 @@ export interface ExpressStreamHandlerOptions {
   format?: StreamFormat;
   locals?: Record<string, unknown | ExpressStreamHandlerLocals>;
   name?: string;
+  scrub?: ScrubOption;
   secrets?: string[];
   setup?: JaypieStreamHandlerSetup[] | JaypieStreamHandlerSetup;
   teardown?: JaypieStreamHandlerTeardown[] | JaypieStreamHandlerTeardown;
@@ -206,6 +208,7 @@ function expressStreamHandler(
     contentType = getContentTypeForFormat(format),
     locals,
     name,
+    scrub,
     secrets,
     setup = [],
     teardown = [],
@@ -367,6 +370,7 @@ function expressStreamHandler(
         {
           chaos,
           name,
+          scrub,
           setup: requestSetup,
           teardown,
           unavailable,

--- a/packages/fabric/CLAUDE.md
+++ b/packages/fabric/CLAUDE.md
@@ -191,13 +191,16 @@ const greetService = fabricService({
   service: ({ name }) => `Hello, ${name}!`,
 });
 
-suite.register(greetService, { category: "utils" });
+suite.register(greetService, { category: "utils", tags: ["immediate", "public"] });
 
 // Access metadata
 suite.services;              // ServiceMeta[] - metadata for all services
 suite.categories;            // string[] - registered categories
+suite.tags;                  // string[] - registered tags
 suite.getService("greet");   // ServiceMeta | undefined
 suite.getServicesByCategory("utils"); // ServiceMeta[]
+suite.getServicesByTag("immediate");  // ServiceMeta[]
+suite.filterServices((meta) => !meta.tags.includes("long")); // ServiceMeta[]
 
 // Execute services
 await suite.execute("greet", { name: "World" }); // "Hello, World!"
@@ -211,10 +214,12 @@ suite.getServiceFunction("greet"); // Service | undefined
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `register(service, { category })` | void | Register a fabricService with a category |
+| `register(service, { category, tags })` | void | Register a fabricService with a category and optional tags |
 | `execute(name, inputs)` | Promise | Execute a service by name |
 | `getService(name)` | ServiceMeta | Get service metadata by name |
 | `getServicesByCategory(category)` | ServiceMeta[] | Get all services in a category |
+| `getServicesByTag(tag)` | ServiceMeta[] | Get all services carrying a tag |
+| `filterServices(predicate)` | ServiceMeta[] | Get all services whose metadata matches a predicate |
 | `getServiceFunctions()` | Service[] | Get all service functions (for transport adapters) |
 | `getServiceFunction(name)` | Service | Get a specific service function |
 
@@ -395,7 +400,7 @@ export { fabricService } from "./service.js";
 
 // ServiceSuite
 export { createServiceSuite } from "./ServiceSuite.js";
-export type { ServiceMeta, ServiceSuite, ServiceSuiteConfig } from "./ServiceSuite.js";
+export type { CreateServiceSuiteConfig, RegisterServiceOptions, ServiceInput, ServiceMeta, ServiceSuite } from "./ServiceSuite.js";
 
 // Models
 export { FabricModel, FabricJob, FabricMessage, Progress } from "./models/base.js";

--- a/packages/fabric/package.json
+++ b/packages/fabric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/fabric",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Jaypie modeling framework with type conversion, service handlers, and adapters",
   "repository": {
     "type": "git",

--- a/packages/fabric/src/ServiceSuite.ts
+++ b/packages/fabric/src/ServiceSuite.ts
@@ -24,10 +24,22 @@ export interface ServiceMeta {
   description: string;
   /** Category for grouping (e.g., "record", "aws", "docs") */
   category: string;
+  /** Cross-cutting classifiers orthogonal to category (e.g., "long", "privileged") */
+  tags: string[];
   /** Input parameter definitions */
   inputs: ServiceInput[];
   /** Whether the service can be executed with no inputs */
   executable?: boolean;
+}
+
+/**
+ * Registration metadata for a service
+ */
+export interface RegisterServiceOptions {
+  /** Category for grouping; a service belongs to exactly one */
+  category: string;
+  /** Cross-cutting classifiers; a service may carry any number */
+  tags?: string[];
 }
 
 /**
@@ -40,6 +52,8 @@ export interface ServiceSuite {
   version: string;
   /** Available categories */
   categories: string[];
+  /** Available tags */
+  tags: string[];
   /** All registered services */
   services: ServiceMeta[];
 
@@ -47,13 +61,17 @@ export interface ServiceSuite {
   getService(name: string): ServiceMeta | undefined;
   /** Get services by category */
   getServicesByCategory(category: string): ServiceMeta[];
+  /** Get services carrying a tag */
+  getServicesByTag(tag: string): ServiceMeta[];
+  /** Get services matching a predicate over their metadata */
+  filterServices(predicate: (meta: ServiceMeta) => boolean): ServiceMeta[];
 
   /** Execute a service by name */
   execute(name: string, inputs: Record<string, unknown>): Promise<unknown>;
 
   /** Register a fabricService into the suite */
 
-  register(service: Service<any, any>, options: { category: string }): void;
+  register(service: Service<any, any>, options: RegisterServiceOptions): void;
 
   /** Get all registered service functions (for transport adapters like FabricMcpServer) */
 
@@ -198,6 +216,7 @@ export function createServiceSuite(
     }
   >();
   const categorySet = new Set<string>();
+  const tagSet = new Set<string>();
 
   const suite: ServiceSuite = {
     name,
@@ -205,6 +224,10 @@ export function createServiceSuite(
 
     get categories(): string[] {
       return Array.from(categorySet).sort();
+    },
+
+    get tags(): string[] {
+      return Array.from(tagSet).sort();
     },
 
     get services(): ServiceMeta[] {
@@ -221,6 +244,18 @@ export function createServiceSuite(
         .map((entry) => entry.meta);
     },
 
+    getServicesByTag(tag: string): ServiceMeta[] {
+      return Array.from(serviceRegistry.values())
+        .filter((entry) => entry.meta.tags.includes(tag))
+        .map((entry) => entry.meta);
+    },
+
+    filterServices(predicate: (meta: ServiceMeta) => boolean): ServiceMeta[] {
+      return Array.from(serviceRegistry.values())
+        .map((entry) => entry.meta)
+        .filter(predicate);
+    },
+
     async execute(
       serviceName: string,
       inputs: Record<string, unknown>,
@@ -234,24 +269,32 @@ export function createServiceSuite(
       return entry.service(inputs);
     },
 
-    register(service: Service<any, any>, options: { category: string }): void {
-      const { category } = options;
+    register(
+      service: Service<any, any>,
+      options: RegisterServiceOptions,
+    ): void {
+      const { category, tags: requestedTags } = options;
       const serviceName = service.alias;
       if (!serviceName) {
         throw new Error("Service must have an alias to be registered");
       }
 
+      const tags = Array.from(new Set(requestedTags ?? []));
       const inputs = extractInputs(service.input);
       const meta: ServiceMeta = {
         name: serviceName,
         description: service.description || "",
         category,
+        tags,
         inputs,
         executable: !hasRequiredInputs(inputs),
       };
 
       serviceRegistry.set(serviceName, { service, meta });
       categorySet.add(category);
+      for (const tag of tags) {
+        tagSet.add(tag);
+      }
     },
 
     getServiceFunctions(): Service<any, any>[] {

--- a/packages/fabric/src/__tests__/service-suite.spec.ts
+++ b/packages/fabric/src/__tests__/service-suite.spec.ts
@@ -272,4 +272,185 @@ describe("ServiceSuite", () => {
       expect(services).toEqual([]);
     });
   });
+
+  describe("tags", () => {
+    it("should default to an empty array when no tags are registered", () => {
+      const suite = createServiceSuite({
+        name: "test-suite",
+        version: "1.0.0",
+      });
+      const service = fabricService({
+        alias: "service-a",
+        service: () => "a",
+      });
+
+      suite.register(service, { category: "utils" });
+
+      expect(suite.services[0].tags).toEqual([]);
+      expect(suite.tags).toEqual([]);
+    });
+
+    it("should register tags alongside a category", () => {
+      const suite = createServiceSuite({
+        name: "test-suite",
+        version: "1.0.0",
+      });
+      const service = fabricService({
+        alias: "service-a",
+        service: () => "a",
+      });
+
+      suite.register(service, {
+        category: "utils",
+        tags: ["long", "privileged"],
+      });
+
+      expect(suite.getService("service-a")?.tags).toEqual([
+        "long",
+        "privileged",
+      ]);
+      expect(suite.services[0].category).toBe("utils");
+    });
+
+    it("should expose sorted unique tags across the suite", () => {
+      const suite = createServiceSuite({
+        name: "test-suite",
+        version: "1.0.0",
+      });
+
+      suite.register(
+        fabricService({ alias: "service-a", service: () => "a" }),
+        {
+          category: "utils",
+          tags: ["short", "public"],
+        },
+      );
+      suite.register(
+        fabricService({ alias: "service-b", service: () => "b" }),
+        {
+          category: "math",
+          tags: ["short", "private"],
+        },
+      );
+
+      expect(suite.tags).toEqual(["private", "public", "short"]);
+    });
+
+    it("should deduplicate tags on a single service", () => {
+      const suite = createServiceSuite({
+        name: "test-suite",
+        version: "1.0.0",
+      });
+
+      suite.register(
+        fabricService({ alias: "service-a", service: () => "a" }),
+        {
+          category: "utils",
+          tags: ["long", "long"],
+        },
+      );
+
+      expect(suite.getService("service-a")?.tags).toEqual(["long"]);
+    });
+  });
+
+  describe("getServicesByTag", () => {
+    it("should return services carrying the tag across categories", () => {
+      const suite = createServiceSuite({
+        name: "test-suite",
+        version: "1.0.0",
+      });
+
+      suite.register(
+        fabricService({ alias: "service-a", service: () => "a" }),
+        {
+          category: "utils",
+          tags: ["immediate", "public"],
+        },
+      );
+      suite.register(
+        fabricService({ alias: "service-b", service: () => "b" }),
+        {
+          category: "math",
+          tags: ["immediate", "privileged"],
+        },
+      );
+      suite.register(
+        fabricService({ alias: "service-c", service: () => "c" }),
+        {
+          category: "math",
+          tags: ["long"],
+        },
+      );
+
+      expect(suite.getServicesByTag("immediate").map((s) => s.name)).toEqual([
+        "service-a",
+        "service-b",
+      ]);
+      expect(suite.getServicesByTag("long").map((s) => s.name)).toEqual([
+        "service-c",
+      ]);
+    });
+
+    it("should return empty array for unknown tag", () => {
+      const suite = createServiceSuite({
+        name: "test-suite",
+        version: "1.0.0",
+      });
+
+      suite.register(
+        fabricService({ alias: "service-a", service: () => "a" }),
+        {
+          category: "utils",
+        },
+      );
+
+      expect(suite.getServicesByTag("unknown")).toEqual([]);
+    });
+  });
+
+  describe("filterServices", () => {
+    it("should return services matching a predicate", () => {
+      const suite = createServiceSuite({
+        name: "test-suite",
+        version: "1.0.0",
+      });
+
+      suite.register(
+        fabricService({ alias: "service-a", service: () => "a" }),
+        {
+          category: "utils",
+          tags: ["short", "public"],
+        },
+      );
+      suite.register(
+        fabricService({ alias: "service-b", service: () => "b" }),
+        {
+          category: "utils",
+          tags: ["long", "public"],
+        },
+      );
+
+      const mounted = suite.filterServices(
+        (meta) => meta.tags.includes("public") && !meta.tags.includes("long"),
+      );
+      expect(mounted.map((s) => s.name)).toEqual(["service-a"]);
+    });
+
+    it("should return empty array when nothing matches", () => {
+      const suite = createServiceSuite({
+        name: "test-suite",
+        version: "1.0.0",
+      });
+
+      suite.register(
+        fabricService({ alias: "service-a", service: () => "a" }),
+        {
+          category: "utils",
+        },
+      );
+
+      expect(suite.filterServices(() => false)).toEqual([]);
+    });
+  });
 });

--- a/packages/fabric/src/express/fabricExpress.ts
+++ b/packages/fabric/src/express/fabricExpress.ts
@@ -207,6 +207,7 @@ export function fabricExpress<
       chaos: config.chaos,
       locals: config.locals,
       name: config.name ?? service.alias,
+      scrub: config.scrub,
       secrets: config.secrets,
       setup: config.setup,
       teardown: config.teardown,

--- a/packages/fabric/src/express/types.ts
+++ b/packages/fabric/src/express/types.ts
@@ -6,6 +6,7 @@ import type {
   FabricHttpService,
   HttpMethod,
 } from "../http/types.js";
+import type { ScrubOption } from "../types.js";
 
 // #region fabricExpress
 
@@ -56,6 +57,8 @@ export interface FabricExpressConfig<
   locals?: Record<string, unknown | FabricExpressLocalsFn>;
   /** Handler name for logging. Defaults to the service alias. */
   name?: string;
+  /** Scrub error detail and title. 5xx only by default. */
+  scrub?: ScrubOption;
   /** AWS Secret names to load into `process.env` before the handler runs. */
   secrets?: string[];
   /** Pre-handler setup function(s). */

--- a/packages/fabric/src/index.ts
+++ b/packages/fabric/src/index.ts
@@ -158,6 +158,7 @@ export type {
   RegExpType,
   ScalarType,
   SerializerFunction,
+  ScrubOption,
   Service,
   ServiceConfig,
   ServiceContext,

--- a/packages/fabric/src/index.ts
+++ b/packages/fabric/src/index.ts
@@ -137,6 +137,7 @@ export type { ResolveServiceConfig } from "./resolveService.js";
 export { createServiceSuite } from "./ServiceSuite.js";
 export type {
   CreateServiceSuiteConfig,
+  RegisterServiceOptions,
   ServiceInput,
   ServiceMeta,
   ServiceSuite,

--- a/packages/fabric/src/lambda/fabricLambda.ts
+++ b/packages/fabric/src/lambda/fabricLambda.ts
@@ -197,6 +197,7 @@ export function fabricLambda<TResult = unknown>(
   return lambdaHandler(innerHandler, {
     chaos: opts.chaos,
     name,
+    scrub: opts.scrub,
     secrets: opts.secrets,
     setup: opts.setup,
     teardown: opts.teardown,

--- a/packages/fabric/src/lambda/types.ts
+++ b/packages/fabric/src/lambda/types.ts
@@ -3,6 +3,7 @@
 import type {
   InputFieldDefinition,
   Message,
+  ScrubOption,
   Service,
   ServiceFunction,
 } from "../types.js";
@@ -44,6 +45,8 @@ export interface FabricLambdaOptions {
   onFatal?: OnFatalCallback;
   /** Callback for receiving messages from service during execution */
   onMessage?: OnMessageCallback;
+  /** Scrub error detail and title: 5xx only by default */
+  scrub?: ScrubOption;
   /** AWS secrets to load into process.env */
   secrets?: string[];
   /** Functions to run before handler */

--- a/packages/fabric/src/types.ts
+++ b/packages/fabric/src/types.ts
@@ -16,6 +16,21 @@ export interface Message {
   level?: MessageLevel;
 }
 
+// Handler Types - Lifecycle options forwarded to the wrapping handler
+
+/**
+ * Error scrub configuration forwarded to `jaypieHandler`. Replaces `detail`
+ * and `title` with the generic strings for the status. 5xx is scrubbed by
+ * default and 4xx is not. Structurally matches `ScrubOption` in `@jaypie/kit`,
+ * defined locally to avoid a hard type dependency.
+ */
+export type ScrubOption =
+  | boolean
+  | {
+      client?: boolean;
+      server?: boolean;
+    };
+
 // Supported scalar types
 export type ScalarType =
   | typeof Boolean

--- a/packages/fabric/src/websocket/fabricWebSocket.ts
+++ b/packages/fabric/src/websocket/fabricWebSocket.ts
@@ -14,6 +14,7 @@ import { resolveService } from "../resolveService.js";
 import type {
   InputFieldDefinition,
   Message,
+  ScrubOption,
   Service,
   ServiceContext,
   ServiceFunction,
@@ -92,6 +93,8 @@ export interface FabricWebSocketOptions {
   onFatal?: OnFatalCallback;
   /** Callback for receiving messages from service during execution */
   onMessage?: OnMessageCallback;
+  /** Scrub error detail and title: 5xx only by default */
+  scrub?: ScrubOption;
   /** AWS secrets to load into process.env */
   secrets?: string[];
   /** Functions to run before handler */
@@ -337,6 +340,7 @@ export function fabricWebSocket(
   return websocketHandler(innerHandler, {
     chaos: opts.chaos,
     name,
+    scrub: opts.scrub,
     secrets: opts.secrets,
     setup: opts.setup,
     teardown: opts.teardown,

--- a/packages/jaypie/package.json
+++ b/packages/jaypie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jaypie",
-  "version": "1.2.75",
+  "version": "1.2.76",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"
@@ -41,9 +41,9 @@
     "@jaypie/core": "^1.2.4",
     "@jaypie/datadog": "^1.2.6",
     "@jaypie/errors": "^1.2.4",
-    "@jaypie/express": "^1.2.30",
-    "@jaypie/kit": "^1.2.14",
-    "@jaypie/lambda": "^1.2.13",
+    "@jaypie/express": "^1.2.31",
+    "@jaypie/kit": "^1.2.15",
+    "@jaypie/lambda": "^1.2.14",
     "@jaypie/logger": "^1.2.22"
   },
   "devDependencies": {

--- a/packages/kit/CLAUDE.md
+++ b/packages/kit/CLAUDE.md
@@ -65,14 +65,19 @@ src/
   - `setup[]` - Pre-handler lifecycle functions
   - `teardown[]` - Post-handler cleanup (always runs)
   - `chaos` - Chaos engineering mode (from `PROJECT_CHAOS` env)
+  - `scrub` - Error scrubbing, `boolean | { client?: boolean, server?: boolean }`,
+    defaults to `{ client: false, server: true }`
 
   Caught Jaypie errors log by status: 4xx at warn, 500 and above at error, both
-  with `log.var({ jaypieError: { detail, status, title } })`. The error's
-  `detail` and `title` are then replaced with the generic strings for its status
-  so a constructor message never reaches a response body; `status`, `message`,
-  and `stack` are untouched. An unmapped 4xx status takes the bad request
-  strings and keeps its own status; a status outside 4xx and 5xx is not scrubbed.
-  Non-Jaypie errors log at fatal and become `UnhandledError`.
+  with `log.var({ jaypieError: { detail, status, title } })`. A 500-class error
+  then has its `detail` and `title` replaced with the generic strings for its
+  status, so a constructor message describing application internals never
+  reaches a response body. 4xx keeps its detail as thrown, since a client error
+  is only actionable when it says what to correct. `scrub` overrides either
+  class; `status`, `message`, and `stack` are untouched either way. A scrubbed
+  unmapped 4xx status takes the bad request strings and keeps its own status; a
+  status outside 4xx and 5xx is never scrubbed. Non-Jaypie errors log at fatal
+  and become `UnhandledError`.
 
 ### Type Coercion
 

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/kit",
-  "version": "1.2.14",
+  "version": "1.2.15",
   "description": "Utility functions for Jaypie applications",
   "repository": {
     "type": "git",

--- a/packages/kit/src/__tests__/jaypieHandler.module.spec.ts
+++ b/packages/kit/src/__tests__/jaypieHandler.module.spec.ts
@@ -229,7 +229,7 @@ describe("Jaypie Handler Module", () => {
       }
       expect.assertions(3);
     });
-    it("Replaces the detail and title of a caught 4xx Jaypie error", async () => {
+    it("Preserves the detail and title of a caught 4xx Jaypie error", async () => {
       // Arrange
       const handler = jaypieHandler(() => {
         throw new NotFoundError("User 12345 not found");
@@ -240,12 +240,12 @@ describe("Jaypie Handler Module", () => {
       } catch (error) {
         // Assert
         const jaypieError = error as InstanceType<typeof NotFoundError>;
-        expect(jaypieError.detail).toBe("The requested resource was not found");
+        expect(jaypieError.detail).toBe("User 12345 not found");
         expect(jaypieError.title).toBe("Not Found");
       }
       expect.assertions(2);
     });
-    it("Scrubs an unmapped 4xx to the bad request strings, keeping its status", async () => {
+    it("Preserves the detail of an unmapped 4xx", async () => {
       // Arrange
       const handler = jaypieHandler(() => {
         throw new JaypieError("Field ssn failed validation", {
@@ -260,10 +260,8 @@ describe("Jaypie Handler Module", () => {
         // Assert
         const jaypieError = error as JaypieError;
         expect(jaypieError.status).toBe(422);
-        expect(jaypieError.detail).toBe(
-          "The request was not properly formatted",
-        );
-        expect(jaypieError.title).toBe("Bad Request");
+        expect(jaypieError.detail).toBe("Field ssn failed validation");
+        expect(jaypieError.title).toBe("Unprocessable Entity");
       }
       expect.assertions(3);
     });
@@ -321,6 +319,7 @@ describe("Jaypie Handler Module", () => {
     it("Scrubs an error caught during validate", async () => {
       // Arrange
       const handler = jaypieHandler(() => {}, {
+        scrub: true,
         validate: [
           () => {
             throw new NotFoundError("Account 999 does not exist");
@@ -337,6 +336,146 @@ describe("Jaypie Handler Module", () => {
         );
       }
       expect.assertions(1);
+    });
+    describe("Scrub option", () => {
+      it("Scrubs a 4xx when scrub is true", async () => {
+        // Arrange
+        const handler = jaypieHandler(
+          () => {
+            throw new NotFoundError("User 12345 not found");
+          },
+          { scrub: true },
+        );
+        // Act
+        try {
+          await handler();
+        } catch (error) {
+          // Assert
+          const jaypieError = error as InstanceType<typeof NotFoundError>;
+          expect(jaypieError.detail).toBe(
+            "The requested resource was not found",
+          );
+          expect(jaypieError.title).toBe("Not Found");
+        }
+        expect.assertions(2);
+      });
+      it("Scrubs a 4xx when scrub.client is true", async () => {
+        // Arrange
+        const handler = jaypieHandler(
+          () => {
+            throw new NotFoundError("User 12345 not found");
+          },
+          { scrub: { client: true } },
+        );
+        // Act
+        try {
+          await handler();
+        } catch (error) {
+          // Assert
+          expect((error as InstanceType<typeof NotFoundError>).detail).toBe(
+            "The requested resource was not found",
+          );
+        }
+        expect.assertions(1);
+      });
+      it("Preserves a 5xx when scrub is false", async () => {
+        // Arrange
+        const handler = jaypieHandler(
+          () => {
+            throw new ConfigurationError("Fabric model chat is not registered");
+          },
+          { scrub: false },
+        );
+        // Act
+        try {
+          await handler();
+        } catch (error) {
+          // Assert
+          const jaypieError = error as InstanceType<typeof ConfigurationError>;
+          expect(jaypieError.detail).toBe(
+            "Fabric model chat is not registered",
+          );
+          expect(jaypieError.title).toBe("Internal Configuration Error");
+        }
+        expect.assertions(2);
+      });
+      it("Preserves a 5xx when scrub.server is false", async () => {
+        // Arrange
+        const handler = jaypieHandler(
+          () => {
+            throw new ConfigurationError("Fabric model chat is not registered");
+          },
+          { scrub: { server: false } },
+        );
+        // Act
+        try {
+          await handler();
+        } catch (error) {
+          // Assert
+          expect(
+            (error as InstanceType<typeof ConfigurationError>).detail,
+          ).toBe("Fabric model chat is not registered");
+        }
+        expect.assertions(1);
+      });
+      it("Scrubs a 5xx but not a 4xx when scrub.client is false", async () => {
+        // Arrange
+        const clientHandler = jaypieHandler(
+          () => {
+            throw new NotFoundError("User 12345 not found");
+          },
+          { scrub: { client: false } },
+        );
+        const serverHandler = jaypieHandler(
+          () => {
+            throw new ConfigurationError("Fabric model chat is not registered");
+          },
+          { scrub: { client: false } },
+        );
+        // Act
+        try {
+          await clientHandler();
+        } catch (error) {
+          // Assert
+          expect((error as InstanceType<typeof NotFoundError>).detail).toBe(
+            "User 12345 not found",
+          );
+        }
+        try {
+          await serverHandler();
+        } catch (error) {
+          // Assert
+          expect(
+            (error as InstanceType<typeof ConfigurationError>).detail,
+          ).toBe(
+            "An unexpected error occurred and the request was unable to complete",
+          );
+        }
+        expect.assertions(2);
+      });
+      it("Still logs the error as thrown when scrub is true", async () => {
+        // Arrange
+        const handler = jaypieHandler(
+          () => {
+            throw new NotFoundError("User 12345 not found");
+          },
+          { scrub: true },
+        );
+        // Act
+        try {
+          await handler();
+        } catch {
+          // Assert
+          expect(log.var).toHaveBeenCalledWith({
+            jaypieError: {
+              detail: "User 12345 not found",
+              status: HTTP.CODE.NOT_FOUND,
+              title: "Not Found",
+            },
+          });
+        }
+        expect.assertions(1);
+      });
     });
     it("Logs fatal if a non-Jaypie error is caught", async () => {
       // Arrange

--- a/packages/kit/src/index.ts
+++ b/packages/kit/src/index.ts
@@ -28,6 +28,11 @@ export { default as HTTP } from "./lib/http.lib.js";
 
 // Handler
 export { default as jaypieHandler } from "./jaypieHandler.module.js";
+export type {
+  JaypieHandlerOptions,
+  ScrubOption,
+  ScrubOptions,
+} from "./jaypieHandler.module.js";
 
 // UUID
 export { v4 as uuid } from "uuid";

--- a/packages/kit/src/jaypieHandler.module.ts
+++ b/packages/kit/src/jaypieHandler.module.ts
@@ -20,9 +20,17 @@ type AsyncHandler = (...args: unknown[]) => Promise<unknown>;
 type ValidatorFunction = (...args: unknown[]) => unknown | Promise<unknown>;
 type LifecycleFunction = (...args: unknown[]) => void | Promise<void>;
 
-interface JaypieHandlerOptions {
+export interface ScrubOptions {
+  client?: boolean;
+  server?: boolean;
+}
+
+export type ScrubOption = boolean | ScrubOptions;
+
+export interface JaypieHandlerOptions {
   chaos?: string;
   name?: string;
+  scrub?: ScrubOption;
   setup?: LifecycleFunction[];
   teardown?: LifecycleFunction[];
   unavailable?: boolean;
@@ -46,6 +54,23 @@ function errorClass(status: number): number {
   return Math.floor(status / 100);
 }
 
+// 4xx describes what the caller can correct, so its detail is the response;
+// 5xx describes application internals and belongs only in logs
+const SCRUB_DEFAULT: Required<ScrubOptions> = {
+  client: false,
+  server: true,
+};
+
+function resolveScrub(scrub: ScrubOption): Required<ScrubOptions> {
+  if (typeof scrub === "boolean") {
+    return { client: scrub, server: scrub };
+  }
+  return {
+    client: scrub.client ?? SCRUB_DEFAULT.client,
+    server: scrub.server ?? SCRUB_DEFAULT.server,
+  };
+}
+
 //
 //
 // Main
@@ -56,6 +81,7 @@ const jaypieHandler = (
   {
     chaos = process.env.PROJECT_CHAOS || "none",
     name = undefined,
+    scrub = SCRUB_DEFAULT,
     setup = [],
     teardown = [],
     unavailable = envBoolean("PROJECT_UNAVAILABLE", { defaultValue: false }) ??
@@ -93,16 +119,21 @@ const jaypieHandler = (
     lib: JAYPIE.LIB.KIT,
   });
 
+  const scrubErrors = resolveScrub(scrub);
+
   // Report a caught Jaypie error, then scrub it.
   //
   // Level follows status: 500-class is an infrastructure or application fault
   // and logs at error so monitors filtering on error status see the outage;
   // 4xx is a caller mistake and logs at warn.
   //
-  // The error's own `detail` and `title` are logged and then replaced with the
-  // generic strings for its status, so whatever the application passed to the
-  // error constructor never reaches a response body. `message` and `stack` are
-  // left intact for logs and for handlers configured to rethrow.
+  // The error as thrown is always logged. Scrubbing replaces `detail` and
+  // `title` with the generic strings for the status, so whatever the
+  // application passed to the error constructor never reaches a response body.
+  // 5xx is scrubbed by default and 4xx is not, since a client error is only
+  // actionable when it says what to correct; `scrub` overrides either class.
+  // `message` and `stack` are left intact for logs and for handlers configured
+  // to rethrow.
   const reportJaypieError = (error: JaypieError, message: string): void => {
     const { detail, status, title } = error;
 
@@ -116,6 +147,17 @@ const jaypieHandler = (
     log.var({ jaypieError: { detail, status, title } });
 
     if (typeof status !== "number") {
+      return;
+    }
+    if (status >= HTTP.CODE.INTERNAL_ERROR) {
+      if (!scrubErrors.server) {
+        return;
+      }
+    } else if (status >= HTTP.CODE.BAD_REQUEST) {
+      if (!scrubErrors.client) {
+        return;
+      }
+    } else {
       return;
     }
     const generic = jaypieErrorFromStatus(status);

--- a/packages/lambda/CLAUDE.md
+++ b/packages/lambda/CLAUDE.md
@@ -41,7 +41,7 @@ src/
 |--------|-------------|
 | `LambdaContext` | AWS Lambda context with optional `awsRequestId` |
 | `LambdaHandlerFunction` | Standard handler function signature |
-| `LambdaHandlerOptions` | Options for standard handler (chaos, logEvent, logResponse, name, secrets, setup, teardown, throw, unavailable, validate) |
+| `LambdaHandlerOptions` | Options for standard handler (chaos, logEvent, logResponse, name, scrub, secrets, setup, teardown, throw, unavailable, validate) |
 | `LambdaStreamContext` | Streaming Lambda context |
 | `LambdaStreamHandlerOptions` | Options for streaming handler (adds `contentType`, `format`) |
 | `StreamHandlerContext` | Extended context with `responseStream` |
@@ -135,6 +135,7 @@ lambdaHandler({ name: "test" }, myFunction);
 | `logEvent` | `boolean` | `true` | Log the incoming event at info |
 | `logResponse` | `boolean` | `true` | Log the response at info (standard and websocket only) |
 | `name` | `string` | function name | Handler name for logging |
+| `scrub` | `boolean \| { client?, server? }` | `{ client: false, server: true }` | Replace caught error `detail` and `title` with the generic strings for the status |
 | `secrets` | `string[]` | `[]` | AWS secrets to load into `process.env` |
 | `setup` | `Function[]` | `[]` | Functions to run before handler |
 | `teardown` | `Function[]` | `[]` | Functions to run after handler (always runs) |

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/lambda",
-  "version": "1.2.13",
+  "version": "1.2.14",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"

--- a/packages/lambda/src/__tests__/issue-467-scrub-detail.spec.ts
+++ b/packages/lambda/src/__tests__/issue-467-scrub-detail.spec.ts
@@ -1,0 +1,81 @@
+import { BadRequestError, ConfigurationError } from "@jaypie/errors";
+import { log } from "@jaypie/logger";
+import { restoreLog, spyLog } from "@jaypie/testkit";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Subject
+import lambdaHandler from "../lambdaHandler.js";
+
+beforeEach(() => {
+  spyLog(log);
+});
+
+afterEach(() => {
+  restoreLog(log);
+  vi.clearAllMocks();
+});
+
+//
+//
+// Constants
+//
+
+const CLIENT_DETAIL = "data.confirm must match the API key id, name, or label";
+const SERVER_DETAIL = "Fabric model chat is not registered";
+
+type ErrorResponse = { errors: { detail: string; status: number }[] };
+
+//
+//
+// Run tests
+//
+
+describe("Issue 467: lambdaHandler error detail scrubbing", () => {
+  it("Returns the detail of a 4xx error as thrown", async () => {
+    const handler = lambdaHandler(() => {
+      throw new BadRequestError(CLIENT_DETAIL);
+    });
+
+    const result = (await handler({}, {})) as ErrorResponse;
+
+    expect(result.errors[0].detail).toBe(CLIENT_DETAIL);
+  });
+
+  it("Scrubs the detail of a 4xx error when scrub is true", async () => {
+    const handler = lambdaHandler(
+      () => {
+        throw new BadRequestError(CLIENT_DETAIL);
+      },
+      { scrub: true },
+    );
+
+    const result = (await handler({}, {})) as ErrorResponse;
+
+    expect(result.errors[0].detail).toBe(
+      "The request was not properly formatted",
+    );
+  });
+
+  it("Scrubs the detail of a 5xx error by default", async () => {
+    const handler = lambdaHandler(() => {
+      throw new ConfigurationError(SERVER_DETAIL);
+    });
+
+    const result = (await handler({}, {})) as ErrorResponse;
+
+    expect(result.errors[0].detail).not.toBe(SERVER_DETAIL);
+  });
+
+  it("Returns the detail of a 5xx error when scrub.server is false", async () => {
+    const handler = lambdaHandler(
+      () => {
+        throw new ConfigurationError(SERVER_DETAIL);
+      },
+      { scrub: { server: false } },
+    );
+
+    const result = (await handler({}, {})) as ErrorResponse;
+
+    expect(result.errors[0].detail).toBe(SERVER_DETAIL);
+  });
+});

--- a/packages/lambda/src/lambdaHandler.ts
+++ b/packages/lambda/src/lambdaHandler.ts
@@ -2,6 +2,7 @@ import { loadEnvSecrets, loadEnvVariables } from "@jaypie/aws";
 import { flushLlmObs, loadDatadogApiKey } from "@jaypie/datadog";
 import { ConfigurationError, UnhandledError } from "@jaypie/errors";
 import { JAYPIE, jaypieHandler } from "@jaypie/kit";
+import type { ScrubOption } from "@jaypie/kit";
 import { log as publicLogger } from "@jaypie/logger";
 
 //
@@ -22,6 +23,7 @@ export interface LambdaHandlerOptions {
   logEvent?: boolean;
   logResponse?: boolean;
   name?: string;
+  scrub?: ScrubOption;
   secrets?: string[];
   setup?: LifecycleFunction[];
   teardown?: LifecycleFunction[];
@@ -84,6 +86,7 @@ const lambdaHandler = function <TEvent = unknown, TResult = unknown>(
     logEvent = true,
     logResponse = true,
     name,
+    scrub,
     secrets,
     setup = [],
     teardown,
@@ -187,6 +190,7 @@ const lambdaHandler = function <TEvent = unknown, TResult = unknown>(
       {
         chaos,
         name,
+        scrub,
         setup,
         teardown,
         unavailable,

--- a/packages/lambda/src/lambdaStreamHandler.ts
+++ b/packages/lambda/src/lambdaStreamHandler.ts
@@ -8,6 +8,7 @@ import type { StreamFormat } from "@jaypie/aws";
 import { flushLlmObs, loadDatadogApiKey } from "@jaypie/datadog";
 import { ConfigurationError, UnhandledError } from "@jaypie/errors";
 import { JAYPIE, jaypieHandler } from "@jaypie/kit";
+import type { ScrubOption } from "@jaypie/kit";
 import { log as publicLogger } from "@jaypie/logger";
 
 //
@@ -66,6 +67,7 @@ export interface LambdaStreamHandlerOptions {
   format?: StreamFormat;
   logEvent?: boolean;
   name?: string;
+  scrub?: ScrubOption;
   secrets?: string[];
   setup?: LifecycleFunction[];
   teardown?: LifecycleFunction[];
@@ -185,6 +187,7 @@ const lambdaStreamHandler = function <TEvent = unknown>(
     contentType = getContentTypeForFormat(format),
     logEvent = true,
     name,
+    scrub,
     secrets,
     setup = [],
     teardown,
@@ -306,6 +309,7 @@ const lambdaStreamHandler = function <TEvent = unknown>(
       {
         chaos,
         name,
+        scrub,
         setup,
         teardown,
         unavailable,

--- a/packages/lambda/src/websocketHandler.ts
+++ b/packages/lambda/src/websocketHandler.ts
@@ -6,6 +6,7 @@ import {
 } from "@jaypie/aws";
 import { ConfigurationError, UnhandledError } from "@jaypie/errors";
 import { JAYPIE, jaypieHandler } from "@jaypie/kit";
+import type { ScrubOption } from "@jaypie/kit";
 import { log as publicLogger } from "@jaypie/logger";
 
 //
@@ -73,6 +74,7 @@ export interface WebSocketHandlerOptions {
   logEvent?: boolean;
   logResponse?: boolean;
   name?: string;
+  scrub?: ScrubOption;
   secrets?: string[];
   setup?: LifecycleFunction[];
   teardown?: LifecycleFunction[];
@@ -136,6 +138,7 @@ const websocketHandler = function <TResult = WebSocketResponse>(
     logEvent = true,
     logResponse = true,
     name,
+    scrub,
     secrets,
     setup = [],
     teardown,
@@ -286,6 +289,7 @@ const websocketHandler = function <TResult = WebSocketResponse>(
       {
         chaos,
         name,
+        scrub,
         setup,
         teardown,
         unavailable,

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.119",
+  "version": "0.8.120",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/express/1.2.31.md
+++ b/packages/mcp/release-notes/express/1.2.31.md
@@ -1,0 +1,18 @@
+---
+version: 1.2.31
+date: 2026-08-01
+summary: Handlers accept the scrub option and preserve 4xx error detail
+---
+
+## Fixes
+
+- `expressHandler` and `expressStreamHandler` return the `detail` of a caught 4xx
+  Jaypie error as thrown. 500-class detail is still replaced with the generic
+  string for the status.
+
+## Features
+
+- `scrub` option forwarded to `jaypieHandler`, `boolean | { client?: boolean,
+  server?: boolean }`, defaulting to `{ client: false, server: true }`.
+
+Addresses issue #467.

--- a/packages/mcp/release-notes/fabric/0.3.8.md
+++ b/packages/mcp/release-notes/fabric/0.3.8.md
@@ -1,0 +1,13 @@
+---
+version: 0.3.8
+date: 2026-08-01
+summary: Fabric adapters forward the scrub option
+---
+
+## Features
+
+- `fabricExpress`, `fabricLambda`, and `fabricWebSocket` accept `scrub` and
+  forward it to the wrapping handler.
+- `ScrubOption` exported type.
+
+Addresses issue #467.

--- a/packages/mcp/release-notes/fabric/0.3.8.md
+++ b/packages/mcp/release-notes/fabric/0.3.8.md
@@ -1,7 +1,7 @@
 ---
 version: 0.3.8
 date: 2026-08-01
-summary: Fabric adapters forward the scrub option
+summary: Fabric adapters forward the scrub option; ServiceSuite registration accepts tags
 ---
 
 ## Features
@@ -9,5 +9,10 @@ summary: Fabric adapters forward the scrub option
 - `fabricExpress`, `fabricLambda`, and `fabricWebSocket` accept `scrub` and
   forward it to the wrapping handler.
 - `ScrubOption` exported type.
+- `ServiceSuite.register(service, { category, tags })` accepts cross-cutting
+  classifiers alongside the category grouping. `ServiceMeta.tags` is always an
+  array, `suite.tags` lists every registered tag sorted, and
+  `getServicesByTag(tag)` and `filterServices(predicate)` select from the suite.
+- `RegisterServiceOptions` exported type.
 
-Addresses issue #467.
+Addresses issues #467 and #468.

--- a/packages/mcp/release-notes/jaypie/1.2.76.md
+++ b/packages/mcp/release-notes/jaypie/1.2.76.md
@@ -1,0 +1,18 @@
+---
+version: 1.2.76
+date: 2026-08-01
+summary: Handlers preserve 4xx error detail and accept the scrub option
+---
+
+## Fixes
+
+- A caught 4xx Jaypie error reaches the caller with the `detail` the application
+  wrote. 500-class detail is still replaced with the generic string for the
+  status.
+
+## Features
+
+- `scrub` option on every handler, `boolean | { client?: boolean, server?:
+  boolean }`, defaulting to `{ client: false, server: true }`.
+
+Addresses issue #467.

--- a/packages/mcp/release-notes/kit/1.2.15.md
+++ b/packages/mcp/release-notes/kit/1.2.15.md
@@ -1,0 +1,28 @@
+---
+version: 1.2.15
+date: 2026-08-01
+summary: Handler preserves 4xx error detail and adds the scrub option
+---
+
+## Fixes
+
+- `jaypieHandler` no longer scrubs 4xx errors. A client error is only actionable
+  when it says what to correct, so `BadRequestError("data.confirm must match the
+  API key id")` again answers with that detail. 1.2.14 replaced it with the
+  generic string for the status, which removed the caller's only signal.
+- 500-class errors are still scrubbed: `detail` and `title` are replaced with the
+  generic strings for the status, so a message describing application internals
+  never reaches a response body.
+
+## Features
+
+- `scrub` option, `boolean | { client?: boolean, server?: boolean }`, defaults to
+  `{ client: false, server: true }`. `scrub: true` scrubs both classes,
+  `scrub: false` scrubs neither, and the object form sets either class
+  independently. Unspecified keys keep the default.
+- `JaypieHandlerOptions`, `ScrubOption`, and `ScrubOptions` are exported types.
+
+Scrubbing never changes what is logged: `log.var({ jaypieError })` always carries
+the error as thrown, and `status`, `message`, and `stack` are untouched.
+
+Addresses issue #467.

--- a/packages/mcp/release-notes/lambda/1.2.14.md
+++ b/packages/mcp/release-notes/lambda/1.2.14.md
@@ -1,0 +1,18 @@
+---
+version: 1.2.14
+date: 2026-08-01
+summary: Handlers accept the scrub option and preserve 4xx error detail
+---
+
+## Fixes
+
+- `lambdaHandler`, `lambdaStreamHandler`, and `websocketHandler` return the
+  `detail` of a caught 4xx Jaypie error as thrown. 500-class detail is still
+  replaced with the generic string for the status.
+
+## Features
+
+- `scrub` option forwarded to `jaypieHandler`, `boolean | { client?: boolean,
+  server?: boolean }`, defaulting to `{ client: false, server: true }`.
+
+Addresses issue #467.

--- a/packages/mcp/release-notes/mcp/0.8.120.md
+++ b/packages/mcp/release-notes/mcp/0.8.120.md
@@ -1,10 +1,12 @@
 ---
 version: 0.8.120
 date: 2026-08-01
-summary: Handler and log skills document the scrub option
+summary: Handler, log, and fabric skills document the scrub option and suite tags
 ---
 
 ## Documentation
 
 - `skill("handlers")` and `skill("logs")` describe the `scrub` option and the
   default of scrubbing 500-class error detail while preserving 4xx.
+- `skill("fabric")` documents ServiceSuite `tags`, `getServicesByTag`, and
+  `filterServices` for curating a transport surface's mounted service set.

--- a/packages/mcp/release-notes/mcp/0.8.120.md
+++ b/packages/mcp/release-notes/mcp/0.8.120.md
@@ -1,0 +1,10 @@
+---
+version: 0.8.120
+date: 2026-08-01
+summary: Handler and log skills document the scrub option
+---
+
+## Documentation
+
+- `skill("handlers")` and `skill("logs")` describe the `scrub` option and the
+  default of scrubbing 500-class error detail while preserving 4xx.

--- a/packages/mcp/skills/fabric.md
+++ b/packages/mcp/skills/fabric.md
@@ -148,14 +148,35 @@ const suite = createServiceSuite({
   version: "1.0.0",
 });
 
-suite.register(userService, { category: "users" });
-suite.register(userListService, { category: "users" });
+suite.register(userService, { category: "users", tags: ["immediate"] });
+suite.register(userListService, { category: "users", tags: ["long"] });
 
 // Access services
 suite.services;                    // ServiceMeta[] - metadata for listing
 suite.getServiceFunctions();       // Service[] - actual functions
 suite.execute("user_get", { id }); // Direct execution
 ```
+
+### Categories and Tags
+
+`category` groups a service; a service has exactly one. `tags` classify across
+categories; a service may carry any number. Transport surfaces curate their
+mounted set from suite metadata rather than a hand-maintained list:
+
+```typescript
+suite.categories;                  // string[] - every registered category, sorted
+suite.tags;                        // string[] - every registered tag, sorted
+suite.getServicesByCategory("users");
+suite.getServicesByTag("immediate");
+
+// A 2-minute Express surface mounts only what fits its ceiling
+const mounted = suite.filterServices(
+  (meta) => !meta.tags.includes("long") && !meta.tags.includes("local"),
+);
+```
+
+`ServiceMeta.tags` is always an array, empty when a service registers without
+tags. Duplicate tags collapse on registration.
 
 ### Suite to MCP Server
 

--- a/packages/mcp/skills/handlers.md
+++ b/packages/mcp/skills/handlers.md
@@ -33,6 +33,7 @@ All handlers accept these options:
 | Option | Type | Description |
 |--------|------|-------------|
 | `name` | `string` | Handler name for logging |
+| `scrub` | `boolean \| { client?: boolean, server?: boolean }` | Replace caught error `detail` and `title` with the generic strings for the status. Defaults to `{ client: false, server: true }` |
 | `setup` | `Function[]` | Pre-handler functions |
 | `teardown` | `Function[]` | Cleanup functions (always run) |
 | `unavailable` | `boolean` | Return 503 immediately |
@@ -159,7 +160,7 @@ All handlers catch errors and format responses:
 - **Unhandled errors**: Wrap in `UnhandledError`, log at fatal level
 - **With `throw: true`**: Re-throw instead of formatting (for custom handling)
 
-Every caught Jaypie error is logged as `log.var({ jaypieError: { detail, status, title } })` and then scrubbed: `detail` and `title` are replaced with the generic strings for the status, so a constructor message never reaches a response body. Do not use an error message to tell the caller anything — see `skill("logs")`.
+Every caught Jaypie error is logged as `log.var({ jaypieError: { detail, status, title } })`. A 500-class error is then scrubbed: `detail` and `title` are replaced with the generic strings for the status, so a constructor message describing application internals never reaches a response body. 4xx keeps the detail as thrown, since a client error is only actionable when it says what to correct. The `scrub` option overrides either class: `scrub: true` scrubs both, `scrub: false` scrubs neither, `scrub: { client: true }` or `scrub: { server: false }` sets one class — see `skill("logs")`.
 
 ```typescript
 import { NotFoundError, BadRequestError } from "jaypie";

--- a/packages/mcp/skills/logs.md
+++ b/packages/mcp/skills/logs.md
@@ -74,9 +74,9 @@ The handler lifecycle picks the level from the error's status, so an outage is v
 
 Either way the handler emits `log.var({ jaypieError: { detail, status, title } })` carrying the error as thrown. The same applies to errors thrown during `validate` and `teardown`. Non-Jaypie errors remain `log.fatal` plus `log.error`.
 
-### Detail is logged, then scrubbed
+### 5xx detail is logged, then scrubbed
 
-After logging, the handler replaces the error's `detail` and `title` with the generic strings for its status. The message an application passes to an error constructor reaches the logs and never reaches a response body.
+After logging a 500-class error, the handler replaces its `detail` and `title` with the generic strings for the status. The message an application passes to a 500-class error constructor reaches the logs and never reaches a response body.
 
 ```typescript
 throw new ConfigurationError("Fabric model chat is not registered");
@@ -86,11 +86,24 @@ throw new ConfigurationError("Fabric model chat is not registered");
 //   detail: "An unexpected error occurred and the request was unable to complete" }] }
 ```
 
-This applies to 4xx as well, so `NotFoundError("User 12345 not found")` answers `"The requested resource was not found"`. Do not use the error message to communicate with the caller. Return a normal response body when the caller needs specifics.
+4xx is not scrubbed. A client error is only actionable when it says what to correct, so `NotFoundError("User 12345 not found")` answers with that detail. Write 4xx messages for the caller and 5xx messages for the logs.
 
 `status`, `message`, and `stack` are untouched, so logs and handlers configured with `throw: true` still see the original.
 
-A status with no error class of its own falls to the generic for its class: an unmapped 4xx (422, 451, …) answers the bad request strings while keeping its own status, and 500-class falls to internal error. A status outside 4xx and 5xx has no correct substitute and is logged without scrubbing.
+### The `scrub` option
+
+Every handler accepts `scrub` to override the default of `{ client: false, server: true }`:
+
+```typescript
+expressHandler(handler, { scrub: true });              // scrub 4xx and 5xx
+expressHandler(handler, { scrub: false });             // scrub neither
+expressHandler(handler, { scrub: { client: true } });  // scrub 4xx as well
+expressHandler(handler, { scrub: { server: false } }); // return 5xx detail
+```
+
+Scrubbing never changes what is logged: `log.var({ jaypieError })` always carries the error as thrown.
+
+A scrubbed status with no error class of its own falls to the generic for its class: an unmapped 4xx (422, 451, …) answers the bad request strings while keeping its own status, and 500-class falls to internal error. A status outside 4xx and 5xx has no correct substitute and is never scrubbed.
 
 ## Session Management
 


### PR DESCRIPTION
Two issues, both landing on the already-bumped versions for this branch.

## #467 — jaypieHandler scrubbed 4xx detail with no opt-out

`jaypieHandler` replaced `detail` and `title` on every caught Jaypie error with the generic strings for its status. Scrubbing 5xx is right: that message describes application internals and belongs only in logs. Scrubbing 4xx removed the one thing that makes a client error actionable, so a deliberate `BadRequestError("data.confirm must match the API key id")` reached the caller as "The request was not properly formatted" with no way to learn what to fix.

The handler now scrubs 500-class only. A caught 4xx keeps the detail and title the application wrote. Logging is unchanged.

The `scrub` option (`boolean | { client?: boolean, server?: boolean }`) overrides either class and defaults to `{ client: false, server: true }`. Forwarded by `expressHandler`, `expressStreamHandler`, `lambdaHandler`, `lambdaStreamHandler`, `websocketHandler`, `fabricExpress`, `fabricLambda`, and `fabricWebSocket`.

## #468 — ServiceSuite.register accepted only category

A suite mounted behind several transport surfaces had no way to express facets orthogonal to the category grouping. A duration class (`immediate`, `short`, `long`, `interactive`) and an access class (`public`, `private`, `privileged`, `local`) cut across categories, and every surface needs both to curate the command set that fits its runtime ceiling.

- `register(service, { category, tags? })`
- `ServiceMeta.tags` is always an array, empty when none are given; duplicates collapse on registration
- `suite.tags` lists every registered tag sorted, paralleling `suite.categories`
- `getServicesByTag(tag)` selects on one tag
- `filterServices(predicate)` covers the compound case: a two-minute Express surface mounts `!tags.includes("long") && !tags.includes("local")` in one call
- `RegisterServiceOptions` exported from `@jaypie/fabric`

`category` stays required and remains the single grouping.

## Versions

`@jaypie/express` 1.2.31, `@jaypie/fabric` 0.3.8, `@jaypie/kit` 1.2.15, `@jaypie/lambda` 1.2.14, `@jaypie/mcp` 0.8.120, `jaypie` 1.2.76. Release notes accompany each.

## Verification

Root typecheck clean. Root test suite: 4119 passed, 254 files. Lint clean on all touched files.

Fixes #467
Fixes #468

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CujwCsRaPAKZpQuip24nvn