### PR TITLE
fix(fabric): parse JSON array strings for untyped Array inputs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15192,7 +15192,7 @@
     },
     "packages/fabric": {
       "name": "@jaypie/fabric",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*"
@@ -15545,7 +15545,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.121",
+      "version": "0.8.122",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.3.3",

--- a/packages/fabric/CLAUDE.md
+++ b/packages/fabric/CLAUDE.md
@@ -108,7 +108,7 @@ Located in `resolve.ts`. Handle flexible type conversion with predictable behavi
 | `fabricBoolean` | Convert to boolean (`"true"` -> `true`, positive numbers -> `true`) |
 | `fabricNumber` | Convert to number (`"true"` -> `1`, booleans -> `0`/`1`) |
 | `fabricString` | Convert to string (booleans -> `"true"`/`"false"`) |
-| `fabricArray` | Wrap non-arrays in array |
+| `fabricArray` | Wrap non-arrays in array (raw; `fabric(value, Array)` parses first) |
 | `resolveFromArray` | Extract single-element array to scalar |
 | `fabricObject` | Pass through objects; wrap scalars/arrays in `{ value: ... }` |
 | `resolveFromObject` | Extract `.value` if present; pass through otherwise |
@@ -245,6 +245,19 @@ fabric([1, 0], [Boolean])        // → [true, false]
 fabric([1, 2], [Object])         // → [{ value: 1 }, { value: 2 }]
 fabric([1, "a", true], [])       // → [1, "a", true] (untyped, no element conversion)
 ```
+
+`Array` and `"array"` are the untyped array declaration and behave exactly as
+`[]` does. They parse JSON array strings and split delimited strings, with no
+element conversion:
+
+```typescript
+fabric('[{"role":"user"}]', Array) // → [{ role: "user" }]
+fabric("a,b,c", Array)             // → ["a", "b", "c"]
+fabric("solo", Array)              // → ["solo"]
+```
+
+`fabricArray` remains the raw wrapper and does no parsing. Call `fabric` to get
+the parsing behavior.
 
 **String Splitting**: Strings with commas or tabs are automatically split before conversion:
 
@@ -570,7 +583,7 @@ This means:
 - `'[X]'` parses and unwraps for all scalar types
 - Objects JSON.stringify when coerced to String
 - JSON strings automatically parse
-- `"1,2,3"` splits into array when target is typed array
+- `"1,2,3"` splits into array when target is any array type
 - `"a\tb\tc"` splits on tabs when target is typed array
 - `["a", "b"]` as type means validated string (must be "a" or "b")
 - `/regex/` as type means string validated against pattern (bare RegExp)

--- a/packages/fabric/package.json
+++ b/packages/fabric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/fabric",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "Jaypie modeling framework with type conversion, service handlers, and adapters",
   "repository": {
     "type": "git",

--- a/packages/fabric/src/__tests__/commander.spec.ts
+++ b/packages/fabric/src/__tests__/commander.spec.ts
@@ -774,6 +774,116 @@ describe("Commander Adapter", () => {
       expect(capturedInput).toEqual({ count: 42, verbose: true });
     });
 
+    describe("Array inputs", () => {
+      // Commander declares every array option variadic, so the raw argument
+      // arrives wrapped in an array (Issue #475)
+      function arrayService(type: InputFieldDefinition["type"]): {
+        captured: () => unknown;
+        handler: ReturnType<typeof fabricService>;
+      } {
+        let capturedInput: unknown;
+        const handler = fabricService({
+          alias: "test",
+          input: {
+            items: { type },
+          },
+          service: (input) => {
+            capturedInput = input;
+            return input;
+          },
+        });
+        return { captured: () => capturedInput, handler };
+      }
+
+      it("parses a JSON array string on an untyped Array input", async () => {
+        const { captured, handler } = arrayService(Array);
+        fabricCommand({ program, service: handler });
+
+        await program.parseAsync([
+          "node",
+          "test",
+          "test",
+          "--items",
+          '[{"role":"user","content":"hi"}]',
+        ]);
+
+        expect(captured()).toEqual({
+          items: [{ role: "user", content: "hi" }],
+        });
+      });
+
+      it("parses a JSON array string on a [] input", async () => {
+        const { captured, handler } = arrayService([]);
+        fabricCommand({ program, service: handler });
+
+        await program.parseAsync([
+          "node",
+          "test",
+          "test",
+          "--items",
+          '[{"role":"user"}]',
+        ]);
+
+        expect(captured()).toEqual({ items: [{ role: "user" }] });
+      });
+
+      it("parses a multi-element JSON array string on a [String] input", async () => {
+        const { captured, handler } = arrayService([String]);
+        fabricCommand({ program, service: handler });
+
+        await program.parseAsync([
+          "node",
+          "test",
+          "test",
+          "--items",
+          '["a","b"]',
+        ]);
+
+        expect(captured()).toEqual({ items: ["a", "b"] });
+      });
+
+      it("splits a comma-separated string on an untyped Array input", async () => {
+        const { captured, handler } = arrayService(Array);
+        fabricCommand({ program, service: handler });
+
+        await program.parseAsync([
+          "node",
+          "test",
+          "test",
+          "--items",
+          "self:*,admin:read",
+        ]);
+
+        expect(captured()).toEqual({ items: ["self:*", "admin:read"] });
+      });
+
+      it("keeps multiple variadic values as separate entries", async () => {
+        const { captured, handler } = arrayService(Array);
+        fabricCommand({ program, service: handler });
+
+        await program.parseAsync([
+          "node",
+          "test",
+          "test",
+          "--items",
+          "a",
+          "b",
+          "c",
+        ]);
+
+        expect(captured()).toEqual({ items: ["a", "b", "c"] });
+      });
+
+      it("wraps a lone plain string in a single-element array", async () => {
+        const { captured, handler } = arrayService(Array);
+        fabricCommand({ program, service: handler });
+
+        await program.parseAsync(["node", "test", "test", "--items", "solo"]);
+
+        expect(captured()).toEqual({ items: ["solo"] });
+      });
+    });
+
     it("handles boolean flags with --no- prefix", () => {
       const handler = fabricService({
         alias: "test",

--- a/packages/fabric/src/__tests__/resolve.spec.ts
+++ b/packages/fabric/src/__tests__/resolve.spec.ts
@@ -453,6 +453,24 @@ describe("resolve", () => {
       expect(fabric([1, 2], Array)).toEqual([1, 2]);
     });
 
+    it("parses a JSON array string to Array", () => {
+      expect(fabric('["a","b"]', Array)).toEqual(["a", "b"]);
+      expect(fabric('[{"role":"user"}]', "array")).toEqual([{ role: "user" }]);
+      expect(fabric("[]", Array)).toEqual([]);
+    });
+
+    it("splits a delimited string to Array", () => {
+      expect(fabric("a,b,c", Array)).toEqual(["a", "b", "c"]);
+      expect(fabric("a\tb", Array)).toEqual(["a", "b"]);
+    });
+
+    it("matches the untyped typed-array declaration", () => {
+      const values = ['["a","b"]', "a,b", "solo", 42, ["a", "b"]];
+      for (const value of values) {
+        expect(fabric(value, Array)).toEqual(fabric(value, []));
+      }
+    });
+
     it("converts to Object", () => {
       expect(fabric(42, Object)).toEqual({ value: 42 });
       expect(fabric(42, "object")).toEqual({ value: 42 });

--- a/packages/fabric/src/commander/parseCommanderOptions.ts
+++ b/packages/fabric/src/commander/parseCommanderOptions.ts
@@ -94,6 +94,32 @@ function isObjectType(type: ConversionType): boolean {
 }
 
 /**
+ * Convert a string to an array
+ * - JSON array strings parse to that array
+ * - Comma or tab separated strings split into entries
+ * - Anything else becomes a single-element array
+ */
+function stringToArray(value: string): unknown[] {
+  // Try to parse as JSON first
+  try {
+    const parsed = JSON.parse(value);
+    if (Array.isArray(parsed)) {
+      return parsed;
+    }
+  } catch {
+    // Not JSON, check for comma or tab separated
+    if (value.includes(",")) {
+      return value.split(",").map((s) => s.trim());
+    }
+    if (value.includes("\t")) {
+      return value.split("\t").map((s) => s.trim());
+    }
+  }
+  // Single value becomes array
+  return [value];
+}
+
+/**
  * Convert a single value based on its target type
  */
 function convertValue(value: unknown, type: ConversionType): unknown {
@@ -148,26 +174,15 @@ function convertValue(value: unknown, type: ConversionType): unknown {
   // Array types - handle variadic options
   if (isArrayType(type)) {
     if (Array.isArray(value)) {
+      // Commander wraps every array option in an array, so a lone string
+      // element is the raw argument and may itself express the whole array
+      if (value.length === 1 && typeof value[0] === "string") {
+        return stringToArray(value[0]);
+      }
       return value;
     }
     if (typeof value === "string") {
-      // Try to parse as JSON first
-      try {
-        const parsed = JSON.parse(value);
-        if (Array.isArray(parsed)) {
-          return parsed;
-        }
-      } catch {
-        // Not JSON, check for comma or tab separated
-        if (value.includes(",")) {
-          return value.split(",").map((s) => s.trim());
-        }
-        if (value.includes("\t")) {
-          return value.split("\t").map((s) => s.trim());
-        }
-      }
-      // Single value becomes array
-      return [value];
+      return stringToArray(value);
     }
     return [value];
   }

--- a/packages/fabric/src/resolve.ts
+++ b/packages/fabric/src/resolve.ts
@@ -476,7 +476,9 @@ export function fabric(value: unknown, type: ConversionType): unknown {
 
   switch (normalizedType) {
     case "array":
-      return fabricArray(value);
+      // Array is the untyped array declaration; it behaves as [] does,
+      // parsing JSON array strings and splitting delimited strings
+      return fabricTypedArray(value, undefined);
     case "boolean":
       return fabricBoolean(value);
     case "number":

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.121",
+  "version": "0.8.122",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/fabric/0.3.10.md
+++ b/packages/mcp/release-notes/fabric/0.3.10.md
@@ -1,0 +1,18 @@
+---
+version: 0.3.10
+date: 2026-08-02
+summary: Untyped Array inputs parse JSON array strings on the command line
+---
+
+## Changes
+
+- `fabric(value, Array)` and `fabric(value, "array")` now behave exactly as the
+  untyped typed-array declaration `[]` does: a JSON array string parses to that
+  array, and a comma or tab delimited string splits into entries. Previously the
+  untyped declaration accepted strictly less than `[String]` (#475).
+- `parseCommanderOptions` unwraps Commander's variadic wrapping. Every array
+  option is declared variadic, so the raw argument arrives as a single-element
+  array; that lone string is now parsed rather than passed through. Objects
+  inside an array input are reachable from the CLI for the first time, and
+  `[String]` with a multi-element JSON array string no longer throws.
+- `fabricArray` is unchanged. It remains the raw wrapper and does no parsing.

--- a/packages/mcp/release-notes/mcp/0.8.122.md
+++ b/packages/mcp/release-notes/mcp/0.8.122.md
@@ -1,0 +1,12 @@
+---
+version: 0.8.122
+date: 2026-08-02
+summary: Document the three accepted forms for fabric CLI array inputs
+---
+
+## Changes
+
+- `skills/fabric.md` documents array inputs on the CLI command adapter: JSON
+  array string, comma or tab delimited string, and separate arguments. Notes
+  that `type: Array` and `type: []` behave identically and that objects inside
+  an array input are only reachable through the JSON form.

--- a/packages/mcp/skills/fabric.md
+++ b/packages/mcp/skills/fabric.md
@@ -51,6 +51,19 @@ program.addCommand(fabricCommand(greetService));
 // $ cli greet --name World
 ```
 
+Array inputs are variadic and accept three forms. `type: Array` and `type: []`
+behave identically; a typed array such as `[String]` additionally converts each
+element.
+
+```bash
+cli chat --messages '[{"role":"user","content":"hi"}]'  # JSON array string
+cli grant --permissions 'self:*,admin:read'             # comma or tab delimited
+cli tag --labels alpha beta gamma                       # separate arguments
+```
+
+A lone argument that is neither JSON nor delimited becomes a single-element
+array. Objects inside an array input are only reachable through the JSON form.
+
 ### MCP Tool
 
 ```typescript


### PR DESCRIPTION
Closes #475

## Problem

The commander adapter declares every array option variadic (`--items <items...>`), so Commander hands `parseCommanderOptions` an array and the string-handling branch below it was unreachable. Objects inside an array input were unreachable from the command line, and the defect was broader than reported: `[]` behaved like `Array`, and `[String]` given a multi-element JSON string threw.

| declared | argument | before | after |
|---|---|---|---|
| `Array` | `[{"role":"user","content":"hi"}]` | `["[{\"role\"…]"]` | `[{role:"user",content:"hi"}]` |
| `Array` | `self:*,admin:read` | `["self:*,admin:read"]` | `["self:*","admin:read"]` |
| `[]` | `[{"role":"user"}]` | `["[{\"role\"…]"]` | `[{role:"user"}]` |
| `[String]` | `["a","b"]` | **threw** | `["a","b"]` |
| `[String]` | `a,b,c` | `["a,b,c"]` | `["a","b","c"]` |

## Changes

- `packages/fabric/src/resolve.ts` — `Array` and `"array"` route through `fabricTypedArray(value, undefined)`, which is exactly what `[]` does. The untyped declaration no longer accepts less than `[String]`.
- `packages/fabric/src/commander/parseCommanderOptions.ts` — extracted `stringToArray` and applied it to Commander's variadic wrapping, so a lone string element is parsed rather than passed through.
- `fabricArray` is untouched. It stays the raw wrapper; parsing lives in `fabric`.

The issue left comma splitting for untyped arrays as a separate decision. It is applied here, because `[]` already splits and leaving `Array` different from `[]` would preserve half the asymmetry. A parity test asserts the two declarations produce identical output across input shapes.

## Coverage

- 6 tests in `commander.spec.ts` (`describe("Array inputs")`) exercising the real mounted-command path, not the parser directly. The prior test passed only because it called `parseCommanderOptions` with a raw string, bypassing Commander entirely.
- 3 tests in `resolve.spec.ts`, including the `Array` ≡ `[]` parity assertion.
- Full repo: 4284 passed, 0 failures. Typecheck, build, and lint clean.

## Versioning

`@jaypie/fabric` 0.3.10, `@jaypie/mcp` 0.8.122, release notes for both, lockfile updated. `jaypie` does not depend on fabric, so no umbrella bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011qBLiUdsXkVkxUa2fjusdt