### PR TITLE
fix(constructs): unshadow addBehavior paths and allow a second web bucket (#479, #480)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14955,7 +14955,7 @@
     },
     "packages/constructs": {
       "name": "@jaypie/constructs",
-      "version": "1.2.76",
+      "version": "1.2.77",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*",
@@ -15567,7 +15567,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.125",
+      "version": "0.8.126",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.3.3",

--- a/packages/constructs/CLAUDE.md
+++ b/packages/constructs/CLAUDE.md
@@ -394,6 +394,25 @@ WAF logs (label `…:core-rule-set:NoUserAgent_Header` → name `NoUserAgent_HEA
 names; AWS WAF would otherwise silently ignore an unmatched name and keep
 blocking. Custom (non-AWS) rule groups are not validated.
 
+### Static Site Bucket
+
+`JaypieWebDeploymentBucket` names its bucket `constructEnvName(component)`, with
+`component` defaulting to the literal `"web"` — independent of the construct id
+and of `host`. A second instance in the same account and region collides on
+`<env>-<key>-web-<nonce>` and fails change-set validation, so it needs a
+`component` (or an explicit `name`). Changing either renames the bucket, which
+replaces it.
+
+```typescript
+new JaypieWebDeploymentBucket(this, "Web", { host: webHost, zone });
+new JaypieWebDeploymentBucket(this, "App", { component: "app", host: appHost, zone });
+```
+
+Production edge caching rides on the default behavior (`CACHING_OPTIMIZED`;
+`CACHING_DISABLED` elsewhere). The construct adds no `/*` behavior, which would
+rank ahead of anything added later and shadow it — paths registered with
+`distribution.addBehavior("/app/*", origin)` match in every environment.
+
 ### Streaming Lambda
 
 For streaming responses, use `createLambdaStreamHandler` from `@jaypie/express` with `JaypieDistribution`:

--- a/packages/constructs/package.json
+++ b/packages/constructs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/constructs",
-  "version": "1.2.76",
+  "version": "1.2.77",
   "description": "CDK constructs for Jaypie applications",
   "repository": {
     "type": "git",

--- a/packages/constructs/src/JaypieWebDeploymentBucket.ts
+++ b/packages/constructs/src/JaypieWebDeploymentBucket.ts
@@ -71,6 +71,17 @@ export interface JaypieWebDeploymentBucketProps extends s3.BucketProps {
    */
   certificate?: boolean | acm.ICertificate;
   /**
+   * Name component for the default bucket name, as
+   * `constructEnvName(component)`.
+   *
+   * Set this when a second instance shares the account and region: the default
+   * `"web"` collides. Ignored when `name` is provided, and independent of
+   * `host` — changing it renames (and so replaces) the bucket.
+   *
+   * @default "web"
+   */
+  component?: string;
+  /**
    * Log destination configuration for CloudFront access logs.
    * - LambdaDestination: Use a specific Lambda destination for S3 notifications
    * - true: Use Datadog forwarder for S3 notifications (default)
@@ -176,6 +187,7 @@ export class JaypieWebDeploymentBucket extends Construct implements s3.IBucket {
 
     const {
       certificate: certificateProp,
+      component: componentProp = "web",
       destination: destinationProp = true,
       host: propsHost,
       logBucket: logBucketProp,
@@ -258,7 +270,7 @@ export class JaypieWebDeploymentBucket extends Construct implements s3.IBucket {
       accessControl: s3.BucketAccessControl.BUCKET_OWNER_FULL_CONTROL,
       autoDeleteObjects: true,
       blockPublicAccess: s3.BlockPublicAccess.BLOCK_ACLS_ONLY,
-      bucketName: nameProp || constructEnvName("web"),
+      bucketName: nameProp || constructEnvName(componentProp),
       publicReadAccess: true,
       removalPolicy: RemovalPolicy.DESTROY,
       versioned: false,
@@ -505,10 +517,14 @@ export class JaypieWebDeploymentBucket extends Construct implements s3.IBucket {
 
       this.logBucket = accessLogBucket;
 
-      // Create CloudFront distribution
+      // Create CloudFront distribution. Production caches at the edge; the
+      // policy rides on the default behavior rather than a `/*` behavior so
+      // paths registered later with addBehavior still match (#479).
       this.distribution = new cloudfront.Distribution(this, "Distribution", {
         defaultBehavior: {
-          cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
+          cachePolicy: isProductionEnv()
+            ? cloudfront.CachePolicy.CACHING_OPTIMIZED
+            : cloudfront.CachePolicy.CACHING_DISABLED,
           origin: new origins.S3StaticWebsiteOrigin(this.bucket),
           ...(resolvedResponseHeadersPolicy
             ? { responseHeadersPolicy: resolvedResponseHeadersPolicy }
@@ -527,22 +543,6 @@ export class JaypieWebDeploymentBucket extends Construct implements s3.IBucket {
           : {}),
       });
       Tags.of(this.distribution).add(CDK.TAG.ROLE, roleTag);
-
-      // If this is production, enable caching on everything but index.html
-      if (isProductionEnv()) {
-        this.distribution.addBehavior(
-          "/*",
-          new origins.S3StaticWebsiteOrigin(this.bucket),
-          {
-            viewerProtocolPolicy:
-              cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
-            cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
-            ...(resolvedResponseHeadersPolicy
-              ? { responseHeadersPolicy: resolvedResponseHeadersPolicy }
-              : {}),
-          },
-        );
-      }
 
       // Create DNS record
       const record = new route53.ARecord(this, "AliasRecord", {

--- a/packages/constructs/src/__tests__/JaypieWebDeploymentBucket.spec.ts
+++ b/packages/constructs/src/__tests__/JaypieWebDeploymentBucket.spec.ts
@@ -3,9 +3,16 @@ import { ConfigurationError } from "@jaypie/errors";
 import { Stack } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import * as cloudfront from "aws-cdk-lib/aws-cloudfront";
+import * as origins from "aws-cdk-lib/aws-cloudfront-origins";
 import * as route53 from "aws-cdk-lib/aws-route53";
 import * as s3 from "aws-cdk-lib/aws-s3";
 import { JaypieWebDeploymentBucket } from "../JaypieWebDeploymentBucket";
+
+function findBucketNames(template: Template) {
+  return Object.values(template.findResources("AWS::S3::Bucket")).map(
+    (bucket) => bucket.Properties?.BucketName,
+  );
+}
 
 function findDistribution(template: Template) {
   const resources = template.findResources("AWS::CloudFront::Distribution");
@@ -95,6 +102,141 @@ describe("JaypieWebDeploymentBucket", () => {
 
       template.hasResource("AWS::WAFv2::WebACL", {});
       template.hasResource("AWS::WAFv2::LoggingConfiguration", {});
+    });
+  });
+
+  describe("Bucket Name", () => {
+    it("defaults to the web component", () => {
+      process.env.PROJECT_ENV = "sandbox";
+      process.env.PROJECT_KEY = "cloudagent";
+      process.env.PROJECT_NONCE = "ckujet";
+      const stack = new Stack();
+
+      new JaypieWebDeploymentBucket(stack, "Web");
+      const template = Template.fromStack(stack);
+
+      expect(findBucketNames(template)).toEqual([
+        "sandbox-cloudagent-web-ckujet",
+      ]);
+    });
+
+    it("names the bucket from component", () => {
+      process.env.PROJECT_ENV = "sandbox";
+      process.env.PROJECT_KEY = "cloudagent";
+      process.env.PROJECT_NONCE = "ckujet";
+      const stack = new Stack();
+
+      new JaypieWebDeploymentBucket(stack, "App", { component: "app" });
+      const template = Template.fromStack(stack);
+
+      expect(findBucketNames(template)).toEqual([
+        "sandbox-cloudagent-app-ckujet",
+      ]);
+    });
+
+    it("gives two instances distinct names when component is set", () => {
+      process.env.PROJECT_ENV = "sandbox";
+      process.env.PROJECT_KEY = "cloudagent";
+      process.env.PROJECT_NONCE = "ckujet";
+      const stack = new Stack();
+
+      new JaypieWebDeploymentBucket(stack, "Web");
+      new JaypieWebDeploymentBucket(stack, "App", { component: "app" });
+      const template = Template.fromStack(stack);
+
+      expect(findBucketNames(template)).toEqual([
+        "sandbox-cloudagent-web-ckujet",
+        "sandbox-cloudagent-app-ckujet",
+      ]);
+    });
+
+    it("honors an explicit name over component", () => {
+      process.env.PROJECT_ENV = "sandbox";
+      process.env.PROJECT_KEY = "cloudagent";
+      process.env.PROJECT_NONCE = "ckujet";
+      const stack = new Stack();
+
+      new JaypieWebDeploymentBucket(stack, "App", {
+        component: "app",
+        name: "explicit-name",
+      });
+      const template = Template.fromStack(stack);
+
+      expect(findBucketNames(template)).toEqual(["explicit-name"]);
+    });
+
+    it("ignores host.component for the bucket name", () => {
+      process.env.PROJECT_ENV = "sandbox";
+      process.env.PROJECT_KEY = "cloudagent";
+      process.env.PROJECT_NONCE = "ckujet";
+      const { stack, zone } = makeStack();
+
+      new JaypieWebDeploymentBucket(stack, "Surface", {
+        host: { component: "app", domain: "example.com" },
+        zone,
+      });
+      const template = Template.fromStack(stack);
+
+      expect(findBucketNames(template)).toContain(
+        "sandbox-cloudagent-web-ckujet",
+      );
+    });
+  });
+
+  describe("Cache Behaviors", () => {
+    it("caches at the edge in production without a catch-all behavior", () => {
+      process.env.PROJECT_ENV = "production";
+      const { stack, zone } = makeStack();
+
+      new JaypieWebDeploymentBucket(stack, "Web", {
+        host: "app.example.com",
+        zone,
+      });
+      const template = Template.fromStack(stack);
+      const config = findDistribution(template).Properties.DistributionConfig;
+
+      expect(config.DefaultCacheBehavior.CachePolicyId).toBe(
+        cloudfront.CachePolicy.CACHING_OPTIMIZED.cachePolicyId,
+      );
+      expect(config.CacheBehaviors).toBeUndefined();
+    });
+
+    it("disables caching outside production", () => {
+      process.env.PROJECT_ENV = "sandbox";
+      const { stack, zone } = makeStack();
+
+      new JaypieWebDeploymentBucket(stack, "Web", {
+        host: "app.example.com",
+        zone,
+      });
+      const template = Template.fromStack(stack);
+      const config = findDistribution(template).Properties.DistributionConfig;
+
+      expect(config.DefaultCacheBehavior.CachePolicyId).toBe(
+        cloudfront.CachePolicy.CACHING_DISABLED.cachePolicyId,
+      );
+      expect(config.CacheBehaviors).toBeUndefined();
+    });
+
+    it("keeps behaviors added after construction reachable in production", () => {
+      process.env.PROJECT_ENV = "production";
+      const { stack, zone } = makeStack();
+
+      const construct = new JaypieWebDeploymentBucket(stack, "Web", {
+        host: "app.example.com",
+        zone,
+      });
+      construct.distribution!.addBehavior(
+        "/app/*",
+        new origins.HttpOrigin("origin.example.com"),
+      );
+      const template = Template.fromStack(stack);
+      const config = findDistribution(template).Properties.DistributionConfig;
+
+      const patterns = (
+        config.CacheBehaviors as Array<{ PathPattern: string }>
+      ).map((behavior) => behavior.PathPattern);
+      expect(patterns).toEqual(["/app/*"]);
     });
   });
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.125",
+  "version": "0.8.126",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/constructs/1.2.77.md
+++ b/packages/mcp/release-notes/constructs/1.2.77.md
@@ -1,0 +1,35 @@
+---
+version: 1.2.77
+date: 2026-08-04
+summary: JaypieWebDeploymentBucket drops the production /* behavior and accepts a component prop
+---
+
+## Changes
+
+- `JaypieWebDeploymentBucket` no longer adds a production-only `/*` cache
+  behavior. Production edge caching (`CACHING_OPTIMIZED`) now rides on the
+  default behavior, so paths registered afterward with
+  `distribution.addBehavior("/app/*", origin)` match in every environment
+  instead of being shadowed in production (#479).
+- `component` sets the name component of the default bucket name
+  (`constructEnvName(component)`, default `"web"`). A second instance in the
+  same account and region no longer needs a full `name` to avoid the
+  `<env>-<key>-web-<nonce>` collision (#480).
+
+## Migration
+
+Edge caching is unchanged: the removed `/*` behavior matched every request
+path, so the default behavior carries the same cache policy. The distribution
+updates in place.
+
+`component` is opt-in. Existing bucket names do not change; setting `component`
+on a deployed stack renames the bucket, which replaces it.
+
+```typescript
+new JaypieWebDeploymentBucket(this, "Web", { host: webHost, zone });
+new JaypieWebDeploymentBucket(this, "App", {
+  component: "app",
+  host: appHost,
+  zone,
+});
+```

--- a/packages/mcp/release-notes/mcp/0.8.126.md
+++ b/packages/mcp/release-notes/mcp/0.8.126.md
@@ -1,0 +1,11 @@
+---
+version: 0.8.126
+date: 2026-08-04
+summary: Document JaypieWebDeploymentBucket bucket naming and cache behaviors
+---
+
+## Changes
+
+- `skill("web")` documents the `component` prop, the bucket-name collision
+  between two instances, and the production cache policy now living on the
+  default behavior rather than a `/*` behavior.

--- a/packages/mcp/skills/web.md
+++ b/packages/mcp/skills/web.md
@@ -38,9 +38,10 @@ new JaypieWebDeploymentBucket(this, "Web", {
 | `host` | `string \| HostConfig` | `mergeDomain(CDK_ENV_WEB_SUBDOMAIN, CDK_ENV_WEB_HOSTED_ZONE \|\| CDK_ENV_HOSTED_ZONE)` — `HostConfig` is resolved via `envHostname()` |
 | `zone` | `string \| IHostedZone \| JaypieHostedZone` | `CDK_ENV_WEB_HOSTED_ZONE \|\| CDK_ENV_HOSTED_ZONE` |
 | `certificate` | `boolean \| ICertificate` | `true` (creates via `resolveCertificate`) |
+| `component` | `string` | `"web"` — name component for the default bucket name |
 | `destination` | `LambdaDestination \| boolean` | `true` (Datadog forwarder for access-log bucket notifications) |
 | `logBucket` | `IBucket \| string \| { exportName } \| true` | undefined — creates a new bucket if `destination !== false` |
-| `name` | `string` | `constructEnvName("web")` |
+| `name` | `string` | `constructEnvName(component)` |
 | `responseHeadersPolicy` | `IResponseHeadersPolicy` | undefined — full override; bypasses default security headers |
 | `roleTag` | `string` | `CDK.ROLE.HOSTING` |
 | `securityHeaders` | `boolean \| SecurityHeadersOverrides` | `true` |
@@ -48,15 +49,31 @@ new JaypieWebDeploymentBucket(this, "Web", {
 
 Also accepts all `s3.BucketProps` — the bucket defaults to `autoDeleteObjects: true`, `publicReadAccess: true`, `websiteIndexDocument: "index.html"`, `websiteErrorDocument: "index.html"` (SPA-friendly).
 
+### Bucket Name
+
+The bucket name defaults to `constructEnvName(component)`, and `component` defaults to `"web"` — a literal, independent of the construct id and of `host`. Two instances in one account and region therefore collide on `<env>-<key>-web-<nonce>` and the second stack fails change-set validation with `already exists`. Give the second instance a `component` (or a full `name`):
+
+```typescript
+new JaypieWebDeploymentBucket(this, "Web", { host: webHost, zone });
+new JaypieWebDeploymentBucket(this, "App", { component: "app", host: appHost, zone });
+```
+
+Changing `component` or `name` on a deployed stack renames the bucket, which replaces it. `JaypieStaticWebBucket` sets its own default name (`constructEnvName("static")`) and does not collide.
+
 ### CloudFront
 
-- Default behavior: S3 static website origin, `REDIRECT_TO_HTTPS`, `CACHING_DISABLED`.
-- In production (`isProductionEnv()`), a second behavior on `/*` enables `CACHING_OPTIMIZED` — `index.html` stays uncached so SPA deploys are visible immediately; hashed assets get edge cache.
+- Default behavior: S3 static website origin, `REDIRECT_TO_HTTPS`. `CACHING_DISABLED` outside production; `CACHING_OPTIMIZED` in production (`isProductionEnv()`), so hashed assets get edge cache. The response headers policy sets `Cache-Control: no-store` so browsers still revalidate.
+- No `/*` behavior is created. Paths registered afterward with `distribution.addBehavior("/app/*", origin)` are evaluated ahead of the default behavior and match in every environment — a static site and a Lambda surface can share one distribution.
 - Access logs land in a CloudFront log bucket with Datadog forwarding by default. Set `destination: false` to skip notifications, or pass `logBucket: <existing>` to reuse a bucket.
+
+```typescript
+const web = new JaypieWebDeploymentBucket(this, "Web", { host, zone });
+web.distribution!.addBehavior("/app/*", new origins.FunctionUrlOrigin(api.functionUrl));
+```
 
 ### Security Headers
 
-Same defaults as `JaypieDistribution`: HSTS, X-Frame-Options, CSP, Referrer-Policy, Permissions-Policy, Cross-Origin-* headers, and Server header removal (applied via a `ResponseHeadersPolicy` on the default behavior and the production `/*` behavior). Override the same way:
+Same defaults as `JaypieDistribution`: HSTS, X-Frame-Options, CSP, Referrer-Policy, Permissions-Policy, Cross-Origin-* headers, and Server header removal (applied via a `ResponseHeadersPolicy` on the default behavior). Override the same way:
 
 ```typescript
 // Disable

--- a/workspaces/documentation/src/content/docs/docs/packages/constructs.md
+++ b/workspaces/documentation/src/content/docs/docs/packages/constructs.md
@@ -227,6 +227,26 @@ new JaypieWebDeploymentBucket(this, "Web", {
 });
 ```
 
+### Bucket Naming
+
+The bucket name defaults to `constructEnvName(component)`, and `component` defaults to `"web"` — independent of the construct id and of `host`. Two instances in one account and region collide on `<env>-<key>-web-<nonce>`, so give the second one a `component` (or an explicit `name`):
+
+```typescript
+new JaypieWebDeploymentBucket(this, "Web", { host: webHost, zone });
+new JaypieWebDeploymentBucket(this, "App", { component: "app", host: appHost, zone });
+```
+
+Changing `component` or `name` on a deployed stack renames the bucket, which replaces it.
+
+### Additional Behaviors
+
+The default behavior serves the S3 static website origin, with `CACHING_OPTIMIZED` in production and `CACHING_DISABLED` elsewhere. No `/*` behavior is created, so paths registered afterward are evaluated ahead of the default and a static site can share a distribution with a Lambda surface:
+
+```typescript
+const web = new JaypieWebDeploymentBucket(this, "Web", { host, zone });
+web.distribution!.addBehavior("/app/*", new origins.FunctionUrlOrigin(api.functionUrl));
+```
+
 ### Stable Outputs for cdk-outputs.json
 
 Call `exportOutputs()` to emit stack-level `CfnOutput`s with hash-free logical IDs (`DestinationBucketName`, `DestinationBucketDeployRoleArn`, `DistributionId`, `CertificateArn`):


### PR DESCRIPTION
Closes #479. Closes #480.

## #479 — production `/*` shadows later `addBehavior` paths

`JaypieWebDeploymentBucket` added a production-only `/*` CACHING_OPTIMIZED behavior. CloudFront evaluates behaviors in order, so anything added afterward through `distribution.addBehavior("/app/*", …)` ranked after `/*` and never matched: a static site sharing a distribution with a Lambda surface 404'd its API paths in production only.

The catch-all is removed and `CACHING_OPTIMIZED` moves onto the default behavior in production. Edge caching is unchanged — `/*` matched every request path, so the previous default behavior was unreachable — and the default behavior is evaluated last by definition, so later behaviors match in every environment.

## #480 — default bucket name is always `constructEnvName("web")`

The name defaulted to the literal `"web"`, independent of construct id and `host`, so two instances in one account and region collided on `<env>-<key>-web-<nonce>` and the second stack failed change-set validation.

New `component` prop feeds `constructEnvName(component)`, default `"web"`. Opt-in, so no deployed bucket is renamed; a second instance passes `component: "app"` rather than a full `name`. Naming stays independent of `host` — a test pins that `host.component` does not leak into the bucket name.

```typescript
new JaypieWebDeploymentBucket(this, "Web", { host: webHost, zone });
new JaypieWebDeploymentBucket(this, "App", { component: "app", host: appHost, zone });
```

## Verification

Four tests written against the reported behavior first (behavior order in production, cache policy per environment, name defaults) — red before the change. `packages/constructs` 703 tests, repo 4356 tests, typecheck and build clean.

## Also

- `skill("web")`, `packages/constructs/CLAUDE.md`, and the jaypie.net constructs page document `component`, the collision, and the `addBehavior` capability.
- `@jaypie/constructs` 1.2.77, `@jaypie/mcp` 0.8.126, release notes for both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UtNvkDUvXi9tEGb1AT27gZ