### PR TITLE
fix(express): emit every Set-Cookie separately from Lambda adapters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15145,7 +15145,7 @@
     },
     "packages/express": {
       "name": "@jaypie/express",
-      "version": "1.2.32",
+      "version": "1.2.33",
       "license": "MIT",
       "dependencies": {
         "@jaypie/datadog": "*",
@@ -15302,14 +15302,14 @@
       "license": "MIT"
     },
     "packages/jaypie": {
-      "version": "1.2.77",
+      "version": "1.2.78",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "^1.2.11",
         "@jaypie/core": "^1.2.4",
         "@jaypie/datadog": "^1.2.6",
         "@jaypie/errors": "^1.2.4",
-        "@jaypie/express": "^1.2.32",
+        "@jaypie/express": "^1.2.33",
         "@jaypie/kit": "^1.2.15",
         "@jaypie/lambda": "^1.2.14",
         "@jaypie/logger": "^1.2.22"
@@ -15545,7 +15545,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.123",
+      "version": "0.8.124",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.3.3",

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/express",
-  "version": "1.2.32",
+  "version": "1.2.33",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"

--- a/packages/express/src/adapter/LambdaResponseBuffered.ts
+++ b/packages/express/src/adapter/LambdaResponseBuffered.ts
@@ -2,6 +2,7 @@ import type { OutgoingHttpHeaders } from "node:http";
 import { ServerResponse } from "node:http";
 import { Writable } from "node:stream";
 
+import { normalizeHeaderValue, splitCookieHeaders } from "./headers.helper.js";
 import type { LambdaResponse } from "./types.js";
 
 //
@@ -165,7 +166,8 @@ export class LambdaResponseBuffered extends Writable {
       return this;
     }
     const lowerName = name.toLowerCase();
-    this._headers.set(lowerName, String(value));
+    const normalized = normalizeHeaderValue(value);
+    this._headers.set(lowerName, normalized);
     // Sync with kOutHeaders for dd-trace compatibility
     // Node stores as { 'header-name': ['Header-Name', value] }
     if (kOutHeaders) {
@@ -173,7 +175,7 @@ export class LambdaResponseBuffered extends Writable {
         this as unknown as Record<symbol, Record<string, unknown>>
       )[kOutHeaders];
       if (outHeaders) {
-        outHeaders[lowerName] = [name, String(value)];
+        outHeaders[lowerName] = [name, normalized];
       }
     }
     return this;
@@ -280,7 +282,7 @@ export class LambdaResponseBuffered extends Writable {
       // Use direct _headers access to bypass dd-trace interception
       for (const [key, value] of Object.entries(headersToSet)) {
         if (value !== undefined) {
-          this._headers.set(key.toLowerCase(), String(value));
+          this._headers.set(key.toLowerCase(), normalizeHeaderValue(value));
         }
       }
     }
@@ -313,7 +315,7 @@ export class LambdaResponseBuffered extends Writable {
    */
   set(name: string, value: number | string | string[]): this {
     if (!this._headersSent) {
-      this._headers.set(name.toLowerCase(), String(value));
+      this._headers.set(name.toLowerCase(), normalizeHeaderValue(value));
     }
     return this;
   }
@@ -396,22 +398,8 @@ export class LambdaResponseBuffered extends Writable {
     // Determine if response should be base64 encoded
     const isBase64Encoded = this.isBinaryContentType(contentType);
 
-    // Build headers object
-    const headers: Record<string, string> = {};
-    const cookies: string[] = [];
-
-    for (const [key, value] of this._headers) {
-      if (key === "set-cookie") {
-        // Collect Set-Cookie headers for v2 response format
-        if (Array.isArray(value)) {
-          cookies.push(...value);
-        } else {
-          cookies.push(value);
-        }
-      } else {
-        headers[key] = Array.isArray(value) ? value.join(", ") : String(value);
-      }
-    }
+    // Build headers object, carrying Set-Cookie out-of-band (v2 format)
+    const { cookies, headers } = splitCookieHeaders(this._headers);
 
     const result: LambdaResponse = {
       body: isBase64Encoded ? body.toString("base64") : body.toString("utf8"),

--- a/packages/express/src/adapter/LambdaResponseStreaming.ts
+++ b/packages/express/src/adapter/LambdaResponseStreaming.ts
@@ -2,6 +2,7 @@ import type { OutgoingHttpHeaders } from "node:http";
 import { ServerResponse } from "node:http";
 import { Writable } from "node:stream";
 
+import { normalizeHeaderValue, splitCookieHeaders } from "./headers.helper.js";
 import type {
   AwsLambdaGlobal,
   HttpResponseStreamMetadata,
@@ -164,7 +165,8 @@ export class LambdaResponseStreaming extends Writable {
       return this;
     }
     const lowerName = name.toLowerCase();
-    this._headers.set(lowerName, String(value));
+    const normalized = normalizeHeaderValue(value);
+    this._headers.set(lowerName, normalized);
     // Sync with kOutHeaders for dd-trace compatibility
     // Node stores as { 'header-name': ['Header-Name', value] }
     if (kOutHeaders) {
@@ -172,7 +174,7 @@ export class LambdaResponseStreaming extends Writable {
         this as unknown as Record<symbol, Record<string, unknown>>
       )[kOutHeaders];
       if (outHeaders) {
-        outHeaders[lowerName] = [name, String(value)];
+        outHeaders[lowerName] = [name, normalized];
       }
     }
     return this;
@@ -287,7 +289,7 @@ export class LambdaResponseStreaming extends Writable {
       // Use direct _headers access to bypass dd-trace interception
       for (const [key, value] of Object.entries(headersToSet)) {
         if (value !== undefined) {
-          this._headers.set(key.toLowerCase(), String(value));
+          this._headers.set(key.toLowerCase(), normalizeHeaderValue(value));
         }
       }
     }
@@ -305,10 +307,8 @@ export class LambdaResponseStreaming extends Writable {
       return;
     }
 
-    const headers: Record<string, string> = {};
-    for (const [key, value] of this._headers) {
-      headers[key] = Array.isArray(value) ? value.join(", ") : String(value);
-    }
+    // Set-Cookie travels in metadata.cookies, never folded into headers
+    const { cookies, headers } = splitCookieHeaders(this._headers);
 
     // Lambda streaming requires body content for metadata to be transmitted.
     // Convert 204 No Content to 200 OK with empty JSON body as workaround.
@@ -325,6 +325,11 @@ export class LambdaResponseStreaming extends Writable {
       headers,
       statusCode,
     };
+
+    // Only include cookies if present (v2 format)
+    if (cookies.length > 0) {
+      metadata.cookies = cookies;
+    }
 
     // Create wrapped stream with metadata
     this._wrappedStream = awslambda.HttpResponseStream.from(
@@ -361,7 +366,7 @@ export class LambdaResponseStreaming extends Writable {
    */
   set(name: string, value: number | string | string[]): this {
     if (!this._headersSent) {
-      this._headers.set(name.toLowerCase(), String(value));
+      this._headers.set(name.toLowerCase(), normalizeHeaderValue(value));
     }
     return this;
   }

--- a/packages/express/src/adapter/__tests__/LambdaResponseBuffered.spec.ts
+++ b/packages/express/src/adapter/__tests__/LambdaResponseBuffered.spec.ts
@@ -437,5 +437,41 @@ describe("LambdaResponseBuffered", () => {
 
       expect(result.cookies).toBeUndefined();
     });
+
+    it("setHeader() preserves array values without folding", () => {
+      const res = new LambdaResponseBuffered();
+      res.setHeader("set-cookie", ["a=1; Path=/", "b=2; Path=/"]);
+
+      expect(res.getHeader("set-cookie")).toEqual([
+        "a=1; Path=/",
+        "b=2; Path=/",
+      ]);
+    });
+
+    it("emits each Set-Cookie separately when set as an array", async () => {
+      const res = new LambdaResponseBuffered();
+      res.setHeader("set-cookie", [
+        "appSession=abc; Path=/",
+        "auth_verification=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT",
+      ]);
+      res.end();
+
+      const result = await res.getResult();
+
+      expect(result.cookies).toEqual([
+        "appSession=abc; Path=/",
+        "auth_verification=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT",
+      ]);
+    });
+
+    it("set() preserves array values without folding", async () => {
+      const res = new LambdaResponseBuffered();
+      res.set("Set-Cookie", ["a=1", "b=2"]);
+      res.end();
+
+      const result = await res.getResult();
+
+      expect(result.cookies).toEqual(["a=1", "b=2"]);
+    });
   });
 });

--- a/packages/express/src/adapter/__tests__/LambdaResponseStreaming.spec.ts
+++ b/packages/express/src/adapter/__tests__/LambdaResponseStreaming.spec.ts
@@ -449,6 +449,61 @@ describe("LambdaResponseStreaming", () => {
     });
   });
 
+  describe("cookie handling", () => {
+    it("setHeader() preserves array values without folding", () => {
+      const res = new LambdaResponseStreaming(mockResponseStream);
+      res.setHeader("set-cookie", ["a=1; Path=/", "b=2; Path=/"]);
+
+      expect(res.getHeader("set-cookie")).toEqual([
+        "a=1; Path=/",
+        "b=2; Path=/",
+      ]);
+    });
+
+    it("passes Set-Cookie values as metadata.cookies", () => {
+      const res = new LambdaResponseStreaming(mockResponseStream);
+      res.setHeader("set-cookie", [
+        "appSession=abc; Path=/",
+        "auth_verification=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT",
+      ]);
+      res.flushHeaders();
+
+      expect(awslambda.HttpResponseStream.from).toHaveBeenCalledWith(
+        mockResponseStream,
+        expect.objectContaining({
+          cookies: [
+            "appSession=abc; Path=/",
+            "auth_verification=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT",
+          ],
+        }),
+      );
+    });
+
+    it("excludes set-cookie from metadata.headers", () => {
+      const res = new LambdaResponseStreaming(mockResponseStream);
+      res.setHeader("content-type", "text/html");
+      res.setHeader("set-cookie", "session=abc");
+      res.flushHeaders();
+
+      const metadata = vi.mocked(awslambda.HttpResponseStream.from).mock
+        .calls[0][1];
+
+      expect(metadata.headers["set-cookie"]).toBeUndefined();
+      expect(metadata.cookies).toEqual(["session=abc"]);
+    });
+
+    it("omits cookies when no Set-Cookie present", () => {
+      const res = new LambdaResponseStreaming(mockResponseStream);
+      res.setHeader("content-type", "text/html");
+      res.flushHeaders();
+
+      const metadata = vi.mocked(awslambda.HttpResponseStream.from).mock
+        .calls[0][1];
+
+      expect(metadata.cookies).toBeUndefined();
+    });
+  });
+
   describe("ignored operations after headers sent", () => {
     it("ignores setHeader after flush", () => {
       const res = new LambdaResponseStreaming(mockResponseStream);

--- a/packages/express/src/adapter/__tests__/integration.spec.ts
+++ b/packages/express/src/adapter/__tests__/integration.spec.ts
@@ -495,6 +495,22 @@ describe("Lambda Adapter Integration", () => {
 
       expect(result.cookies).toEqual(["session=xyz789; Path=/"]);
     });
+
+    it("handles multiple res.cookie() calls in response", async () => {
+      const app = express();
+      app.get("/", (_req, res) => {
+        res.cookie("appSession", "abc", { path: "/" });
+        res.clearCookie("auth_verification", { path: "/" });
+        res.json({ ok: true });
+      });
+
+      const handler = createLambdaHandler(app);
+      const result = await handler(createMockEvent(), mockContext);
+
+      expect(result.cookies).toHaveLength(2);
+      expect(result.cookies![0]).toMatch(/^appSession=abc/);
+      expect(result.cookies![1]).toMatch(/^auth_verification=/);
+    });
   });
 
   describe("createLambdaStreamHandler", () => {
@@ -543,6 +559,26 @@ describe("Lambda Adapter Integration", () => {
       await handler(createMockEvent(), mockContext);
 
       expect(mockWrappedStream.end).toHaveBeenCalled();
+    });
+
+    it("emits multiple res.cookie() calls as metadata.cookies", async () => {
+      const app = express();
+      app.get("/", (_req, res) => {
+        res.cookie("appSession", "abc", { path: "/" });
+        res.clearCookie("auth_verification", { path: "/" });
+        res.json({ ok: true });
+      });
+
+      const handler = createLambdaStreamHandler(app);
+      await handler(createMockEvent(), mockContext);
+
+      const metadata = vi.mocked(awslambda.HttpResponseStream.from).mock
+        .calls[0][1];
+
+      expect(metadata.headers["set-cookie"]).toBeUndefined();
+      expect(metadata.cookies).toHaveLength(2);
+      expect(metadata.cookies![0]).toMatch(/^appSession=abc/);
+      expect(metadata.cookies![1]).toMatch(/^auth_verification=/);
     });
 
     it("sets Lambda context for getCurrentInvoke", async () => {

--- a/packages/express/src/adapter/headers.helper.ts
+++ b/packages/express/src/adapter/headers.helper.ts
@@ -1,0 +1,52 @@
+//
+//
+// Constants
+//
+
+// Set-Cookie is the one header that must never be comma-folded: cookie
+// expiry dates contain commas, so a folded value is unparseable. Lambda
+// carries these out-of-band in the `cookies` field of the v2 response
+// payload and of the response-streaming metadata prelude.
+export const SET_COOKIE = "set-cookie";
+
+//
+//
+// Functions
+//
+
+/**
+ * Normalize a header value for storage, preserving arrays.
+ * Node's ServerResponse keeps multi-value headers as arrays; stringifying
+ * here would fold them into a single comma-separated value.
+ */
+export function normalizeHeaderValue(
+  value: number | string | string[],
+): string | string[] {
+  return Array.isArray(value) ? value.map(String) : String(value);
+}
+
+/**
+ * Split stored headers into a single-value header record and a cookies
+ * array, matching the Lambda Function URL (v2) response shape.
+ */
+export function splitCookieHeaders(source: Map<string, string | string[]>): {
+  cookies: string[];
+  headers: Record<string, string>;
+} {
+  const cookies: string[] = [];
+  const headers: Record<string, string> = {};
+
+  for (const [key, value] of source) {
+    if (key === SET_COOKIE) {
+      if (Array.isArray(value)) {
+        cookies.push(...value);
+      } else {
+        cookies.push(value);
+      }
+    } else {
+      headers[key] = Array.isArray(value) ? value.join(", ") : String(value);
+    }
+  }
+
+  return { cookies, headers };
+}

--- a/packages/express/src/adapter/types.ts
+++ b/packages/express/src/adapter/types.ts
@@ -119,6 +119,7 @@ export interface ResponseStream {
 }
 
 export interface HttpResponseStreamMetadata {
+  cookies?: string[];
   headers: Record<string, string>;
   statusCode: number;
 }

--- a/packages/jaypie/package.json
+++ b/packages/jaypie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jaypie",
-  "version": "1.2.77",
+  "version": "1.2.78",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"
@@ -41,7 +41,7 @@
     "@jaypie/core": "^1.2.4",
     "@jaypie/datadog": "^1.2.6",
     "@jaypie/errors": "^1.2.4",
-    "@jaypie/express": "^1.2.32",
+    "@jaypie/express": "^1.2.33",
     "@jaypie/kit": "^1.2.15",
     "@jaypie/lambda": "^1.2.14",
     "@jaypie/logger": "^1.2.22"

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.123",
+  "version": "0.8.124",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/express/1.2.33.md
+++ b/packages/mcp/release-notes/express/1.2.33.md
@@ -1,0 +1,24 @@
+---
+version: 1.2.33
+date: 2026-08-03
+summary: Emit every Set-Cookie separately from both Lambda adapters
+---
+
+## Changes
+
+- `setHeader()`, `set()`, and `writeHead()` on `LambdaResponseBuffered` and
+  `LambdaResponseStreaming` preserve array header values instead of
+  stringifying them. `String(["a=1", "b=2"])` comma-folded multi-value
+  headers, and `Set-Cookie` must never be folded because expiry dates
+  contain commas.
+- `createLambdaStreamHandler` passes cookies as `metadata.cookies` in the
+  response-streaming prelude and no longer places `set-cookie` in
+  `metadata.headers`. `HttpResponseStreamMetadata` gains `cookies?: string[]`.
+- `createLambdaHandler` returns every cookie in the `cookies` array of the
+  v2 response payload. Its `buildResult()` already handled arrays; the
+  stringify on the way in meant it never saw one.
+
+Fixes cookie-session auth (multiple cookies per response, chunked session
+cookies) behind both BUFFERED and RESPONSE_STREAM Function URLs.
+
+Resolves [#481](https://github.com/finlaysonstudio/jaypie/issues/481).

--- a/packages/mcp/release-notes/jaypie/1.2.78.md
+++ b/packages/mcp/release-notes/jaypie/1.2.78.md
@@ -1,0 +1,10 @@
+---
+version: 1.2.78
+date: 2026-08-03
+summary: Track @jaypie/express 1.2.33, fixing multiple Set-Cookie headers
+---
+
+## Changes
+
+- Update the `@jaypie/express` range to `^1.2.33`, which emits every
+  `Set-Cookie` separately from both Lambda adapters

--- a/packages/mcp/release-notes/mcp/0.8.124.md
+++ b/packages/mcp/release-notes/mcp/0.8.124.md
@@ -1,0 +1,11 @@
+---
+version: 0.8.124
+date: 2026-08-03
+summary: Document cookie handling in the express skill
+---
+
+## Changes
+
+- `skills/express.md` documents that both Lambda adapters emit each
+  `Set-Cookie` separately: `createLambdaHandler` via the v2 `cookies` array,
+  `createLambdaStreamHandler` via `metadata.cookies` in the streaming prelude.

--- a/packages/mcp/skills/express.md
+++ b/packages/mcp/skills/express.md
@@ -104,6 +104,20 @@ import { createLambdaStreamHandler } from "@jaypie/express";
 export const handler = createLambdaStreamHandler(app);
 ```
 
+### Cookies
+
+Both adapters emit every `Set-Cookie` value separately, so cookie-session auth (multiple cookies per response, chunked session cookies) works unchanged:
+
+```typescript
+app.get("/callback", (req, res) => {
+  res.cookie("appSession", token, { path: "/" });
+  res.clearCookie("auth_verification", { path: "/" });
+  res.json({ ok: true });
+});
+```
+
+`createLambdaHandler` returns them in `cookies` on the v2 response payload. `createLambdaStreamHandler` passes them as `metadata.cookies` in the response-streaming prelude. Neither folds them into a single comma-separated `set-cookie` header, which would be unparseable because expiry dates contain commas.
+
 ### LLM Observability auto-flush
 
 `createLambdaHandler` and `createLambdaStreamHandler` call `flushLlmObs()` from `@jaypie/datadog` in their `finally` block, so buffered Datadog LLM Obs spans flush before the Lambda freezes — even when the Express app errors. No-op unless `DD_LLMOBS_ENABLED` is truthy; never affects the response. No per-handler flush code is required.


### PR DESCRIPTION
Resolves #481.

## Problem

`setHeader()`, `set()`, and `writeHead()` on both Lambda adapters stringified header values. Express `res.cookie()` goes through `res.append("Set-Cookie", …)`, which builds an **array**, and `String(["a=1; Path=/", "b=; Expires=Thu, 01 Jan 1970 00:00:00 GMT"])` comma-folds it into one header. `Set-Cookie` is the one header that must never be folded, because expiry dates contain commas.

Effect: any response setting more than one cookie loses every cookie after the first. Cookie-session auth behind a Function URL never completes login, with no error anywhere.

`LambdaResponseStreaming` had a second half to the bug: its metadata prelude carried only `headers` and `statusCode`, with nowhere to put cookies. `LambdaResponseBuffered.buildResult()` already had correct array handling, but the stringify on the way in meant it never saw an array.

## Fix

| File | Change |
|---|---|
| `adapter/headers.helper.ts` (new) | `normalizeHeaderValue()` preserves arrays, matching Node's `ServerResponse`; `splitCookieHeaders()` returns `{ cookies, headers }` |
| `adapter/LambdaResponseBuffered.ts` | `setHeader`, `set`, `writeHead` stop stringifying; `buildResult` uses the shared split |
| `adapter/LambdaResponseStreaming.ts` | Same three, plus `flushHeaders` sets `metadata.cookies` and drops `set-cookie` from `metadata.headers` |
| `adapter/types.ts` | `HttpResponseStreamMetadata` gains `cookies?: string[]` |

`metadata.cookies` in the response-streaming prelude is the documented shape: the JSON metadata accepts `statusCode`, `headers`, `multiValueHeaders`, and `cookies`.

## Tests

8 tests written first, all failing, one reproducing the exact production string:

```
appSession=abc; Path=/,auth_verification=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT
```

Coverage spans unit tests on both adapter classes and integration tests driving a real Express app through `res.cookie()` + `res.clearCookie()` on both `createLambdaHandler` and `createLambdaStreamHandler`.

Repo green: 4334 tests passing, typecheck and build clean, format reports 0 errors.

## Versions

`@jaypie/express` 1.2.33, `@jaypie/mcp` 0.8.124, `jaypie` 1.2.78, with release notes and the umbrella dependency range synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UtNvkDUvXi9tEGb1AT27gZ