### PR TITLE
fix(express): call writeHead implicitly so on-headers listeners fire (#483)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4630,6 +4630,16 @@
         "undici-types": "~8.3.0"
       }
     },
+    "node_modules/@types/on-headers": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/on-headers/-/on-headers-1.0.4.tgz",
+      "integrity": "sha512-D8Dy7oiM4fFQPA1TtHVTGPFNgCCYY132dTFLezhvlPiiiyKkuW6tVipPXpUOiuTUu8Kzd+ASKjULvZld197Dhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/qs": {
       "version": "6.15.1",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
@@ -11331,6 +11341,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -15145,7 +15165,7 @@
     },
     "packages/express": {
       "name": "@jaypie/express",
-      "version": "1.2.33",
+      "version": "1.2.34",
       "license": "MIT",
       "dependencies": {
         "@jaypie/datadog": "*",
@@ -15157,7 +15177,9 @@
         "@types/cors": "^2.8.17",
         "@types/express": "^5.0.0",
         "@types/node": "^22.13.1",
+        "@types/on-headers": "^1.0.4",
         "express": "^5.1.0",
+        "on-headers": "^1.1.0",
         "rollup-plugin-dts": "^6.1.1",
         "typescript": "^5.3.3"
       },
@@ -15302,14 +15324,14 @@
       "license": "MIT"
     },
     "packages/jaypie": {
-      "version": "1.2.78",
+      "version": "1.2.79",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "^1.2.11",
         "@jaypie/core": "^1.2.4",
         "@jaypie/datadog": "^1.2.6",
         "@jaypie/errors": "^1.2.4",
-        "@jaypie/express": "^1.2.33",
+        "@jaypie/express": "^1.2.34",
         "@jaypie/kit": "^1.2.15",
         "@jaypie/lambda": "^1.2.14",
         "@jaypie/logger": "^1.2.22"
@@ -15545,7 +15567,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.124",
+      "version": "0.8.125",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.3.3",

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/express",
-  "version": "1.2.33",
+  "version": "1.2.34",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"
@@ -57,7 +57,9 @@
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.0",
     "@types/node": "^22.13.1",
+    "@types/on-headers": "^1.0.4",
     "express": "^5.1.0",
+    "on-headers": "^1.1.0",
     "rollup-plugin-dts": "^6.1.1",
     "typescript": "^5.3.3"
   },

--- a/packages/express/src/adapter/LambdaResponseBuffered.ts
+++ b/packages/express/src/adapter/LambdaResponseBuffered.ts
@@ -79,6 +79,7 @@ export class LambdaResponseBuffered extends Writable {
     this.getHeaders = this.getHeaders.bind(this);
     this.getHeaderNames = this.getHeaderNames.bind(this);
     this.writeHead = this.writeHead.bind(this);
+    this._implicitHeader = this._implicitHeader.bind(this);
     this.get = this.get.bind(this);
     this.set = this.set.bind(this);
     this.status = this.status.bind(this);
@@ -264,6 +265,10 @@ export class LambdaResponseBuffered extends Writable {
     statusMessageOrHeaders?: OutgoingHttpHeaders | string,
     headers?: OutgoingHttpHeaders,
   ): this {
+    if (this._headersSent) {
+      return this;
+    }
+
     this.statusCode = statusCode;
 
     let headersToSet: OutgoingHttpHeaders | undefined;
@@ -289,6 +294,18 @@ export class LambdaResponseBuffered extends Writable {
 
     this._headersSent = true;
     return this;
+  }
+
+  /**
+   * Node's implicit-header hook, called before the first body byte commits.
+   * Routes through this.writeHead resolved at call time so wrappers installed
+   * mid-request (on-headers, and through it express-session, morgan,
+   * compression, express-openid-connect) run their listeners.
+   */
+  _implicitHeader(): void {
+    if (!this._headersSent) {
+      this.writeHead(this.statusCode);
+    }
   }
 
   get headersSent(): boolean {
@@ -373,12 +390,14 @@ export class LambdaResponseBuffered extends Writable {
     const buffer = Buffer.isBuffer(chunk)
       ? chunk
       : Buffer.from(chunk, encoding);
+    this._implicitHeader();
     this._chunks.push(buffer);
     this._headersSent = true;
     callback();
   }
 
   _final(callback: (error?: Error | null) => void): void {
+    this._implicitHeader();
     this._ended = true;
     if (this._resolve) {
       this._resolve(this.buildResult());

--- a/packages/express/src/adapter/LambdaResponseStreaming.ts
+++ b/packages/express/src/adapter/LambdaResponseStreaming.ts
@@ -96,6 +96,8 @@ export class LambdaResponseStreaming extends Writable {
     this.getHeaderNames = this.getHeaderNames.bind(this);
     this.writeHead = this.writeHead.bind(this);
     this.flushHeaders = this.flushHeaders.bind(this);
+    this._implicitHeader = this._implicitHeader.bind(this);
+    this._commitHeaders = this._commitHeaders.bind(this);
     this.get = this.get.bind(this);
     this.set = this.set.bind(this);
     this.status = this.status.bind(this);
@@ -294,8 +296,20 @@ export class LambdaResponseStreaming extends Writable {
       }
     }
 
-    this.flushHeaders();
+    this._commitHeaders();
     return this;
+  }
+
+  /**
+   * Node's implicit-header hook, called before the first body byte commits.
+   * Routes through this.writeHead resolved at call time so wrappers installed
+   * mid-request (on-headers, and through it express-session, morgan,
+   * compression, express-openid-connect) run their listeners.
+   */
+  _implicitHeader(): void {
+    if (!this._headersSent) {
+      this.writeHead(this.statusCode);
+    }
   }
 
   get headersSent(): boolean {
@@ -303,6 +317,10 @@ export class LambdaResponseStreaming extends Writable {
   }
 
   flushHeaders(): void {
+    this._implicitHeader();
+  }
+
+  private _commitHeaders(): void {
     if (this._headersSent) {
       return;
     }
@@ -429,7 +447,7 @@ export class LambdaResponseStreaming extends Writable {
       // Buffer writes until headers are sent
       this._pendingWrites.push({ callback: () => callback(), chunk: buffer });
       // Auto-flush headers on first write
-      this.flushHeaders();
+      this._implicitHeader();
     } else {
       this._wrappedStream!.write(buffer);
       callback();
@@ -437,9 +455,7 @@ export class LambdaResponseStreaming extends Writable {
   }
 
   _final(callback: (error?: Error | null) => void): void {
-    if (!this._headersSent) {
-      this.flushHeaders();
-    }
+    this._implicitHeader();
 
     // For converted 204 responses, write empty JSON body
     // Lambda streaming requires body content for metadata to be transmitted

--- a/packages/express/src/adapter/__tests__/LambdaResponseBuffered.spec.ts
+++ b/packages/express/src/adapter/__tests__/LambdaResponseBuffered.spec.ts
@@ -1,6 +1,21 @@
+import type { ServerResponse } from "node:http";
+import onHeaders from "on-headers";
 import { describe, expect, it } from "vitest";
 
 import LambdaResponseBuffered from "../LambdaResponseBuffered.js";
+
+//
+//
+// Helpers
+//
+
+// on-headers is typed against ServerResponse; the adapter duck-types it
+const listenForHeaders = (
+  res: LambdaResponseBuffered,
+  listener: () => void,
+): void => {
+  onHeaders(res as unknown as ServerResponse, listener);
+};
 
 //
 //
@@ -472,6 +487,93 @@ describe("LambdaResponseBuffered", () => {
       const result = await res.getResult();
 
       expect(result.cookies).toEqual(["a=1", "b=2"]);
+    });
+  });
+
+  describe("implicit writeHead", () => {
+    it("fires on-headers listeners when end() commits headers", async () => {
+      const res = new LambdaResponseBuffered();
+      listenForHeaders(res, () => {
+        res.setHeader("x-on-headers-fired", "yes");
+        res.setHeader("set-cookie", ["appSession=deferred; Path=/"]);
+      });
+      res.statusCode = 302;
+      res.setHeader("location", "/");
+      res.end();
+
+      const result = await res.getResult();
+
+      expect(result.statusCode).toBe(302);
+      expect(result.headers["x-on-headers-fired"]).toBe("yes");
+      expect(result.cookies).toEqual(["appSession=deferred; Path=/"]);
+    });
+
+    it("fires on-headers listeners before the first body write", async () => {
+      const res = new LambdaResponseBuffered();
+      listenForHeaders(res, () => {
+        res.setHeader("x-on-headers-fired", "yes");
+      });
+      res.write("hello");
+      res.end();
+
+      const result = await res.getResult();
+
+      expect(result.body).toBe("hello");
+      expect(result.headers["x-on-headers-fired"]).toBe("yes");
+    });
+
+    it("fires on-headers listeners only once", async () => {
+      const res = new LambdaResponseBuffered();
+      let count = 0;
+      listenForHeaders(res, () => {
+        count += 1;
+      });
+      res.write("a");
+      res.write("b");
+      res.end("c");
+
+      await res.getResult();
+
+      expect(count).toBe(1);
+    });
+
+    it("uses a status code the listener changes", async () => {
+      const res = new LambdaResponseBuffered();
+      listenForHeaders(res, () => {
+        res.statusCode = 418;
+      });
+      res.end();
+
+      const result = await res.getResult();
+
+      expect(result.statusCode).toBe(418);
+    });
+
+    it("does not fire on-headers listeners twice after explicit writeHead()", async () => {
+      const res = new LambdaResponseBuffered();
+      let count = 0;
+      listenForHeaders(res, () => {
+        count += 1;
+      });
+      res.writeHead(201, { "content-type": "application/json" });
+      res.end("{}");
+
+      const result = await res.getResult();
+
+      expect(count).toBe(1);
+      expect(result.statusCode).toBe(201);
+    });
+
+    it("_implicitHeader() commits headers", () => {
+      const res = new LambdaResponseBuffered();
+      let fired = false;
+      listenForHeaders(res, () => {
+        fired = true;
+      });
+      res._implicitHeader();
+
+      expect(fired).toBe(true);
+      expect(res.headersSent).toBe(true);
     });
   });
 });

--- a/packages/express/src/adapter/__tests__/LambdaResponseStreaming.spec.ts
+++ b/packages/express/src/adapter/__tests__/LambdaResponseStreaming.spec.ts
@@ -1,3 +1,5 @@
+import type { ServerResponse } from "node:http";
+import onHeaders from "on-headers";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AwsLambdaGlobal, ResponseStream } from "../types.js";
@@ -28,6 +30,19 @@ vi.stubGlobal("awslambda", {
 
 // Import after mocking
 import LambdaResponseStreaming from "../LambdaResponseStreaming.js";
+
+//
+//
+// Helpers
+//
+
+// on-headers is typed against ServerResponse; the adapter duck-types it
+const listenForHeaders = (
+  res: LambdaResponseStreaming,
+  listener: () => void,
+): void => {
+  onHeaders(res as unknown as ServerResponse, listener);
+};
 
 //
 //
@@ -501,6 +516,89 @@ describe("LambdaResponseStreaming", () => {
         .calls[0][1];
 
       expect(metadata.cookies).toBeUndefined();
+    });
+  });
+
+  describe("implicit writeHead", () => {
+    it("fires on-headers listeners when end() commits headers", async () => {
+      const res = new LambdaResponseStreaming(mockResponseStream);
+      listenForHeaders(res, () => {
+        res.setHeader("x-on-headers-fired", "yes");
+        res.setHeader("set-cookie", ["appSession=deferred; Path=/"]);
+      });
+      res.statusCode = 302;
+      res.setHeader("location", "/");
+      await new Promise<void>((resolve) => res.end(resolve));
+
+      const metadata = vi.mocked(awslambda.HttpResponseStream.from).mock
+        .calls[0][1];
+
+      expect(metadata.statusCode).toBe(302);
+      expect(metadata.headers["x-on-headers-fired"]).toBe("yes");
+      expect(metadata.cookies).toEqual(["appSession=deferred; Path=/"]);
+    });
+
+    it("fires on-headers listeners before the first body write", () => {
+      const res = new LambdaResponseStreaming(mockResponseStream);
+      listenForHeaders(res, () => {
+        res.setHeader("x-on-headers-fired", "yes");
+      });
+      res.write("hello");
+
+      const metadata = vi.mocked(awslambda.HttpResponseStream.from).mock
+        .calls[0][1];
+
+      expect(metadata.headers["x-on-headers-fired"]).toBe("yes");
+    });
+
+    it("fires on-headers listeners when flushHeaders() commits headers", () => {
+      const res = new LambdaResponseStreaming(mockResponseStream);
+      let fired = false;
+      listenForHeaders(res, () => {
+        fired = true;
+      });
+      res.flushHeaders();
+
+      expect(fired).toBe(true);
+      expect(res.headersSent).toBe(true);
+    });
+
+    it("fires on-headers listeners only once", () => {
+      const res = new LambdaResponseStreaming(mockResponseStream);
+      let count = 0;
+      listenForHeaders(res, () => {
+        count += 1;
+      });
+      res.write("a");
+      res.flushHeaders();
+      res.write("b");
+
+      expect(count).toBe(1);
+    });
+
+    it("uses a status code the listener changes", () => {
+      const res = new LambdaResponseStreaming(mockResponseStream);
+      listenForHeaders(res, () => {
+        res.statusCode = 418;
+      });
+      res.flushHeaders();
+
+      const metadata = vi.mocked(awslambda.HttpResponseStream.from).mock
+        .calls[0][1];
+
+      expect(metadata.statusCode).toBe(418);
+    });
+
+    it("_implicitHeader() commits headers", () => {
+      const res = new LambdaResponseStreaming(mockResponseStream);
+      let fired = false;
+      listenForHeaders(res, () => {
+        fired = true;
+      });
+      res._implicitHeader();
+
+      expect(fired).toBe(true);
+      expect(res.headersSent).toBe(true);
     });
   });
 

--- a/packages/express/src/adapter/__tests__/integration.spec.ts
+++ b/packages/express/src/adapter/__tests__/integration.spec.ts
@@ -1,4 +1,5 @@
 import express from "express";
+import onHeaders from "on-headers";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { flushLlmObs } from "@jaypie/datadog";
@@ -511,6 +512,29 @@ describe("Lambda Adapter Integration", () => {
       expect(result.cookies![0]).toMatch(/^appSession=abc/);
       expect(result.cookies![1]).toMatch(/^auth_verification=/);
     });
+
+    it("delivers headers and cookies written by on-headers listeners", async () => {
+      const app = express();
+      app.get("/", (_req, res) => {
+        onHeaders(res, () => {
+          res.setHeader("x-on-headers-fired", "yes");
+          res.cookie("appSession", "deferred", { path: "/" });
+        });
+        res.cookie("inline", "value", { path: "/" });
+        res.status(302);
+        res.setHeader("location", "/");
+        res.end();
+      });
+
+      const handler = createLambdaHandler(app);
+      const result = await handler(createMockEvent(), mockContext);
+
+      expect(result.statusCode).toBe(302);
+      expect(result.headers["x-on-headers-fired"]).toBe("yes");
+      expect(result.cookies).toHaveLength(2);
+      expect(result.cookies![0]).toMatch(/^inline=value/);
+      expect(result.cookies![1]).toMatch(/^appSession=deferred/);
+    });
   });
 
   describe("createLambdaStreamHandler", () => {
@@ -579,6 +603,32 @@ describe("Lambda Adapter Integration", () => {
       expect(metadata.cookies).toHaveLength(2);
       expect(metadata.cookies![0]).toMatch(/^appSession=abc/);
       expect(metadata.cookies![1]).toMatch(/^auth_verification=/);
+    });
+
+    it("delivers headers and cookies written by on-headers listeners", async () => {
+      const app = express();
+      app.get("/", (_req, res) => {
+        onHeaders(res, () => {
+          res.setHeader("x-on-headers-fired", "yes");
+          res.cookie("appSession", "deferred", { path: "/" });
+        });
+        res.cookie("inline", "value", { path: "/" });
+        res.status(302);
+        res.setHeader("location", "/");
+        res.end();
+      });
+
+      const handler = createLambdaStreamHandler(app);
+      await handler(createMockEvent(), mockContext);
+
+      const metadata = vi.mocked(awslambda.HttpResponseStream.from).mock
+        .calls[0][1];
+
+      expect(metadata.statusCode).toBe(302);
+      expect(metadata.headers["x-on-headers-fired"]).toBe("yes");
+      expect(metadata.cookies).toHaveLength(2);
+      expect(metadata.cookies![0]).toMatch(/^inline=value/);
+      expect(metadata.cookies![1]).toMatch(/^appSession=deferred/);
     });
 
     it("sets Lambda context for getCurrentInvoke", async () => {

--- a/packages/jaypie/package.json
+++ b/packages/jaypie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jaypie",
-  "version": "1.2.78",
+  "version": "1.2.79",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"
@@ -41,7 +41,7 @@
     "@jaypie/core": "^1.2.4",
     "@jaypie/datadog": "^1.2.6",
     "@jaypie/errors": "^1.2.4",
-    "@jaypie/express": "^1.2.33",
+    "@jaypie/express": "^1.2.34",
     "@jaypie/kit": "^1.2.15",
     "@jaypie/lambda": "^1.2.14",
     "@jaypie/logger": "^1.2.22"

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.124",
+  "version": "0.8.125",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/express/1.2.34.md
+++ b/packages/mcp/release-notes/express/1.2.34.md
@@ -1,0 +1,24 @@
+---
+version: 1.2.34
+date: 2026-08-04
+summary: Fire on-headers listeners by calling writeHead implicitly in both Lambda adapters
+---
+
+## Changes
+
+- `LambdaResponseBuffered` and `LambdaResponseStreaming` gain `_implicitHeader()`,
+  Node's hook for committing headers before the first body byte. Both call it
+  from `_write()` and `_final()`, and it resolves `this.writeHead` at call time
+  so wrappers installed mid-request run.
+- `LambdaResponseStreaming.flushHeaders()` now routes through `_implicitHeader()`.
+  The prelude construction moved to a private `_commitHeaders()`, which
+  `writeHead()` calls.
+- `LambdaResponseBuffered.writeHead()` returns early once headers are sent,
+  matching `LambdaResponseStreaming` and keeping listeners to one firing.
+
+Previously `end()` reached `_write` / `_final` without ever calling `writeHead`,
+so `on-headers` listeners never ran under Lambda. Any library deferring header
+or cookie writes through `on-headers` silently lost them: `express-openid-connect`
+(session cookie), `express-session`, `morgan`, `compression`.
+
+Resolves [#483](https://github.com/finlaysonstudio/jaypie/issues/483).

--- a/packages/mcp/release-notes/jaypie/1.2.79.md
+++ b/packages/mcp/release-notes/jaypie/1.2.79.md
@@ -1,0 +1,10 @@
+---
+version: 1.2.79
+date: 2026-08-04
+summary: Track @jaypie/express 1.2.34, firing on-headers listeners in Lambda
+---
+
+## Changes
+
+- Update the `@jaypie/express` range to `^1.2.34`, which calls `writeHead`
+  implicitly so `on-headers` listeners fire in both Lambda adapters

--- a/packages/mcp/release-notes/mcp/0.8.125.md
+++ b/packages/mcp/release-notes/mcp/0.8.125.md
@@ -1,0 +1,12 @@
+---
+version: 0.8.125
+date: 2026-08-04
+summary: Document on-headers support in the express skill
+---
+
+## Changes
+
+- `skills/express.md` documents that both Lambda adapters commit headers
+  through `writeHead`, so `on-headers` listeners fire and the libraries
+  built on it (`express-openid-connect`, `express-session`, `morgan`,
+  `compression`) work unchanged.

--- a/packages/mcp/skills/express.md
+++ b/packages/mcp/skills/express.md
@@ -118,6 +118,19 @@ app.get("/callback", (req, res) => {
 
 `createLambdaHandler` returns them in `cookies` on the v2 response payload. `createLambdaStreamHandler` passes them as `metadata.cookies` in the response-streaming prelude. Neither folds them into a single comma-separated `set-cookie` header, which would be unparseable because expiry dates contain commas.
 
+### Deferred headers (`on-headers`)
+
+Both adapters commit headers through `writeHead`, resolved at call time, so `on-headers` listeners fire exactly once before the first body byte:
+
+```typescript
+app.get("/callback", (req, res) => {
+  onHeaders(res, () => res.cookie("appSession", token, { path: "/" }));
+  res.redirect("/");
+});
+```
+
+Libraries that defer header or cookie writes this way work unchanged: `express-openid-connect` (session cookie), `express-session`, `morgan`, `compression`. `res.flushHeaders()` and `res._implicitHeader()` both route through the same path.
+
 ### LLM Observability auto-flush
 
 `createLambdaHandler` and `createLambdaStreamHandler` call `flushLlmObs()` from `@jaypie/datadog` in their `finally` block, so buffered Datadog LLM Obs spans flush before the Lambda freezes — even when the Express app errors. No-op unless `DD_LLMOBS_ENABLED` is truthy; never affects the response. No per-handler flush code is required.


### PR DESCRIPTION
Closes #483

## Problem

`createLambdaHandler` and `createLambdaStreamHandler` reached `_write` / `_final` without ever calling `writeHead`. `on-headers` patches only `writeHead`, so under Lambda its listeners never fired.

Any library that defers header or cookie writes through `on-headers` silently lost them: `express-openid-connect` (session cookie), `express-session`, `morgan`, `compression`. The Auth0 callback returned a clean 302 with no session, no exception, and no log line.

## Change

- Both adapters gain `_implicitHeader()`, Node's hook for committing headers before the first body byte, called from `_write()` and `_final()`. It resolves `this.writeHead` at call time so wrappers installed mid-request run. `compression` calls `_implicitHeader()` directly as well.
- `LambdaResponseStreaming.flushHeaders()` routes through `_implicitHeader()`. Prelude construction moved to a private `_commitHeaders()` that `writeHead()` calls.
- `LambdaResponseBuffered.writeHead()` returns early once headers are sent, matching the streaming adapter and keeping listeners to one firing.

## Tests

13 new tests against the real `on-headers` package (added as a devDependency), covering both adapters at the unit level and both handlers end-to-end: listener firing on `end()`, before the first body write, exactly once, status codes the listener changes, and `_implicitHeader()` / `flushHeaders()` entry points.

## Versions

`@jaypie/express` 1.2.34, `jaypie` 1.2.79, `@jaypie/mcp` 0.8.125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UtNvkDUvXi9tEGb1AT27gZ