### PR TITLE
feat(llm): wait and retry rate limits on a dedicated budget

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15459,7 +15459,7 @@
     },
     "packages/llm": {
       "name": "@jaypie/llm",
-      "version": "1.3.24",
+      "version": "1.3.25",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "*",
@@ -15545,7 +15545,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.122",
+      "version": "0.8.123",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.3.3",
@@ -15625,7 +15625,7 @@
     },
     "packages/testkit": {
       "name": "@jaypie/testkit",
-      "version": "1.2.62",
+      "version": "1.2.63",
       "license": "MIT",
       "dependencies": {
         "jest-json-schema": "^6.1.0",

--- a/packages/llm/CLAUDE.md
+++ b/packages/llm/CLAUDE.md
@@ -286,7 +286,7 @@ the failed call.
 | Class | `category` | `status` | When |
 |-------|-----------|----------|------|
 | `LlmAbortError` | `aborted` | 499 | The caller's `signal` aborted the request; never retried |
-| `LlmRateLimitError` | `rate_limit` | 429 | Short-term rate limit; carries `retryAfterMs` |
+| `LlmRateLimitError` | `rate_limit` | 429 | Short-term rate limit survived the rate-limit retry budget; carries `retryAfterMs` |
 | `LlmQuotaError` | `quota` | 402 | Quota exhausted or insufficient funds; `reason: "quota" \| "billing"` |
 | `LlmUnrecoverableError` | `unrecoverable` | 502 | Bad request / auth / not found |
 | `LlmTransientError` | `retryable` | 504 | A transient/unknown error survived the retry budget |
@@ -300,7 +300,8 @@ try {
   if (error instanceof LlmQuotaError) {
     // terminal: exhausted quota or unbillable account (error.reason)
   } else if (error instanceof LlmRateLimitError) {
-    // back off error.retryAfterMs and retry
+    // the wait already happened and did not clear; error.retryAfterMs
+    // reports what was waited
   }
 }
 ```
@@ -310,9 +311,41 @@ consults the shared `classifyProviderError` pass so that cross-provider
 conditions agree: retryable structured-output compile timeouts (e.g. Anthropic
 `Grammar compilation timed out.`, issue #422), exhausted quota, and billing
 failures classify the same everywhere. A daily-quota `429` is classified as
-`Quota` (terminal), not `RateLimit`. Rate-limit and quota errors are **not**
-auto-retried within the request budget; they throw immediately as typed errors
-so the caller decides.
+`Quota` (terminal), not `RateLimit`. Quota errors are never retried: waiting
+does not refill an exhausted plan.
+
+### Rate Limit Backoff
+
+A rate-limited request waits and retries by default. The wait draws on a budget
+**separate from the transient-error retries**, so throttling never spends the
+retries reserved for a flaky socket, and a transient failure never eats the
+allowance for a 429.
+
+| Knob | Default | Meaning |
+|------|---------|---------|
+| `rateLimitRetries` | 2 | Attempts granted to a rate-limited request; 0 disables |
+| `rateLimitMaxDelayMs` | 90,000 | Ceiling on a single wait |
+
+The wait itself is the provider's `suggestedDelayMs` (every adapter reports
+60,000 today) when there is one, otherwise it grows from a one-minute floor by
+the policy's backoff factor. Either way it is capped. Waits are interruptible:
+a caller `signal` that aborts mid-wait ends the call immediately rather than
+holding the request for the remaining minute.
+
+```typescript
+await Llm.operate(input, { model: "mistral-large-latest" }); // waits and retries
+
+await Llm.operate(input, { retry: { rateLimit: false } });   // throws at once
+await Llm.operate(input, {
+  retry: { rateLimit: { maxDelayMs: 30_000, maxRetries: 1 } },
+});
+```
+
+**A configured fallback chain wins over waiting.** Reaching for another
+provider is strictly faster than sleeping a minute, so the facade tells every
+attempt that has somewhere left to go not to wait; only the final entry in the
+chain keeps its budget. An explicit `retry` option from the caller overrides
+that and applies to every attempt.
 
 **Model array sugar:**
 
@@ -895,14 +928,20 @@ knobs: `APP_MODELS`, `APP_GROUP`, `APP_CAPABILITIES`, `APP_USER`, `APP_FORCE`
 
 **Request pacing** (`test/rateLimit.ts`) exists because Mistral enforces a
 requests-per-second ceiling that varies by tier and by model, and returns a
-bare 429 with no `Retry-After`. `operate()` classifies rate limits as terminal
-and does not retry them, so an unpaced run fails on throttling rather than on
-capability. Pacing is applied per **model request** via the
+bare 429 with no `Retry-After`. Pacing keeps the run under that ceiling rather
+than relying on recovery. Pacing is applied per **model request** via the
 `beforeEachModelRequest` hook, not per cell — one cell is a multi-turn loop
 issuing many requests. Limiters are keyed by model and outlive the cell;
 scoping one to a cell lets each cell's first request fire unspaced, which is
 its own source of spurious `Rate limit exceeded` cells. Current rates: Mistral
 Large 0.07 req/s, the rest of the Mistral catalog 0.83 req/s.
+
+Pacing is not sufficient on its own: a paced run still lost a
+`mistral-large-latest / pdf` cell to `Rate limit exceeded` while spacing
+correctly at 14.3s, which points at a token-per-minute ceiling that
+request-count pacing cannot see. The matrix now also inherits the library's
+rate-limit backoff, so a 429 that slips past pacing waits and retries instead
+of failing the cell.
 
 ## Commands
 

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/llm",
-  "version": "1.3.24",
+  "version": "1.3.25",
   "description": "Large language model utilities",
   "repository": {
     "type": "git",

--- a/packages/llm/src/Llm.ts
+++ b/packages/llm/src/Llm.ts
@@ -228,13 +228,22 @@ class Llm implements LlmProvider {
       fallback: false as const,
     };
 
+    // Reaching for another provider beats waiting out a rate limit, so every
+    // attempt with somewhere left to go fails fast instead of sleeping. The
+    // final attempt keeps the wait: there is no cheaper remedy left. An
+    // explicit `retry` option from the caller wins over both.
+    const eagerOptions =
+      fallbackChain.length > 0 && resolvedOptions.retry === undefined
+        ? { ...optionsWithoutFallback, retry: { rateLimit: false as const } }
+        : optionsWithoutFallback;
+
     let lastError: Error | undefined;
     let attempts = 0;
 
     // Try primary provider first
     attempts++;
     try {
-      const response = await this._llm.operate(input, optionsWithoutFallback);
+      const response = await this._llm.operate(input, eagerOptions);
       const settled = {
         ...response,
         fallbackAttempts: attempts,
@@ -257,7 +266,7 @@ class Llm implements LlmProvider {
     // Try fallback providers. The fallback instance's underlying provider is
     // called directly so the nested facade does not settle the exchange —
     // exactly one settlement per operate() happens here.
-    for (const fallbackConfig of fallbackChain) {
+    for (const [index, fallbackConfig] of fallbackChain.entries()) {
       attempts++;
       try {
         const fallbackInstance = this.createFallbackInstance(fallbackConfig);
@@ -266,9 +275,10 @@ class Llm implements LlmProvider {
             `Provider ${fallbackConfig.provider} does not support operate method`,
           );
         }
+        const isLastAttempt = index === fallbackChain.length - 1;
         const response = await fallbackInstance._llm.operate(
           input,
-          optionsWithoutFallback,
+          isLastAttempt ? optionsWithoutFallback : eagerOptions,
         );
         const settled = {
           ...response,

--- a/packages/llm/src/__tests__/Llm.class.spec.ts
+++ b/packages/llm/src/__tests__/Llm.class.spec.ts
@@ -325,6 +325,55 @@ describe("Llm Class", () => {
       });
     });
 
+    describe("rate limit waits", () => {
+      // Reaching for another provider beats sleeping out a rate limit, so
+      // every attempt with somewhere left to go is told not to wait
+      it("disables the wait on every attempt but the last", async () => {
+        openAiOperateMock.mockRejectedValue(new Error("OpenAI failed"));
+        anthropicOperateMock.mockRejectedValue(new Error("Anthropic failed"));
+
+        const llm = new Llm(PROVIDER.OPENAI.NAME, {
+          fallback: [
+            { provider: PROVIDER.ANTHROPIC.NAME },
+            { provider: PROVIDER.GOOGLE.NAME },
+          ],
+        });
+
+        await llm.operate("test");
+
+        expect(openAiOperateMock.mock.calls[0][1]).toMatchObject({
+          retry: { rateLimit: false },
+        });
+        expect(anthropicOperateMock.mock.calls[0][1]).toMatchObject({
+          retry: { rateLimit: false },
+        });
+        // The last provider has nowhere left to go, so it keeps the wait
+        expect(geminiOperateMock.mock.calls[0][1].retry).toBeUndefined();
+      });
+
+      it("leaves the wait in place when no fallback is configured", async () => {
+        const llm = new Llm(PROVIDER.OPENAI.NAME);
+
+        await llm.operate("test");
+
+        expect(openAiOperateMock.mock.calls[0][1].retry).toBeUndefined();
+      });
+
+      it("honors an explicit retry option over the fallback default", async () => {
+        openAiOperateMock.mockRejectedValue(new Error("OpenAI failed"));
+
+        const llm = new Llm(PROVIDER.OPENAI.NAME, {
+          fallback: [{ provider: PROVIDER.ANTHROPIC.NAME }],
+        });
+
+        await llm.operate("test", { retry: { rateLimit: true } });
+
+        expect(openAiOperateMock.mock.calls[0][1]).toMatchObject({
+          retry: { rateLimit: true },
+        });
+      });
+    });
+
     describe("per-call override", () => {
       it("overrides instance config with per-call fallback", async () => {
         openAiOperateMock.mockRejectedValue(new Error("Primary failed"));

--- a/packages/llm/src/index.ts
+++ b/packages/llm/src/index.ts
@@ -80,6 +80,13 @@ export {
 export type { LlmErrorOptions } from "./errors/LlmError.js";
 export { ErrorCategory } from "./operate/types.js";
 
+// Retry
+export { RetryPolicy } from "./operate/retry/index.js";
+export type {
+  LlmRetryOptions,
+  RetryPolicyConfig,
+} from "./operate/retry/index.js";
+
 // Exchange persistence
 export { useExchangeStore } from "./observability/exchangeStore.js";
 export type {

--- a/packages/llm/src/operate/OperateLoop.ts
+++ b/packages/llm/src/operate/OperateLoop.ts
@@ -52,6 +52,7 @@ import {
 import {
   defaultRetryPolicy,
   ErrorClassifier,
+  resolveRetryPolicy,
   RetryExecutor,
   RetryPolicy,
 } from "./retry/index.js";
@@ -593,7 +594,10 @@ export class OperateLoop {
     const retryExecutor = new RetryExecutor({
       errorClassifier,
       hookRunner: this.hookRunnerInstance,
-      policy: this.retryPolicy,
+      policy: resolveRetryPolicy({
+        policy: this.retryPolicy,
+        retry: options.retry,
+      }),
     });
 
     // Build provider-specific request

--- a/packages/llm/src/operate/StreamLoop.ts
+++ b/packages/llm/src/operate/StreamLoop.ts
@@ -3,7 +3,6 @@ import {
   BadRequestError,
   TooManyRequestsError,
 } from "@jaypie/errors";
-import { sleep } from "@jaypie/kit";
 import { JsonObject } from "@jaypie/types";
 
 import { MAX_CONSECUTIVE_TOOL_ERRORS } from "./OperateLoop.js";
@@ -37,6 +36,7 @@ import {
   usageToLlmObsMetrics,
   withLlmObsSpan,
 } from "../observability/llmobs.js";
+import { abortableSleep } from "../util/abortableSleep.js";
 import { combineAbortSignals } from "../util/abortSignal.js";
 import { toAbortError } from "../errors/toAbortError.js";
 import { getLogger, maxTurnsFromOptions, tallyOperate } from "../util/index.js";
@@ -50,8 +50,13 @@ import { ProviderAdapter } from "./adapters/ProviderAdapter.interface.js";
 import { HookRunner, hookRunner } from "./hooks/index.js";
 import { InputProcessor, inputProcessor } from "./input/index.js";
 import { resolveResume } from "./resume/index.js";
-import { defaultRetryPolicy, RetryPolicy } from "./retry/index.js";
 import {
+  defaultRetryPolicy,
+  resolveRetryPolicy,
+  RetryPolicy,
+} from "./retry/index.js";
+import {
+  ErrorCategory,
   OperateContext,
   OperateRequest,
   PendingToolCall,
@@ -634,7 +639,12 @@ export class StreamLoop {
     const collectedToolCalls: StandardToolCall[] = [];
 
     // Retry loop for connection-level failures
+    const policy = resolveRetryPolicy({
+      policy: this.retryPolicy,
+      retry: options.retry,
+    });
     let attempt = 0;
+    let rateLimitAttempt = 0;
     let chunksYielded = false;
 
     // Guard against stale rejections firing after the stream loop has already
@@ -765,27 +775,62 @@ export class StreamLoop {
             return { shouldContinue: false };
           }
 
+          // A rate limit draws on its own budget and waits the provider's
+          // suggested delay. Nothing has been yielded at this point, so the
+          // wait is invisible to the consumer.
+          const classified = this.adapter.classifyError(error);
+          if (classified.category === ErrorCategory.RateLimit) {
+            if (!policy.shouldRetryRateLimit(rateLimitAttempt)) {
+              log.error(
+                `Stream request rate limited after ${policy.rateLimitRetries} retries`,
+              );
+              log.var({ error });
+              llmSpan?.finish();
+              throw toLlmError(classified, {
+                model: options.model ?? this.adapter.defaultModel,
+                provider: this.adapter.name,
+              });
+            }
+
+            const rateLimitDelay = policy.getRateLimitDelay({
+              attempt: rateLimitAttempt,
+              suggestedDelayMs: classified.suggestedDelayMs,
+            });
+            log.warn(
+              `Stream request rate limited. Retrying in ${rateLimitDelay}ms...`,
+            );
+            log.var({ error });
+
+            await abortableSleep({
+              ms: rateLimitDelay,
+              signal: options.signal,
+            });
+            rateLimitAttempt++;
+            state.retries++;
+            continue;
+          }
+
           // Check if we've exhausted retries or error is not retryable
           if (
-            !this.retryPolicy.shouldRetry(attempt) ||
+            !policy.shouldRetry(attempt) ||
             !this.adapter.isRetryableError(error)
           ) {
             log.error(
-              `Stream request failed after ${this.retryPolicy.maxRetries} retries`,
+              `Stream request failed after ${policy.maxRetries} retries`,
             );
             log.var({ error });
             llmSpan?.finish();
-            throw toLlmError(this.adapter.classifyError(error), {
+            throw toLlmError(classified, {
               model: options.model ?? this.adapter.defaultModel,
               provider: this.adapter.name,
             });
           }
 
-          const delay = this.retryPolicy.getDelayForAttempt(attempt);
+          const delay = policy.getDelayForAttempt(attempt);
           log.warn(`Stream request failed. Retrying in ${delay}ms...`);
           log.var({ error });
 
-          await sleep(delay);
+          await abortableSleep({ ms: delay, signal: options.signal });
           attempt++;
           state.retries++;
         }

--- a/packages/llm/src/operate/__tests__/StreamLoop.spec.ts
+++ b/packages/llm/src/operate/__tests__/StreamLoop.spec.ts
@@ -1745,6 +1745,117 @@ describe("StreamLoop", () => {
       // Should have only attempted once
       expect(mockAdapter.executeStreamRequest).toHaveBeenCalledTimes(1);
     });
+
+    describe("Rate Limits", () => {
+      function rateLimitAdapter(failures: number): void {
+        let callCount = 0;
+        mockAdapter.executeStreamRequest = vi.fn(
+          async function* (): AsyncIterable<LlmStreamChunk> {
+            callCount++;
+            if (callCount <= failures) {
+              throw new Error("Rate limit exceeded");
+            }
+            yield { type: LlmStreamChunkType.Text, content: "Success" };
+            yield {
+              type: LlmStreamChunkType.Done,
+              usage: [
+                {
+                  input: 10,
+                  output: 5,
+                  reasoning: 0,
+                  total: 15,
+                  provider: "mock",
+                  model: "mock-model",
+                },
+              ],
+            };
+          },
+        );
+
+        // Adapters report a rate limit as non-retryable; the loop's own
+        // budget is what grants the retry
+        mockAdapter.classifyError = vi.fn(() => ({
+          error: new Error("Rate limit exceeded"),
+          category: ErrorCategory.RateLimit,
+          shouldRetry: false,
+          suggestedDelayMs: 1,
+        }));
+        mockAdapter.isRetryableError = vi.fn(() => false);
+      }
+
+      it("waits and retries a rate-limited stream", async () => {
+        rateLimitAdapter(1);
+
+        const loop = new StreamLoop({
+          adapter: mockAdapter,
+          client: mockClient,
+          retryPolicy: new RetryPolicy({ rateLimitMaxDelayMs: 1 }),
+        });
+
+        const chunks = await collectChunks(loop.execute("Hello"));
+
+        expect(mockAdapter.executeStreamRequest).toHaveBeenCalledTimes(2);
+        const textChunks = chunks.filter(
+          (c) => c.type === LlmStreamChunkType.Text,
+        );
+        expect(textChunks[0]).toMatchObject({ content: "Success" });
+      });
+
+      it("throws once the rate limit budget is exhausted", async () => {
+        rateLimitAdapter(Infinity);
+
+        const loop = new StreamLoop({
+          adapter: mockAdapter,
+          client: mockClient,
+          retryPolicy: new RetryPolicy({
+            rateLimitMaxDelayMs: 1,
+            rateLimitRetries: 2,
+          }),
+        });
+
+        await expect(collectChunks(loop.execute("Hello"))).rejects.toThrow(
+          "Rate limit exceeded",
+        );
+
+        // Initial attempt + 2 rate limit retries
+        expect(mockAdapter.executeStreamRequest).toHaveBeenCalledTimes(3);
+      });
+
+      it("honors retry rateLimit false", async () => {
+        rateLimitAdapter(Infinity);
+
+        const loop = new StreamLoop({
+          adapter: mockAdapter,
+          client: mockClient,
+        });
+
+        await expect(
+          collectChunks(loop.execute("Hello", { retry: { rateLimit: false } })),
+        ).rejects.toThrow("Rate limit exceeded");
+
+        expect(mockAdapter.executeStreamRequest).toHaveBeenCalledTimes(1);
+      });
+
+      it("does not spend the transient retry budget", async () => {
+        rateLimitAdapter(Infinity);
+
+        const loop = new StreamLoop({
+          adapter: mockAdapter,
+          client: mockClient,
+          retryPolicy: new RetryPolicy({
+            maxRetries: 1,
+            rateLimitMaxDelayMs: 1,
+            rateLimitRetries: 2,
+          }),
+        });
+
+        await expect(collectChunks(loop.execute("Hello"))).rejects.toThrow(
+          "Rate limit exceeded",
+        );
+
+        expect(mockAdapter.executeStreamRequest).toHaveBeenCalledTimes(3);
+      });
+    });
   });
 
   describe("Tool Error Handling (Issue #242)", () => {

--- a/packages/llm/src/operate/__tests__/rateLimitRetry.spec.ts
+++ b/packages/llm/src/operate/__tests__/rateLimitRetry.spec.ts
@@ -1,0 +1,230 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { OperateLoop, OperateLoopConfig } from "../OperateLoop.js";
+import { BaseProviderAdapter } from "../adapters/index.js";
+import { LlmQuotaError, LlmRateLimitError } from "../../errors/LlmError.js";
+import { RetryPolicy } from "../retry/RetryPolicy.js";
+import { ErrorCategory, ParsedResponse } from "../types.js";
+
+//
+//
+// Mock
+//
+
+vi.mock("@jaypie/kit", () => ({
+  JAYPIE: {
+    LIB: {
+      LLM: "@jaypie/llm",
+    },
+  },
+  placeholders: vi.fn((str: string) => str),
+  resolveValue: vi.fn((val) => val),
+  sleep: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@jaypie/logger", () => ({
+  log: {
+    lib: vi.fn(() => ({
+      debug: vi.fn(),
+      error: vi.fn(),
+      trace: Object.assign(vi.fn(), { var: vi.fn() }),
+      var: vi.fn(),
+      warn: vi.fn(),
+    })),
+    tally: vi.fn(),
+  },
+}));
+
+//
+//
+// Fixtures
+//
+
+const MOCK_USAGE = {
+  input: 10,
+  model: "mock-model",
+  output: 20,
+  provider: "mock",
+  reasoning: 0,
+  total: 30,
+};
+
+// Waits are pinned to 1ms so the suite exercises the real sleep path without
+// spending the provider's suggested minute
+const FAST_POLICY = new RetryPolicy({ rateLimitMaxDelayMs: 1 });
+
+class MockAdapter extends BaseProviderAdapter {
+  readonly name = "mock";
+  readonly defaultModel = "mock-model";
+
+  category: ErrorCategory = ErrorCategory.RateLimit;
+  failures = 1;
+  calls = 0;
+
+  buildRequest = vi.fn((request) => request);
+  formatTools = vi.fn(() => []);
+  formatOutputSchema = vi.fn((schema) => schema);
+  executeRequest = vi.fn((): Promise<unknown> => {
+    this.calls++;
+    if (this.calls <= this.failures) {
+      return Promise.reject(new Error("Rate limit exceeded"));
+    }
+    return Promise.resolve({ content: [{ text: "Hello!", type: "text" }] });
+  });
+  parseResponse = vi.fn((response): ParsedResponse => ({
+    content: "Hello!",
+    hasToolCalls: false,
+    raw: response,
+    stopReason: "end_turn",
+    usage: MOCK_USAGE,
+  }));
+  extractToolCalls = vi.fn(() => []);
+  extractUsage = vi.fn(() => MOCK_USAGE);
+  formatToolResult = vi.fn(() => ({}));
+  appendToolResult = vi.fn((request) => request);
+  responseToHistoryItems = vi.fn(() => []);
+  classifyError = vi.fn((error: unknown) => ({
+    category: this.category,
+    error,
+    shouldRetry: false,
+    suggestedDelayMs: 60000,
+  }));
+  isComplete = vi.fn(() => true);
+  // Adapters report a rate limit as non-retryable; the dedicated budget is
+  // what grants the retry
+  isRetryableError = vi.fn(() => false);
+}
+
+function operateConfig(
+  adapter: MockAdapter,
+  retryPolicy: RetryPolicy = FAST_POLICY,
+): OperateLoopConfig {
+  return { adapter, client: {}, retryPolicy };
+}
+
+//
+//
+// Tests
+//
+
+describe("Rate Limit Retry", () => {
+  let adapter: MockAdapter;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    adapter = new MockAdapter();
+  });
+
+  describe("Base Cases", () => {
+    it("passes a request through untouched when nothing is rate limited", async () => {
+      adapter.failures = 0;
+      const loop = new OperateLoop(operateConfig(adapter));
+
+      const response = await loop.execute("Hello");
+
+      expect(response.content).toBe("Hello!");
+      expect(adapter.executeRequest).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("Happy Paths", () => {
+    it("waits and retries a rate-limited request by default", async () => {
+      const loop = new OperateLoop(operateConfig(adapter));
+
+      const response = await loop.execute("Hello");
+
+      expect(response.content).toBe("Hello!");
+      expect(adapter.executeRequest).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("Error Conditions", () => {
+    it("throws LlmRateLimitError once the budget is exhausted", async () => {
+      adapter.failures = Infinity;
+      const loop = new OperateLoop(
+        operateConfig(
+          adapter,
+          new RetryPolicy({ rateLimitMaxDelayMs: 1, rateLimitRetries: 2 }),
+        ),
+      );
+
+      await expect(loop.execute("Hello")).rejects.toThrow(LlmRateLimitError);
+      // Initial attempt + 2 rate limit retries
+      expect(adapter.executeRequest).toHaveBeenCalledTimes(3);
+    });
+
+    it("never retries a quota error", async () => {
+      adapter.category = ErrorCategory.Quota;
+      adapter.failures = Infinity;
+      const loop = new OperateLoop(operateConfig(adapter));
+
+      await expect(loop.execute("Hello")).rejects.toThrow(LlmQuotaError);
+      expect(adapter.executeRequest).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("Features", () => {
+    it("restores terminal behavior with retry rateLimit false", async () => {
+      adapter.failures = Infinity;
+      const loop = new OperateLoop(operateConfig(adapter));
+
+      await expect(
+        loop.execute("Hello", { retry: { rateLimit: false } }),
+      ).rejects.toThrow(LlmRateLimitError);
+      expect(adapter.executeRequest).toHaveBeenCalledTimes(1);
+    });
+
+    it("tunes the budget from the retry option", async () => {
+      adapter.failures = Infinity;
+      const loop = new OperateLoop(operateConfig(adapter));
+
+      await expect(
+        loop.execute("Hello", {
+          retry: { rateLimit: { maxDelayMs: 1, maxRetries: 3 } },
+        }),
+      ).rejects.toThrow(LlmRateLimitError);
+      // Initial attempt + 3 rate limit retries
+      expect(adapter.executeRequest).toHaveBeenCalledTimes(4);
+    });
+
+    it("does not spend the transient retry budget", async () => {
+      adapter.failures = Infinity;
+      const loop = new OperateLoop(
+        operateConfig(
+          adapter,
+          new RetryPolicy({
+            maxRetries: 1,
+            rateLimitMaxDelayMs: 1,
+            rateLimitRetries: 2,
+          }),
+        ),
+      );
+
+      await expect(loop.execute("Hello")).rejects.toThrow(LlmRateLimitError);
+      expect(adapter.executeRequest).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe("Fallback Interaction", () => {
+    // A configured fallback is a faster remedy than waiting, so the facade
+    // tells every attempt with somewhere left to go not to sleep
+    it("fails fast when the facade disables the wait", async () => {
+      adapter.failures = Infinity;
+      const loop = new OperateLoop(operateConfig(adapter));
+
+      await expect(
+        loop.execute("Hello", { retry: { rateLimit: false } }),
+      ).rejects.toThrow(LlmRateLimitError);
+      expect(adapter.executeRequest).toHaveBeenCalledTimes(1);
+    });
+
+    it("waits on the final attempt, which has nowhere left to go", async () => {
+      const loop = new OperateLoop(operateConfig(adapter));
+
+      const response = await loop.execute("Hello");
+
+      expect(response.content).toBe("Hello!");
+      expect(adapter.executeRequest).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/packages/llm/src/operate/retry/RetryExecutor.ts
+++ b/packages/llm/src/operate/retry/RetryExecutor.ts
@@ -1,5 +1,4 @@
-import { sleep } from "@jaypie/kit";
-
+import { abortableSleep } from "../../util/abortableSleep.js";
 import { combineAbortSignals } from "../../util/abortSignal.js";
 import { getLogger } from "../../util/index.js";
 import { toAbortError } from "../../errors/toAbortError.js";
@@ -10,7 +9,7 @@ import {
   LlmHooks,
 } from "../hooks/HookRunner.js";
 import { RetryPolicy, defaultRetryPolicy } from "./RetryPolicy.js";
-import { ClassifiedError } from "../types.js";
+import { ClassifiedError, ErrorCategory } from "../types.js";
 import { toLlmError } from "../../errors/toLlmError.js";
 
 //
@@ -112,6 +111,7 @@ export class RetryExecutor {
   ): Promise<T> {
     const log = getLogger();
     let attempt = 0;
+    let rateLimitAttempt = 0;
 
     // Guard against stale rejections firing on a subsequent microtask after
     // the retry layer has already caught the originating error: undici socket
@@ -150,6 +150,52 @@ export class RetryExecutor {
           if (options.signal?.aborted) {
             log.debug("API call aborted by caller");
             throw this.toCallerAbortError(error, options);
+          }
+
+          // A rate limit clears on wall-clock time. It draws on its own budget
+          // so throttling never consumes the transient-error retries, and it
+          // waits the provider's suggested delay rather than a backoff ramp.
+          // Quota is a sibling category and stays terminal: waiting does not
+          // refill an exhausted plan.
+          const classified = this.errorClassifier.classify(error);
+          if (classified.category === ErrorCategory.RateLimit) {
+            if (!this.policy.shouldRetryRateLimit(rateLimitAttempt)) {
+              log.error(
+                `API call rate limited after ${this.policy.rateLimitRetries} retries`,
+              );
+              log.var({ error });
+
+              await this.hookRunner.runOnUnrecoverableError(options.hooks, {
+                input: options.context.input as never,
+                options: options.context.options as never,
+                providerRequest: options.context.providerRequest,
+                error,
+              });
+
+              throw this.toTerminalError(error, options.context);
+            }
+
+            const rateLimitDelay = this.policy.getRateLimitDelay({
+              attempt: rateLimitAttempt,
+              suggestedDelayMs: classified.suggestedDelayMs,
+            });
+            log.warn(
+              `API call rate limited. Retrying in ${rateLimitDelay}ms...`,
+            );
+
+            await this.hookRunner.runOnRetryableError(options.hooks, {
+              input: options.context.input as never,
+              options: options.context.options as never,
+              providerRequest: options.context.providerRequest,
+              error,
+            });
+
+            await abortableSleep({
+              ms: rateLimitDelay,
+              signal: options.signal,
+            });
+            rateLimitAttempt++;
+            continue;
           }
 
           // Check if we've exhausted retries
@@ -200,7 +246,7 @@ export class RetryExecutor {
             error,
           });
 
-          await sleep(delay);
+          await abortableSleep({ ms: delay, signal: options.signal });
           attempt++;
         }
       }

--- a/packages/llm/src/operate/retry/RetryPolicy.ts
+++ b/packages/llm/src/operate/retry/RetryPolicy.ts
@@ -9,6 +9,13 @@ export const DEFAULT_BACKOFF_FACTOR = 2; // Exponential backoff multiplier
 export const DEFAULT_MAX_RETRIES = 6;
 export const MAX_RETRIES_ABSOLUTE_LIMIT = 72;
 
+// A rate limit clears on wall-clock time, not on a retry, so its budget is
+// counted and capped apart from the transient-error budget: few attempts,
+// each sleeping far longer than an exponential backoff would.
+export const DEFAULT_RATE_LIMIT_RETRIES = 2;
+export const DEFAULT_RATE_LIMIT_DELAY_MS = 60000; // 1 minute
+export const DEFAULT_RATE_LIMIT_MAX_DELAY_MS = 90000; // 90 seconds
+
 //
 //
 // Types
@@ -23,6 +30,22 @@ export interface RetryPolicyConfig {
   backoffFactor?: number;
   /** Maximum number of retries. Default: 6 */
   maxRetries?: number;
+  /** Retries granted to a rate-limited request. 0 disables. Default: 2 */
+  rateLimitRetries?: number;
+  /** Ceiling on a single rate-limit wait. Default: 90000 */
+  rateLimitMaxDelayMs?: number;
+}
+
+/**
+ * Caller-facing retry controls, exposed as `LlmOperateOptions.retry`.
+ */
+export interface LlmRetryOptions {
+  /**
+   * Whether a rate-limited request waits and retries. `true` (the default)
+   * uses the policy budget; `false` restores the terminal behavior; an object
+   * tunes the budget.
+   */
+  rateLimit?: boolean | { maxRetries?: number; maxDelayMs?: number };
 }
 
 //
@@ -39,6 +62,8 @@ export class RetryPolicy {
   readonly maxDelayMs: number;
   readonly backoffFactor: number;
   readonly maxRetries: number;
+  readonly rateLimitRetries: number;
+  readonly rateLimitMaxDelayMs: number;
 
   constructor(config: RetryPolicyConfig = {}) {
     this.initialDelayMs = config.initialDelayMs ?? DEFAULT_INITIAL_DELAY_MS;
@@ -48,6 +73,15 @@ export class RetryPolicy {
       config.maxRetries ?? DEFAULT_MAX_RETRIES,
       MAX_RETRIES_ABSOLUTE_LIMIT,
     );
+    this.rateLimitRetries = Math.max(
+      0,
+      Math.min(
+        config.rateLimitRetries ?? DEFAULT_RATE_LIMIT_RETRIES,
+        MAX_RETRIES_ABSOLUTE_LIMIT,
+      ),
+    );
+    this.rateLimitMaxDelayMs =
+      config.rateLimitMaxDelayMs ?? DEFAULT_RATE_LIMIT_MAX_DELAY_MS;
   }
 
   /**
@@ -64,7 +98,65 @@ export class RetryPolicy {
   shouldRetry(currentAttempt: number): boolean {
     return currentAttempt < this.maxRetries;
   }
+
+  /**
+   * Check if a rate-limited request has budget left. Counted apart from
+   * {@link shouldRetry} so throttling never spends the transient budget.
+   */
+  shouldRetryRateLimit(currentAttempt: number): boolean {
+    return currentAttempt < this.rateLimitRetries;
+  }
+
+  /**
+   * Milliseconds to wait before re-issuing a rate-limited request. The
+   * provider's suggestion wins when there is one; otherwise the wait grows
+   * from a one-minute floor. Either way it is capped.
+   */
+  getRateLimitDelay({
+    attempt = 0,
+    suggestedDelayMs,
+  }: { attempt?: number; suggestedDelayMs?: number } = {}): number {
+    const base =
+      suggestedDelayMs && suggestedDelayMs > 0
+        ? suggestedDelayMs
+        : DEFAULT_RATE_LIMIT_DELAY_MS * Math.pow(this.backoffFactor, attempt);
+    return Math.min(base, this.rateLimitMaxDelayMs);
+  }
 }
 
 // Export a default policy instance
 export const defaultRetryPolicy = new RetryPolicy();
+
+/**
+ * Apply a caller's `retry` option on top of a policy. Returns the policy
+ * unchanged when the caller said nothing, so the common path allocates nothing.
+ */
+export function resolveRetryPolicy({
+  policy = defaultRetryPolicy,
+  retry,
+}: { policy?: RetryPolicy; retry?: LlmRetryOptions } = {}): RetryPolicy {
+  const rateLimit = retry?.rateLimit;
+  if (rateLimit === undefined) {
+    return policy;
+  }
+
+  const overrides: RetryPolicyConfig = {
+    backoffFactor: policy.backoffFactor,
+    initialDelayMs: policy.initialDelayMs,
+    maxDelayMs: policy.maxDelayMs,
+    maxRetries: policy.maxRetries,
+    rateLimitMaxDelayMs: policy.rateLimitMaxDelayMs,
+    rateLimitRetries: policy.rateLimitRetries,
+  };
+
+  if (rateLimit === false) {
+    overrides.rateLimitRetries = 0;
+  } else if (rateLimit !== true) {
+    overrides.rateLimitRetries =
+      rateLimit.maxRetries ?? overrides.rateLimitRetries;
+    overrides.rateLimitMaxDelayMs =
+      rateLimit.maxDelayMs ?? overrides.rateLimitMaxDelayMs;
+  }
+
+  return new RetryPolicy(overrides);
+}

--- a/packages/llm/src/operate/retry/__tests__/RetryExecutor.spec.ts
+++ b/packages/llm/src/operate/retry/__tests__/RetryExecutor.spec.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { RetryExecutor, ErrorClassifier } from "../RetryExecutor.js";
 import { RetryPolicy } from "../RetryPolicy.js";
 import { ErrorCategory } from "../../types.js";
+import { abortableSleep } from "../../../util/abortableSleep.js";
 
 //
 //
@@ -33,6 +34,10 @@ vi.mock("@jaypie/errors", () => ({
       this.name = "JaypieError";
     }
   },
+}));
+
+vi.mock("../../../util/abortableSleep.js", () => ({
+  abortableSleep: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("../../../util/index.js", () => ({
@@ -587,6 +592,159 @@ describe("RetryExecutor", () => {
 
       // Initial attempt + 1 retry
       expect(operation).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // Rate Limits
+  describe("Rate Limits", () => {
+    const mockContext = {
+      input: "test",
+      model: "test-model",
+      options: {},
+      provider: "test-provider",
+      providerRequest: {},
+    };
+
+    const rateLimitClassifier = (): ErrorClassifier => ({
+      classify: (error: unknown) => ({
+        category: ErrorCategory.RateLimit,
+        error,
+        shouldRetry: false,
+        suggestedDelayMs: 60000,
+      }),
+      // The adapters report a rate limit as non-retryable; the executor's own
+      // budget is what grants the retry
+      isRetryable: () => false,
+      isKnownError: () => true,
+    });
+
+    afterEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it("retries a rate-limited request and returns the eventual result", async () => {
+      const executor = new RetryExecutor({
+        errorClassifier: rateLimitClassifier(),
+      });
+      const operation = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("Rate limit exceeded"))
+        .mockResolvedValue("success");
+
+      const result = await executor.execute(operation, {
+        context: mockContext,
+      });
+
+      expect(result).toBe("success");
+      expect(operation).toHaveBeenCalledTimes(2);
+    });
+
+    it("waits the provider's suggested delay", async () => {
+      const executor = new RetryExecutor({
+        errorClassifier: rateLimitClassifier(),
+      });
+      const operation = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("Rate limit exceeded"))
+        .mockResolvedValue("success");
+
+      await executor.execute(operation, { context: mockContext });
+
+      expect(abortableSleep).toHaveBeenCalledWith(
+        expect.objectContaining({ ms: 60000 }),
+      );
+    });
+
+    it("throws once the rate limit budget is exhausted", async () => {
+      const executor = new RetryExecutor({
+        errorClassifier: rateLimitClassifier(),
+        policy: new RetryPolicy({ rateLimitRetries: 2 }),
+      });
+      const operation = vi
+        .fn()
+        .mockRejectedValue(new Error("Rate limit exceeded"));
+
+      await expect(
+        executor.execute(operation, { context: mockContext }),
+      ).rejects.toThrow();
+
+      // Initial attempt + 2 rate limit retries
+      expect(operation).toHaveBeenCalledTimes(3);
+    });
+
+    it("does not spend the transient retry budget", async () => {
+      // One transient retry available, two rate limit retries. A rate limit
+      // must not consume the transient budget, so all three calls happen.
+      const executor = new RetryExecutor({
+        errorClassifier: rateLimitClassifier(),
+        policy: new RetryPolicy({ maxRetries: 1, rateLimitRetries: 2 }),
+      });
+      const operation = vi
+        .fn()
+        .mockRejectedValue(new Error("Rate limit exceeded"));
+
+      await expect(
+        executor.execute(operation, { context: mockContext }),
+      ).rejects.toThrow();
+
+      expect(operation).toHaveBeenCalledTimes(3);
+    });
+
+    it("does not retry when the budget is zero", async () => {
+      const executor = new RetryExecutor({
+        errorClassifier: rateLimitClassifier(),
+        policy: new RetryPolicy({ rateLimitRetries: 0 }),
+      });
+      const operation = vi
+        .fn()
+        .mockRejectedValue(new Error("Rate limit exceeded"));
+
+      await expect(
+        executor.execute(operation, { context: mockContext }),
+      ).rejects.toThrow();
+
+      expect(operation).toHaveBeenCalledTimes(1);
+    });
+
+    it("never retries a quota error", async () => {
+      const executor = new RetryExecutor({
+        errorClassifier: {
+          classify: (error: unknown) => ({
+            category: ErrorCategory.Quota,
+            error,
+            shouldRetry: false,
+          }),
+          isRetryable: () => false,
+          isKnownError: () => true,
+        },
+      });
+      const operation = vi.fn().mockRejectedValue(new Error("Quota exceeded"));
+
+      await expect(
+        executor.execute(operation, { context: mockContext }),
+      ).rejects.toThrow();
+
+      expect(operation).toHaveBeenCalledTimes(1);
+    });
+
+    it("stops when the caller aborts during the wait", async () => {
+      const controller = new AbortController();
+      const executor = new RetryExecutor({
+        errorClassifier: rateLimitClassifier(),
+      });
+      const operation = vi.fn().mockImplementation(async () => {
+        controller.abort();
+        throw new Error("Rate limit exceeded");
+      });
+
+      await expect(
+        executor.execute(operation, {
+          context: mockContext,
+          signal: controller.signal,
+        }),
+      ).rejects.toThrow();
+
+      expect(operation).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/llm/src/operate/retry/__tests__/RetryPolicy.spec.ts
+++ b/packages/llm/src/operate/retry/__tests__/RetryPolicy.spec.ts
@@ -5,8 +5,12 @@ import {
   DEFAULT_INITIAL_DELAY_MS,
   DEFAULT_MAX_DELAY_MS,
   DEFAULT_MAX_RETRIES,
+  DEFAULT_RATE_LIMIT_DELAY_MS,
+  DEFAULT_RATE_LIMIT_MAX_DELAY_MS,
+  DEFAULT_RATE_LIMIT_RETRIES,
   defaultRetryPolicy,
   MAX_RETRIES_ABSOLUTE_LIMIT,
+  resolveRetryPolicy,
   RetryPolicy,
 } from "../RetryPolicy.js";
 
@@ -155,6 +159,93 @@ describe("RetryPolicy", () => {
       expect(policy.maxDelayMs).toBe(DEFAULT_MAX_DELAY_MS);
       expect(policy.backoffFactor).toBe(DEFAULT_BACKOFF_FACTOR);
       expect(policy.maxRetries).toBe(10);
+    });
+  });
+
+  describe("Rate Limit Budget", () => {
+    it("defaults to a small dedicated budget", () => {
+      expect(defaultRetryPolicy.rateLimitRetries).toBe(
+        DEFAULT_RATE_LIMIT_RETRIES,
+      );
+      expect(defaultRetryPolicy.rateLimitMaxDelayMs).toBe(
+        DEFAULT_RATE_LIMIT_MAX_DELAY_MS,
+      );
+    });
+
+    it("counts rate limit attempts against their own budget", () => {
+      const policy = new RetryPolicy({ maxRetries: 6, rateLimitRetries: 2 });
+
+      expect(policy.shouldRetryRateLimit(0)).toBe(true);
+      expect(policy.shouldRetryRateLimit(1)).toBe(true);
+      expect(policy.shouldRetryRateLimit(2)).toBe(false);
+    });
+
+    it("never accepts a negative budget", () => {
+      expect(new RetryPolicy({ rateLimitRetries: -5 }).rateLimitRetries).toBe(
+        0,
+      );
+    });
+
+    it("prefers the provider's suggested delay", () => {
+      expect(
+        defaultRetryPolicy.getRateLimitDelay({ suggestedDelayMs: 30000 }),
+      ).toBe(30000);
+    });
+
+    it("caps the suggested delay", () => {
+      expect(
+        defaultRetryPolicy.getRateLimitDelay({ suggestedDelayMs: 600000 }),
+      ).toBe(DEFAULT_RATE_LIMIT_MAX_DELAY_MS);
+    });
+
+    it("falls back to a growing delay from a one-minute floor", () => {
+      expect(defaultRetryPolicy.getRateLimitDelay()).toBe(
+        DEFAULT_RATE_LIMIT_DELAY_MS,
+      );
+      expect(defaultRetryPolicy.getRateLimitDelay({ attempt: 1 })).toBe(
+        DEFAULT_RATE_LIMIT_MAX_DELAY_MS,
+      );
+    });
+  });
+
+  describe("resolveRetryPolicy", () => {
+    it("returns the policy unchanged when no option is given", () => {
+      const policy = new RetryPolicy({ maxRetries: 3 });
+
+      expect(resolveRetryPolicy({ policy })).toBe(policy);
+      expect(resolveRetryPolicy({ policy, retry: {} })).toBe(policy);
+    });
+
+    it("disables the budget with rateLimit false", () => {
+      const resolved = resolveRetryPolicy({ retry: { rateLimit: false } });
+
+      expect(resolved.rateLimitRetries).toBe(0);
+    });
+
+    it("keeps the budget with rateLimit true", () => {
+      const resolved = resolveRetryPolicy({ retry: { rateLimit: true } });
+
+      expect(resolved.rateLimitRetries).toBe(DEFAULT_RATE_LIMIT_RETRIES);
+    });
+
+    it("tunes the budget from an object", () => {
+      const resolved = resolveRetryPolicy({
+        retry: { rateLimit: { maxDelayMs: 5000, maxRetries: 4 } },
+      });
+
+      expect(resolved.rateLimitRetries).toBe(4);
+      expect(resolved.rateLimitMaxDelayMs).toBe(5000);
+    });
+
+    it("preserves the transient budget when overriding rate limits", () => {
+      const policy = new RetryPolicy({ backoffFactor: 3, maxRetries: 5 });
+      const resolved = resolveRetryPolicy({
+        policy,
+        retry: { rateLimit: false },
+      });
+
+      expect(resolved.maxRetries).toBe(5);
+      expect(resolved.backoffFactor).toBe(3);
     });
   });
 });

--- a/packages/llm/src/operate/retry/index.ts
+++ b/packages/llm/src/operate/retry/index.ts
@@ -3,11 +3,15 @@ export {
   DEFAULT_INITIAL_DELAY_MS,
   DEFAULT_MAX_DELAY_MS,
   DEFAULT_MAX_RETRIES,
+  DEFAULT_RATE_LIMIT_DELAY_MS,
+  DEFAULT_RATE_LIMIT_MAX_DELAY_MS,
+  DEFAULT_RATE_LIMIT_RETRIES,
   defaultRetryPolicy,
   MAX_RETRIES_ABSOLUTE_LIMIT,
+  resolveRetryPolicy,
   RetryPolicy,
 } from "./RetryPolicy.js";
-export type { RetryPolicyConfig } from "./RetryPolicy.js";
+export type { LlmRetryOptions, RetryPolicyConfig } from "./RetryPolicy.js";
 
 export { isTransientNetworkError } from "./isTransientNetworkError.js";
 

--- a/packages/llm/src/types/LlmProvider.interface.ts
+++ b/packages/llm/src/types/LlmProvider.interface.ts
@@ -7,6 +7,7 @@ import {
 } from "@jaypie/types";
 import { z } from "zod/v4";
 import { type LlmEffort } from "../constants.js";
+import { type LlmRetryOptions } from "../operate/retry/RetryPolicy.js";
 import { LlmTool } from "./LlmTool.interface.js";
 import { LlmStreamChunk } from "./LlmStreamChunk.interface.js";
 import { Toolkit } from "../tools/Toolkit.class.js";
@@ -555,6 +556,15 @@ export interface LlmOperateOptions {
    * and history are provider-bound.
    */
   resume?: LlmResumeOption;
+  /**
+   * Retry controls. A rate-limited request waits and retries by default
+   * (`{ rateLimit: true }`), drawing on a budget separate from the
+   * transient-error retries. Pass `{ rateLimit: false }` to restore the
+   * terminal behavior where a 429 throws `LlmRateLimitError` immediately, or
+   * `{ rateLimit: { maxRetries, maxDelayMs } }` to tune the budget. Quota
+   * errors are never retried: waiting does not refill an exhausted plan.
+   */
+  retry?: LlmRetryOptions;
   /**
    * Caller-owned cancellation. Aborting it cancels the in-flight provider
    * request and settles the call: `operate()` rejects with `LlmAbortError`

--- a/packages/llm/src/util/__tests__/abortableSleep.spec.ts
+++ b/packages/llm/src/util/__tests__/abortableSleep.spec.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import { abortableSleep } from "../abortableSleep.js";
+
+//
+//
+// Tests
+//
+
+describe("abortableSleep", () => {
+  describe("Base Cases", () => {
+    it("is a function", () => {
+      expect(typeof abortableSleep).toBe("function");
+    });
+
+    it("resolves immediately for a non-positive duration", async () => {
+      const started = Date.now();
+      await abortableSleep({ ms: 0 });
+      expect(Date.now() - started).toBeLessThan(50);
+    });
+  });
+
+  describe("Happy Paths", () => {
+    it("waits the requested duration", async () => {
+      const started = Date.now();
+      await abortableSleep({ ms: 40 });
+      expect(Date.now() - started).toBeGreaterThanOrEqual(30);
+    });
+  });
+
+  describe("Features", () => {
+    it("returns early when the signal aborts", async () => {
+      const controller = new AbortController();
+      const started = Date.now();
+      setTimeout(() => controller.abort(), 20);
+
+      await abortableSleep({ ms: 5000, signal: controller.signal });
+
+      expect(Date.now() - started).toBeLessThan(1000);
+    });
+
+    it("returns immediately when the signal is already aborted", async () => {
+      const started = Date.now();
+
+      await abortableSleep({ ms: 5000, signal: AbortSignal.abort() });
+
+      expect(Date.now() - started).toBeLessThan(50);
+    });
+
+    it("resolves rather than throwing on abort", async () => {
+      const controller = new AbortController();
+      controller.abort();
+
+      await expect(
+        abortableSleep({ ms: 5000, signal: controller.signal }),
+      ).resolves.toBeUndefined();
+    });
+
+    it("removes its abort listener after a normal wait", async () => {
+      const controller = new AbortController();
+
+      await abortableSleep({ ms: 10, signal: controller.signal });
+      // A late abort must not fire into a removed timer
+      controller.abort();
+
+      expect(controller.signal.aborted).toBe(true);
+    });
+  });
+});

--- a/packages/llm/src/util/abortableSleep.ts
+++ b/packages/llm/src/util/abortableSleep.ts
@@ -1,0 +1,31 @@
+//
+// Backoff sleep that a caller abort can cut short.
+//
+// Rate-limit waits are measured in tens of seconds, so a plain sleep would
+// hold an aborted request open long after the caller stopped caring. This
+// resolves rather than throws on abort: every retry loop re-checks
+// `signal.aborted` at the top and raises the abort error there, so a single
+// code path owns that decision.
+//
+
+export async function abortableSleep({
+  ms,
+  signal,
+}: {
+  ms: number;
+  signal?: AbortSignal;
+}): Promise<void> {
+  if (ms <= 0 || signal?.aborted) {
+    return;
+  }
+
+  await new Promise<void>((resolve) => {
+    const finish = (): void => {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", finish);
+      resolve();
+    };
+    const timer = setTimeout(finish, ms);
+    signal?.addEventListener("abort", finish, { once: true });
+  });
+}

--- a/packages/llm/test/rateLimit.ts
+++ b/packages/llm/test/rateLimit.ts
@@ -3,9 +3,11 @@
 //
 // Mistral enforces a requests-per-second ceiling that varies by tier and by
 // model, and it returns a bare 429 with no Retry-After header, so a run that
-// outpaces the ceiling fails on rate limiting rather than on capability. The
-// matrix cannot solve that by retrying: `operate()` classifies 429 as a
-// terminal LlmRateLimitError and does not retry it within the request budget.
+// outpaces the ceiling spends its time on rate limiting rather than on
+// capability. `operate()` now waits and retries a 429 within its rate-limit
+// budget, but a wait is a minute of wall clock per occurrence: pacing keeps the
+// run under the ceiling, and the backoff catches what pacing cannot see (a
+// token-per-minute ceiling is invisible to request-count pacing).
 //
 // Pacing is enforced per model request rather than per cell, because one cell
 // is a multi-turn loop that can issue many requests. Adapters call the

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.122",
+  "version": "0.8.123",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/llm/1.3.25.md
+++ b/packages/mcp/release-notes/llm/1.3.25.md
@@ -1,0 +1,27 @@
+---
+version: 1.3.25
+date: 2026-08-02
+summary: Rate-limited requests wait and retry on a budget separate from transient errors
+---
+
+## Changes
+
+- A 429 is no longer terminal. `operate()` and `stream()` wait the provider's
+  suggested delay and retry, drawing on a **separate budget** from the
+  transient-error retries, so throttling never spends the retries reserved for
+  a flaky socket and a transient failure never eats the rate-limit allowance.
+  Defaults: 2 attempts, capped at 90s per wait. Every adapter already reported
+  `suggestedDelayMs: 60000`; that value was previously computed and discarded.
+- New `LlmOperateOptions.retry` option. `{ rateLimit: false }` restores the
+  terminal behavior; `{ rateLimit: { maxRetries, maxDelayMs } }` tunes the
+  budget.
+- A configured fallback chain wins over waiting. Reaching for another provider
+  is faster than sleeping, so every attempt with somewhere left to go fails
+  fast; only the final entry keeps its budget. An explicit `retry` option
+  overrides this.
+- Quota errors remain terminal. Waiting does not refill an exhausted plan.
+- Backoff sleeps are interruptible. A caller `signal` that aborts mid-wait ends
+  the call immediately instead of holding the request for the remaining minute.
+  This applies to the transient backoff as well.
+- New exports: `RetryPolicy`, and the types `LlmRetryOptions` and
+  `RetryPolicyConfig`.

--- a/packages/mcp/release-notes/mcp/0.8.123.md
+++ b/packages/mcp/release-notes/mcp/0.8.123.md
@@ -1,0 +1,11 @@
+---
+version: 0.8.123
+date: 2026-08-02
+summary: Document rate-limit backoff in the llm skill
+---
+
+## Changes
+
+- `skills/llm.md` documents the separate rate-limit and transient retry
+  budgets, the `retry` option, the fallback-wins-over-waiting rule, and that
+  quota errors are never retried.

--- a/packages/mcp/release-notes/testkit/1.2.63.md
+++ b/packages/mcp/release-notes/testkit/1.2.63.md
@@ -1,0 +1,10 @@
+---
+version: 1.2.63
+date: 2026-08-02
+summary: Mirror the new RetryPolicy export from @jaypie/llm
+---
+
+## Changes
+
+- `mock/llm` re-exports `RetryPolicy`, keeping the mock namespace aligned with
+  `@jaypie/llm` 1.3.25.

--- a/packages/mcp/skills/llm.md
+++ b/packages/mcp/skills/llm.md
@@ -720,6 +720,23 @@ try {
 }
 ```
 
+Rate limits and transient errors draw on **separate budgets**, so throttling
+never spends the retries reserved for a flaky connection. A 429 waits the
+provider's suggested delay (60s today) up to twice, capped at 90s per wait;
+a transient error follows the usual exponential backoff. Quota errors are
+never retried — waiting does not refill an exhausted plan.
+
+```typescript
+await Llm.operate(input, { retry: { rateLimit: false } }); // throw at once
+await Llm.operate(input, {
+  retry: { rateLimit: { maxDelayMs: 30_000, maxRetries: 1 } },
+});
+```
+
+A configured fallback chain wins over waiting: moving to the next provider is
+faster than sleeping, so only the final entry in the chain keeps its rate-limit
+budget. Waits are interruptible by the caller's `signal`.
+
 ## Testing Pattern
 
 ```typescript

--- a/packages/testkit/package.json
+++ b/packages/testkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/testkit",
-  "version": "1.2.62",
+  "version": "1.2.63",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"

--- a/packages/testkit/src/mock/llm.ts
+++ b/packages/testkit/src/mock/llm.ts
@@ -179,6 +179,7 @@ export const isLlmOperateInputFile = original.isLlmOperateInputFile;
 export const isLlmOperateInputImage = original.isLlmOperateInputImage;
 export const jsonSchemaToNaturalSchema = original.jsonSchemaToNaturalSchema;
 export const naturalSchemaToJsonSchema = original.naturalSchemaToJsonSchema;
+export const RetryPolicy = original.RetryPolicy;
 
 // Tool collections
 export const toolkit = new original.JaypieToolkit([


### PR DESCRIPTION
## Problem

Every adapter classified a 429 as terminal (`shouldRetry: false`) while computing `suggestedDelayMs: 60000`. That value reached only the thrown `LlmRateLimitError.retryAfterMs` — the retry loop never used it. The library knew how long to wait and handed the number to the caller instead of acting on it.

Surfaced by an `NPM Deploy` run where `LLM Capability Matrix (mistral)` lost one cell to `Rate limit exceeded` on `mistral-large-latest / pdf`, while request pacing was spacing correctly at 14.3s. Pacing by request count cannot see a token-per-minute ceiling, so backoff is the right instrument.

## Changes

- `RetryExecutor` and `StreamLoop` catch `ErrorCategory.RateLimit` **before** the transient-error checks and wait the provider's suggested delay.
- The rate-limit budget is **separate from the transient budget**: throttling never spends the retries reserved for a flaky socket, and a dropped connection never eats the rate-limit allowance. Defaults: `rateLimitRetries: 2`, `rateLimitMaxDelayMs: 90_000`.
- New `LlmOperateOptions.retry`:
  ```typescript
  await Llm.operate(input, { retry: { rateLimit: false } });  // terminal, as before
  await Llm.operate(input, { retry: { rateLimit: { maxRetries: 1, maxDelayMs: 30_000 } } });
  ```
- Quota errors stay terminal. Waiting does not refill an exhausted plan.
- **A configured fallback chain wins over waiting.** Sleeping 60s before trying the next provider defeats the point of a fallback, so the facade tells every attempt with somewhere left to go not to wait; only the final entry keeps its budget. An explicit `retry` option overrides this.
- **Backoff sleeps are interruptible** (`abortableSleep`). A 90s wait on the old `sleep()` would have held an aborted request for the full minute before honoring the abort — a regression the longer waits would otherwise introduce. Applied to the transient backoff as well.

## Coverage

30 new tests: policy budget and delay resolution, executor retry/exhaustion/quota/abort, `StreamLoop` parity, `operate()` end-to-end, facade fallback interaction, and `abortableSleep`.

Full repo: 4325 passed, 0 failures. Typecheck, build, and lint clean.

Not verified against a live 429 — that needs a real provider throttle. The next matrix run exercises it.

## Versioning

`@jaypie/llm` 1.3.25, `@jaypie/testkit` 1.2.63 (mock mirrors the new `RetryPolicy` export), `@jaypie/mcp` 0.8.123. Release notes for all three; lockfile updated. `jaypie` does not depend on any of them, so no umbrella bump.

Docs corrected in `packages/llm/CLAUDE.md`, `packages/mcp/skills/llm.md`, and `packages/llm/test/rateLimit.ts`, each of which asserted that rate limits are never retried.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011qBLiUdsXkVkxUa2fjusdt