### PR TITLE
fix(kit): 4xx handler errors at debug; API key environment segment and five-character checksum

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15324,7 +15324,7 @@
       "license": "MIT"
     },
     "packages/jaypie": {
-      "version": "1.2.79",
+      "version": "1.2.80",
       "license": "MIT",
       "dependencies": {
         "@jaypie/aws": "^1.2.11",
@@ -15332,7 +15332,7 @@
         "@jaypie/datadog": "^1.2.6",
         "@jaypie/errors": "^1.2.4",
         "@jaypie/express": "^1.2.34",
-        "@jaypie/kit": "^1.2.15",
+        "@jaypie/kit": "^1.2.16",
         "@jaypie/lambda": "^1.2.14",
         "@jaypie/logger": "^1.2.22"
       },
@@ -15376,7 +15376,7 @@
     },
     "packages/kit": {
       "name": "@jaypie/kit",
-      "version": "1.2.15",
+      "version": "1.2.16",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*",
@@ -15567,7 +15567,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.126",
+      "version": "0.8.127",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.3.3",
@@ -15647,7 +15647,7 @@
     },
     "packages/testkit": {
       "name": "@jaypie/testkit",
-      "version": "1.2.63",
+      "version": "1.2.64",
       "license": "MIT",
       "dependencies": {
         "jest-json-schema": "^6.1.0",

--- a/packages/express/src/__tests__/issue-452-error-log-level.spec.ts
+++ b/packages/express/src/__tests__/issue-452-error-log-level.spec.ts
@@ -44,7 +44,7 @@ describe("Issue 452: expressHandler error log level", () => {
     expect(log.error).toHaveBeenCalled();
   });
 
-  it("Does not log error when the handler throws a 4xx Jaypie error", async () => {
+  it("Does not log error or warn when the handler throws a 4xx Jaypie error", async () => {
     const app = express();
     app.use(
       expressHandler(() => {
@@ -56,5 +56,6 @@ describe("Issue 452: expressHandler error log level", () => {
 
     expect(res.status).toBe(404);
     expect(log.error).not.toHaveBeenCalled();
+    expect(log.warn).not.toHaveBeenCalled();
   });
 });

--- a/packages/jaypie/package.json
+++ b/packages/jaypie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jaypie",
-  "version": "1.2.79",
+  "version": "1.2.80",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"
@@ -42,7 +42,7 @@
     "@jaypie/datadog": "^1.2.6",
     "@jaypie/errors": "^1.2.4",
     "@jaypie/express": "^1.2.34",
-    "@jaypie/kit": "^1.2.15",
+    "@jaypie/kit": "^1.2.16",
     "@jaypie/lambda": "^1.2.14",
     "@jaypie/logger": "^1.2.22"
   },

--- a/packages/kit/CLAUDE.md
+++ b/packages/kit/CLAUDE.md
@@ -68,7 +68,7 @@ src/
   - `scrub` - Error scrubbing, `boolean | { client?: boolean, server?: boolean }`,
     defaults to `{ client: false, server: true }`
 
-  Caught Jaypie errors log by status: 4xx at warn, 500 and above at error, both
+  Caught Jaypie errors log by status: 4xx at debug, 500 and above at error, both
   with `log.var({ jaypieError: { detail, status, title } })`. A 500-class error
   then has its `detail` and `title` replaced with the generic strings for its
   status, so a constructor message describing application internals never
@@ -91,8 +91,13 @@ src/
 
 ### API Key Functions
 
-- `generateJaypieKey({ checksum, issuer, length, pool, prefix, seed, separator })` - Generate API keys (prefix and checksum optional, seed for deterministic derivation)
-- `validateJaypieKey(key, options)` - Validate key format/checksum (prefix and checksum not required, accepts `_` or `-`)
+- `generateJaypieKey({ checksum, environment, issuer, length, pool, prefix, seed, separator, version })` - Generate API keys (prefix, environment, and checksum optional, seed for deterministic derivation)
+  - `environment` defaults to `PROJECT_ENV` and sits between issuer and body, omitted in production or when `false`
+  - `checksum` is truthiness only and emits five characters from a position-weighted rolling hash; `version: 1` reproduces a pre-1.2.16 key with the four-character sum
+  - Random bodies use rejection sampling; seeded bodies read HMAC blocks in counter mode under a versioned message
+- `validateJaypieKey(key, options)` - Validate key format/checksum (prefix, environment, and checksum not required, accepts `_` or `-`)
+  - Accepts a four-character legacy checksum or the five-character current one, so no existing key was invalidated
+  - Throws `UnauthorizedError` when a key carrying an environment is validated in production with an `issuer`
 - `hashJaypieKey(key, { salt })` - SHA-256/HMAC-SHA256 key hashing (reads `PROJECT_SALT` env)
 - `jaypieApiKeyId(key, { namespace, salt })` - Derive a deterministic UUIDv5 from the hashed key, suitable as a user-facing DynamoDB id
 

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/kit",
-  "version": "1.2.15",
+  "version": "1.2.16",
   "description": "Utility functions for Jaypie applications",
   "repository": {
     "type": "git",

--- a/packages/kit/src/__tests__/jaypieHandler.module.spec.ts
+++ b/packages/kit/src/__tests__/jaypieHandler.module.spec.ts
@@ -95,7 +95,7 @@ describe("Jaypie Handler Module", () => {
       expect(log.error).not.toHaveBeenCalled();
       expect(log.fatal).not.toHaveBeenCalled();
     });
-    it("Logs warn if a 4xx Jaypie error is caught", async () => {
+    it("Logs debug if a 4xx Jaypie error is caught", async () => {
       // Arrange
       const handler = jaypieHandler(() => {
         throw new BadRequestError("Sorpresa!");
@@ -105,9 +105,9 @@ describe("Jaypie Handler Module", () => {
         await handler();
       } catch {
         // Assert
-        expect(log.warn).toHaveBeenCalledTimes(1);
-        expect(log.debug).not.toHaveBeenCalled();
+        expect(log.debug).toHaveBeenCalledTimes(1);
         expect(log.error).not.toHaveBeenCalled();
+        expect(log.warn).not.toHaveBeenCalled();
       }
       expect.assertions(3);
     });
@@ -265,7 +265,7 @@ describe("Jaypie Handler Module", () => {
       }
       expect.assertions(3);
     });
-    it("Logs warn for an unmapped 4xx", async () => {
+    it("Logs debug for an unmapped 4xx", async () => {
       // Arrange
       const handler = jaypieHandler(() => {
         throw new JaypieError("Field ssn failed validation", { status: 422 });
@@ -275,10 +275,11 @@ describe("Jaypie Handler Module", () => {
         await handler();
       } catch {
         // Assert
-        expect(log.warn).toHaveBeenCalledTimes(1);
+        expect(log.debug).toHaveBeenCalledTimes(1);
         expect(log.error).not.toHaveBeenCalled();
+        expect(log.warn).not.toHaveBeenCalled();
       }
-      expect.assertions(2);
+      expect.assertions(3);
     });
     it("Does not scrub a status outside 4xx and 5xx", async () => {
       // Arrange

--- a/packages/kit/src/__tests__/jaypieKey.function.spec.ts
+++ b/packages/kit/src/__tests__/jaypieKey.function.spec.ts
@@ -32,6 +32,27 @@ const LEGACY_SEED = "legacy-seed";
 
 //
 //
+// Mock environment
+//
+
+// Key shape follows PROJECT_ENV, which CI sets. Every test states the
+// environment it expects rather than inheriting the runner's
+const ORIGINAL_PROJECT_ENV = process.env.PROJECT_ENV;
+
+beforeEach(() => {
+  delete process.env.PROJECT_ENV;
+});
+
+afterEach(() => {
+  if (ORIGINAL_PROJECT_ENV === undefined) {
+    delete process.env.PROJECT_ENV;
+  } else {
+    process.env.PROJECT_ENV = ORIGINAL_PROJECT_ENV;
+  }
+});
+
+//
+//
 // Tests
 //
 

--- a/packages/kit/src/__tests__/jaypieKey.function.spec.ts
+++ b/packages/kit/src/__tests__/jaypieKey.function.spec.ts
@@ -1,4 +1,5 @@
 import { createHash, createHmac } from "node:crypto";
+import { UnauthorizedError } from "@jaypie/errors";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   v5 as uuidv5,
@@ -20,6 +21,15 @@ import {
 
 const BASE62 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 
+// Minted by the pre-five-character-checksum algorithm. These are the keys the
+// change must never invalidate
+const LEGACY_KEY = {
+  RANDOM: "sk_5G64GGdYP667E79odzffiDaFBzjf2fX6_ALFL",
+  SEEDED: "sk_jaypie_64yXBCCYcEKz9rEk039KwFMPy6wx2whJ_orLJ",
+  SEEDED_NO_ISSUER: "sk_64yXBCCYcEKz9rEk039KwFMPy6wx2whJ_orLJ",
+} as const;
+const LEGACY_SEED = "legacy-seed";
+
 //
 //
 // Tests
@@ -40,15 +50,15 @@ describe("generateJaypieKey", () => {
   describe("Happy Paths", () => {
     it("generates a key with default format", () => {
       const key = generateJaypieKey();
-      // sk_ + 32 body + _ + 4 checksum = 40 chars
-      expect(key.length).toBe(40);
+      // sk_ + 32 body + _ + 5 checksum = 41 chars
+      expect(key.length).toBe(41);
       expect(key.startsWith("sk_")).toBe(true);
     });
 
     it("generates a key with issuer", () => {
       const key = generateJaypieKey({ issuer: "jaypie" });
-      // sk_jaypie_ + 32 body + _ + 4 checksum = 47 chars
-      expect(key.length).toBe(47);
+      // sk_jaypie_ + 32 body + _ + 5 checksum = 48 chars
+      expect(key.length).toBe(48);
       expect(key.startsWith("sk_jaypie_")).toBe(true);
     });
 
@@ -81,14 +91,14 @@ describe("generateJaypieKey", () => {
 
     it("uses custom length", () => {
       const key = generateJaypieKey({ length: 16 });
-      // sk_ + 16 body + _ + 4 checksum = 24 chars
-      expect(key.length).toBe(24);
+      // sk_ + 16 body + _ + 5 checksum = 25 chars
+      expect(key.length).toBe(25);
     });
 
-    it("uses custom checksum length", () => {
+    it("ignores a requested checksum length", () => {
       const key = generateJaypieKey({ checksum: 6 });
-      // sk_ + 32 body + _ + 6 checksum = 42 chars
-      expect(key.length).toBe(42);
+      // Checksum length is not configurable — sk_ + 32 body + _ + 5 checksum
+      expect(key.length).toBe(41);
     });
 
     it("uses custom pool", () => {
@@ -167,8 +177,8 @@ describe("generateJaypieKey", () => {
   describe("Optional Prefix", () => {
     it("generates without prefix when prefix is empty", () => {
       const key = generateJaypieKey({ prefix: "" });
-      // 32 body + _ + 4 checksum = 37 chars
-      expect(key.length).toBe(37);
+      // 32 body + _ + 5 checksum = 38 chars
+      expect(key.length).toBe(38);
       // Should not start with a separator
       const base62Set = new Set(BASE62);
       expect(base62Set.has(key[0])).toBe(true);
@@ -176,8 +186,8 @@ describe("generateJaypieKey", () => {
 
     it("generates with only issuer when prefix is empty", () => {
       const key = generateJaypieKey({ prefix: "", issuer: "jaypie" });
-      // jaypie_ + 32 body + _ + 4 checksum = 44 chars
-      expect(key.length).toBe(44);
+      // jaypie_ + 32 body + _ + 5 checksum = 45 chars
+      expect(key.length).toBe(45);
       expect(key.startsWith("jaypie_")).toBe(true);
     });
   });
@@ -391,6 +401,311 @@ describe("validateJaypieKey", () => {
     it("validates body only (no prefix, no checksum)", () => {
       const key = generateJaypieKey({ prefix: "", checksum: 0 });
       expect(validateJaypieKey(key)).toBe(true);
+    });
+  });
+});
+
+describe("Environment Segment", () => {
+  const originalEnv = process.env.PROJECT_ENV;
+
+  beforeEach(() => {
+    delete process.env.PROJECT_ENV;
+  });
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.PROJECT_ENV = originalEnv;
+    } else {
+      delete process.env.PROJECT_ENV;
+    }
+  });
+
+  describe("Happy Paths", () => {
+    it("places the environment between the issuer and the body", () => {
+      process.env.PROJECT_ENV = "sandbox";
+      const key = generateJaypieKey({ issuer: "jaypie" });
+      expect(key.startsWith("sk_jaypie_sandbox_")).toBe(true);
+      // sk_jaypie_sandbox_ + 32 body + _ + 5 checksum = 56 chars
+      expect(key.length).toBe(56);
+    });
+
+    it("defaults the environment to PROJECT_ENV", () => {
+      process.env.PROJECT_ENV = "local";
+      expect(generateJaypieKey().startsWith("sk_local_")).toBe(true);
+    });
+
+    it("uses an explicit environment over PROJECT_ENV", () => {
+      process.env.PROJECT_ENV = "local";
+      const key = generateJaypieKey({ environment: "sandbox" });
+      expect(key.startsWith("sk_sandbox_")).toBe(true);
+    });
+
+    it("validates a key carrying an environment", () => {
+      process.env.PROJECT_ENV = "sandbox";
+      const key = generateJaypieKey({ issuer: "jaypie" });
+      expect(validateJaypieKey(key, { issuer: "jaypie" })).toBe(true);
+    });
+
+    it("validates a key carrying an environment without an issuer", () => {
+      process.env.PROJECT_ENV = "sandbox";
+      const key = generateJaypieKey();
+      expect(validateJaypieKey(key)).toBe(true);
+    });
+
+    it("does not require an environment outside production", () => {
+      process.env.PROJECT_ENV = "sandbox";
+      const key = generateJaypieKey({ environment: false, issuer: "jaypie" });
+      expect(validateJaypieKey(key, { issuer: "jaypie" })).toBe(true);
+    });
+
+    it("accepts a key from another non-production environment", () => {
+      process.env.PROJECT_ENV = "sandbox";
+      const key = generateJaypieKey({ environment: "local", issuer: "jaypie" });
+      expect(validateJaypieKey(key, { issuer: "jaypie" })).toBe(true);
+    });
+
+    it("strips separators from the environment", () => {
+      process.env.PROJECT_ENV = "pr-123";
+      const key = generateJaypieKey({ issuer: "jaypie" });
+      expect(key.startsWith("sk_jaypie_pr123_")).toBe(true);
+      expect(validateJaypieKey(key, { issuer: "jaypie" })).toBe(true);
+    });
+  });
+
+  describe("Features", () => {
+    it("omits the environment in production", () => {
+      process.env.PROJECT_ENV = "production";
+      const key = generateJaypieKey({ issuer: "jaypie" });
+      // sk_jaypie_ + 32 body + _ + 5 checksum = 48 chars
+      expect(key.length).toBe(48);
+      expect(validateJaypieKey(key, { issuer: "jaypie" })).toBe(true);
+    });
+
+    it("omits the environment when false", () => {
+      process.env.PROJECT_ENV = "sandbox";
+      expect(generateJaypieKey({ environment: false }).length).toBe(41);
+    });
+
+    it("omits the environment when null", () => {
+      process.env.PROJECT_ENV = "sandbox";
+      expect(generateJaypieKey({ environment: null }).length).toBe(41);
+    });
+
+    it("omits the environment when PROJECT_ENV is unset", () => {
+      expect(generateJaypieKey().length).toBe(41);
+    });
+  });
+
+  describe("Error Conditions", () => {
+    it("throws when a non-production key is validated in production", () => {
+      const key = generateJaypieKey({
+        environment: "sandbox",
+        issuer: "jaypie",
+      });
+      process.env.PROJECT_ENV = "production";
+      expect(() => validateJaypieKey(key, { issuer: "jaypie" })).toThrowError(
+        "The provided key matches a non-production environment",
+      );
+    });
+
+    it("throws UnauthorizedError, not a generic error", () => {
+      const key = generateJaypieKey({
+        environment: "sandbox",
+        issuer: "jaypie",
+      });
+      process.env.PROJECT_ENV = "production";
+      let caught;
+      try {
+        validateJaypieKey(key, { issuer: "jaypie" });
+      } catch (error) {
+        caught = error;
+      }
+      expect(caught).toBeInstanceOf(UnauthorizedError);
+    });
+
+    it("does not throw for a malformed key in production", () => {
+      process.env.PROJECT_ENV = "production";
+      expect(
+        validateJaypieKey("sk_jaypie_sandbox_nope", { issuer: "jaypie" }),
+      ).toBe(false);
+    });
+
+    it("does not throw when the environment is validated without an issuer", () => {
+      const key = generateJaypieKey({ environment: "sandbox" });
+      process.env.PROJECT_ENV = "production";
+      expect(validateJaypieKey(key)).toBe(false);
+    });
+  });
+});
+
+describe("Legacy Compatibility", () => {
+  describe("Happy Paths", () => {
+    it("validates a legacy random key", () => {
+      expect(validateJaypieKey(LEGACY_KEY.RANDOM)).toBe(true);
+    });
+
+    it("validates a legacy key with an issuer", () => {
+      expect(validateJaypieKey(LEGACY_KEY.SEEDED, { issuer: "jaypie" })).toBe(
+        true,
+      );
+    });
+
+    it("validates a legacy seeded key without an issuer", () => {
+      expect(validateJaypieKey(LEGACY_KEY.SEEDED_NO_ISSUER)).toBe(true);
+    });
+
+    it("validates a legacy key in production", () => {
+      const originalEnv = process.env.PROJECT_ENV;
+      process.env.PROJECT_ENV = "production";
+      try {
+        expect(validateJaypieKey(LEGACY_KEY.SEEDED, { issuer: "jaypie" })).toBe(
+          true,
+        );
+      } finally {
+        if (originalEnv === undefined) {
+          delete process.env.PROJECT_ENV;
+        } else {
+          process.env.PROJECT_ENV = originalEnv;
+        }
+      }
+    });
+  });
+
+  describe("Features", () => {
+    it("reproduces a legacy seeded key with version 1", () => {
+      const key = generateJaypieKey({
+        issuer: "jaypie",
+        seed: LEGACY_SEED,
+        version: 1,
+      });
+      expect(key).toBe(LEGACY_KEY.SEEDED);
+    });
+
+    it("reproduces a legacy seeded key without an issuer with version 1", () => {
+      const key = generateJaypieKey({ seed: LEGACY_SEED, version: 1 });
+      expect(key).toBe(LEGACY_KEY.SEEDED_NO_ISSUER);
+    });
+
+    it("emits a four-character checksum with version 1", () => {
+      expect(generateJaypieKey({ version: 1 }).length).toBe(40);
+    });
+
+    it("omits the environment with version 1", () => {
+      const originalEnv = process.env.PROJECT_ENV;
+      process.env.PROJECT_ENV = "sandbox";
+      try {
+        expect(generateJaypieKey({ version: 1 }).length).toBe(40);
+      } finally {
+        if (originalEnv === undefined) {
+          delete process.env.PROJECT_ENV;
+        } else {
+          process.env.PROJECT_ENV = originalEnv;
+        }
+      }
+    });
+
+    it("derives a different key from the same seed at version 2", () => {
+      const legacy = generateJaypieKey({ seed: LEGACY_SEED, version: 1 });
+      const current = generateJaypieKey({ seed: LEGACY_SEED });
+      expect(current).not.toBe(legacy);
+      expect(validateJaypieKey(current)).toBe(true);
+    });
+  });
+});
+
+describe("Checksum", () => {
+  // Swap the first adjacent pair of distinct characters
+  function transpose(body: string): string {
+    for (let i = 0; i < body.length - 1; i++) {
+      if (body[i] !== body[i + 1]) {
+        return body.slice(0, i) + body[i + 1] + body[i] + body.slice(i + 2);
+      }
+    }
+    throw new Error("body has no distinct adjacent pair");
+  }
+
+  describe("Features", () => {
+    it("emits five characters", () => {
+      const key = generateJaypieKey({ prefix: "" });
+      expect(key.slice(-6)).toMatch(/^_[0-9A-Za-z]{5}$/);
+    });
+
+    it("catches a transposed pair in the body", () => {
+      const [body, checksum] = generateJaypieKey({ prefix: "" }).split("_");
+      const swapped = transpose(body);
+      expect(swapped).not.toBe(body);
+      expect(validateJaypieKey(`${body}_${checksum}`)).toBe(true);
+      expect(validateJaypieKey(`${swapped}_${checksum}`)).toBe(false);
+    });
+
+    it("documents that the legacy checksum missed a transposed pair", () => {
+      const [body, checksum] = generateJaypieKey({
+        prefix: "",
+        version: 1,
+      }).split("_");
+      const swapped = transpose(body);
+      expect(checksum.length).toBe(4);
+      expect(validateJaypieKey(`${swapped}_${checksum}`)).toBe(true);
+    });
+  });
+});
+
+describe("Seeded Derivation", () => {
+  describe("Features", () => {
+    it("derives a body longer than one digest", () => {
+      const key = generateJaypieKey({
+        length: 64,
+        prefix: "",
+        seed: "long-body",
+      });
+      const body = key.slice(0, 64);
+      expect(body.length).toBe(64);
+      expect(body.includes("undefined")).toBe(false);
+      const base62Set = new Set(BASE62);
+      for (const char of body) {
+        expect(base62Set.has(char)).toBe(true);
+      }
+    });
+
+    it("stays deterministic at the longer length", () => {
+      const options = { length: 64, prefix: "", seed: "long-body" };
+      expect(generateJaypieKey(options)).toBe(generateJaypieKey(options));
+    });
+
+    it("validates the longer key", () => {
+      const key = generateJaypieKey({
+        length: 64,
+        prefix: "",
+        seed: "long-body",
+      });
+      expect(validateJaypieKey(key, { length: 64, prefix: "" })).toBe(true);
+    });
+  });
+});
+
+describe("Body Distribution", () => {
+  describe("Features", () => {
+    it("does not favor the characters modulo bias would favor", () => {
+      // 256 % 62 leaves the first eight pool characters doubly reachable under
+      // a plain modulo. Rejection sampling removes the skew
+      const counts = new Map<string, number>();
+      for (let i = 0; i < 200; i++) {
+        for (const char of generateJaypieKey({ checksum: false, prefix: "" })) {
+          counts.set(char, (counts.get(char) ?? 0) + 1);
+        }
+      }
+      const biased = BASE62.slice(0, 8);
+      let biasedTotal = 0;
+      let total = 0;
+      for (const [char, count] of counts) {
+        total += count;
+        if (biased.includes(char)) biasedTotal += count;
+      }
+      const share = biasedTotal / total;
+      const expected = biased.length / BASE62.length;
+      // A modulo-biased body puts roughly 12.5% of characters in this set
+      expect(share).toBeGreaterThan(expected * 0.75);
+      expect(share).toBeLessThan(expected * 1.25);
     });
   });
 });

--- a/packages/kit/src/jaypieHandler.module.ts
+++ b/packages/kit/src/jaypieHandler.module.ts
@@ -125,7 +125,7 @@ const jaypieHandler = (
   //
   // Level follows status: 500-class is an infrastructure or application fault
   // and logs at error so monitors filtering on error status see the outage;
-  // 4xx is a caller mistake and logs at warn.
+  // 4xx is a caller mistake, part of normal operation, and logs at debug.
   //
   // The error as thrown is always logged. Scrubbing replaces `detail` and
   // `title` with the generic strings for the status, so whatever the
@@ -139,8 +139,6 @@ const jaypieHandler = (
 
     if (typeof status === "number" && status >= HTTP.CODE.INTERNAL_ERROR) {
       log.error(message);
-    } else if (typeof status === "number" && status >= HTTP.CODE.BAD_REQUEST) {
-      log.warn(message);
     } else {
       log.debug(message);
     }

--- a/packages/kit/src/lib/functions/jaypieKey.function.ts
+++ b/packages/kit/src/lib/functions/jaypieKey.function.ts
@@ -1,7 +1,10 @@
 import { createHash, createHmac, randomBytes } from "node:crypto";
 
+import { UnauthorizedError } from "@jaypie/errors";
 import { log } from "@jaypie/logger";
 import { v5 as uuidv5 } from "uuid";
+
+import { isProductionEnv } from "../../isProductionEnv.js";
 
 //
 //
@@ -10,30 +13,67 @@ import { v5 as uuidv5 } from "uuid";
 
 const BASE62 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 
+const BYTE_VALUES = 256;
+const RANDOM_BLOCK_BYTES = 32;
+
+const CHECKSUM_LENGTH = {
+  LEGACY: 4,
+  VERSION_2: 5,
+} as const;
+
 const DEFAULTS = {
-  CHECKSUM: 4,
+  CHECKSUM: true,
   LENGTH: 32,
   POOL: BASE62,
   PREFIX: "sk",
   SEPARATOR: "_",
 } as const;
 
+const ENVIRONMENT_PRODUCTION = "production";
+
+const HASH_MODULUS = 2147483647;
+const HASH_MULTIPLIER = 31;
+
+const HMAC_ALGORITHM = "sha256";
+
+const MESSAGE = {
+  NON_PRODUCTION_KEY: "The provided key matches a non-production environment",
+} as const;
+
 const OFFSETS = [0, 13, 29, 37, 43, 53, 61, 71];
 const PRIMES = [1, 7, 11, 17, 23, 29, 37, 41];
+
+const SEED_CONTEXT = "jaypie";
+const SEED_SEPARATOR = ":";
+const SEED_VERSION_TAG = "v2";
+
+const SEPARATOR_PATTERN = /[_-]/;
+
+const VERSION = {
+  CURRENT: 2,
+  LEGACY: 1,
+} as const;
 
 //
 //
 // Types
 //
 
+type JaypieKeyVersion = 1 | 2;
+
 interface JaypieKeyOptions {
-  checksum?: number;
+  /** Truthy emits a checksum; only the current five-character checksum is generated */
+  checksum?: boolean | number;
+  /** Segment between issuer and body; defaults to `PROJECT_ENV`, omitted in production or when `false` */
+  environment?: string | false | null;
   issuer?: string;
   length?: number;
   pool?: string;
   prefix?: string;
   seed?: string;
   separator?: string;
+  /** `1` reproduces keys minted before the five-character checksum */
+  version?: JaypieKeyVersion;
 }
 
 interface HashOptions {
@@ -50,7 +90,9 @@ interface ApiKeyIdOptions {
 // Internal
 //
 
-function computeChecksum(
+// Order-insensitive sum, kept so keys minted before the five-character checksum
+// keep validating. Never used to mint a new key except with `version: 1`.
+function legacyChecksum(
   body: string,
   pool: string,
   checksumLength: number,
@@ -70,24 +112,71 @@ function computeChecksum(
   return result;
 }
 
-//
-//
-// Main
-//
+// Polynomial rolling hash, so the checksum depends on character order and a
+// transposed pair no longer sums to the same value. Five characters, which is
+// also how validation tells this checksum from the legacy four.
+function currentChecksum(body: string, pool: string): string {
+  let hash = 0;
+  for (let i = 0; i < body.length; i++) {
+    hash = (hash * HASH_MULTIPLIER + body.charCodeAt(i)) % HASH_MODULUS;
+  }
+  let result = "";
+  for (let i = 0; i < CHECKSUM_LENGTH.VERSION_2; i++) {
+    result +=
+      pool[
+        (hash * PRIMES[i % PRIMES.length] + OFFSETS[i % OFFSETS.length]) %
+          pool.length
+      ];
+  }
+  return result;
+}
 
-function generateJaypieKey({
-  checksum = DEFAULTS.CHECKSUM,
-  issuer,
-  length = DEFAULTS.LENGTH,
-  pool = DEFAULTS.POOL,
-  prefix = DEFAULTS.PREFIX,
+// Byte source for version 2. A seed derives bytes in counter mode, so a body
+// longer than one digest reads real bytes instead of running off the end, and
+// rejection sampling can draw as many bytes as it discards. The counter message
+// carries a version tag, so a version 2 derivation can never collide with the
+// version 1 digest for the same seed and issuer.
+function createByteReader({
   seed,
-  separator = DEFAULTS.SEPARATOR,
-}: JaypieKeyOptions = {}): string {
+  context,
+}: {
+  context: string;
+  seed?: string;
+}): () => number {
+  let block = Buffer.alloc(0);
+  let counter = 0;
+  let offset = 0;
+  return () => {
+    if (offset >= block.length) {
+      block = seed
+        ? createHmac(HMAC_ALGORITHM, seed)
+            .update([context, SEED_VERSION_TAG, counter].join(SEED_SEPARATOR))
+            .digest()
+        : randomBytes(RANDOM_BLOCK_BYTES);
+      counter += 1;
+      offset = 0;
+    }
+    const byte = block[offset];
+    offset += 1;
+    return byte;
+  };
+}
+
+function legacyBody({
+  context,
+  length,
+  pool,
+  seed,
+}: {
+  context: string;
+  length: number;
+  pool: string;
+  seed?: string;
+}): string {
   let bytes: Buffer;
   if (seed) {
-    const hmac = createHmac("sha256", seed);
-    hmac.update(issuer ?? "jaypie");
+    const hmac = createHmac(HMAC_ALGORITHM, seed);
+    hmac.update(context);
     bytes = hmac.digest();
   } else {
     bytes = randomBytes(length);
@@ -96,19 +185,90 @@ function generateJaypieKey({
   for (let i = 0; i < length; i++) {
     body += pool[bytes[i] % pool.length];
   }
+  return body;
+}
+
+// Rejection sampling. 256 is not a multiple of 62, so a plain modulo favors the
+// first eight characters of base62; discarding the short tail of the byte range
+// leaves every pool character equally likely. A pool larger than a byte has no
+// tail to discard and falls back to modulo.
+function currentBody({
+  context,
+  length,
+  pool,
+  seed,
+}: {
+  context: string;
+  length: number;
+  pool: string;
+  seed?: string;
+}): string {
+  const nextByte = createByteReader({ context, seed });
+  const limit = Math.floor(BYTE_VALUES / pool.length) * pool.length;
+  let body = "";
+  while (body.length < length) {
+    const byte = nextByte();
+    if (limit > 0 && byte >= limit) continue;
+    body += pool[byte % pool.length];
+  }
+  return body;
+}
+
+// The segment is a hint carried in the key, so it must survive splitting on
+// either separator. Anything outside the alphanumeric range is dropped, which
+// keeps an environment such as `pr-123` from reading as two segments.
+function resolveEnvironment(
+  environment: string | false | null | undefined,
+): string | undefined {
+  if (environment === false || environment === null) return undefined;
+  const value = environment ?? process.env.PROJECT_ENV;
+  if (!value) return undefined;
+  if (value === ENVIRONMENT_PRODUCTION) return undefined;
+  const sanitized = value.replace(/[^0-9A-Za-z]/g, "");
+  return sanitized || undefined;
+}
+
+//
+//
+// Main
+//
+
+function generateJaypieKey({
+  checksum = DEFAULTS.CHECKSUM,
+  environment,
+  issuer,
+  length = DEFAULTS.LENGTH,
+  pool = DEFAULTS.POOL,
+  prefix = DEFAULTS.PREFIX,
+  seed,
+  separator = DEFAULTS.SEPARATOR,
+  version = VERSION.CURRENT,
+}: JaypieKeyOptions = {}): string {
+  const legacy = version === VERSION.LEGACY;
+  const context = issuer ?? SEED_CONTEXT;
+  const body = legacy
+    ? legacyBody({ context, length, pool, seed })
+    : currentBody({ context, length, pool, seed });
 
   const parts: string[] = [];
   if (prefix) parts.push(prefix);
   if (issuer) parts.push(issuer);
+  if (!legacy) {
+    const resolvedEnvironment = resolveEnvironment(environment);
+    if (resolvedEnvironment) parts.push(resolvedEnvironment);
+  }
 
   let result = "";
   if (parts.length > 0) {
     result = parts.join(separator) + separator;
   }
   result += body;
-  if (checksum > 0) {
-    const checksumStr = computeChecksum(body, pool, checksum);
-    result += separator + checksumStr;
+  if (checksum) {
+    result +=
+      separator +
+      (legacy
+        ? legacyChecksum(body, pool, CHECKSUM_LENGTH.LEGACY)
+        : currentChecksum(body, pool));
   }
   return result;
 }
@@ -128,15 +288,43 @@ function hashJaypieKey(key: string, { salt }: HashOptions = {}): string {
   }
 
   if (resolvedSalt) {
-    return createHmac("sha256", resolvedSalt).update(key).digest("hex");
+    return createHmac(HMAC_ALGORITHM, resolvedSalt).update(key).digest("hex");
   }
-  return createHash("sha256").update(key).digest("hex");
+  return createHash(HMAC_ALGORITHM).update(key).digest("hex");
+}
+
+function isPoolString(value: string, pool: Set<string>): boolean {
+  for (const char of value) {
+    if (!pool.has(char)) return false;
+  }
+  return true;
+}
+
+// A checksum is never required. When one is present it must be four characters
+// matching the legacy sum or five matching the current algorithm.
+function isChecksumValid({
+  body,
+  checksum,
+  pool,
+}: {
+  body: string;
+  checksum: string;
+  pool: string;
+}): boolean {
+  if (checksum.length === CHECKSUM_LENGTH.VERSION_2) {
+    return checksum === currentChecksum(body, pool);
+  }
+  if (checksum.length === CHECKSUM_LENGTH.LEGACY) {
+    return checksum === legacyChecksum(body, pool, CHECKSUM_LENGTH.LEGACY);
+  }
+  return false;
 }
 
 function validateJaypieKey(
   key: string,
   {
     checksum = DEFAULTS.CHECKSUM,
+    environment,
     issuer,
     length = DEFAULTS.LENGTH,
     pool = DEFAULTS.POOL,
@@ -144,73 +332,88 @@ function validateJaypieKey(
   }: JaypieKeyOptions = {},
 ): boolean {
   if (typeof key !== "string") return false;
+  if (key.length === 0) return false;
 
   const poolSet = new Set(pool);
-  const separators = ["_", "-"];
+  const segments = key.split(SEPARATOR_PATTERN);
 
-  // Build prefix candidates to try (prefix and checksum are not required)
-  const prefixCandidates = new Set<string>();
-
-  for (const sep of separators) {
-    const parts: string[] = [];
-    if (prefix) parts.push(prefix);
-    if (issuer) parts.push(issuer);
-
-    if (parts.length > 0) {
-      prefixCandidates.add(parts.join(sep) + sep);
+  // Candidate splits of the trailing segments into body and checksum. The
+  // checksum may stand alone, follow the body without a separator, or be absent
+  const candidates: Array<{ body: string; checksum: string; lead: string[] }> =
+    [];
+  const last = segments[segments.length - 1];
+  if (last.length === length) {
+    candidates.push({ body: last, checksum: "", lead: segments.slice(0, -1) });
+  }
+  for (const checksumLength of [
+    CHECKSUM_LENGTH.LEGACY,
+    CHECKSUM_LENGTH.VERSION_2,
+  ]) {
+    if (last.length === length + checksumLength) {
+      candidates.push({
+        body: last.slice(0, length),
+        checksum: last.slice(length),
+        lead: segments.slice(0, -1),
+      });
     }
-
-    // Without the prefix part, just issuer
-    if (prefix && issuer) {
-      prefixCandidates.add(issuer + sep);
+    if (
+      segments.length >= 2 &&
+      last.length === checksumLength &&
+      segments[segments.length - 2].length === length
+    ) {
+      candidates.push({
+        body: segments[segments.length - 2],
+        checksum: last,
+        lead: segments.slice(0, -2),
+      });
     }
   }
 
-  // No prefix at all (only when issuer is not specified)
-  if (!issuer) {
-    prefixCandidates.add("");
+  const production = isProductionEnv();
+  const resolvedEnvironment = resolveEnvironment(environment);
+  let environmentMismatch = false;
+
+  for (const candidate of candidates) {
+    if (!isPoolString(candidate.body, poolSet)) continue;
+    if (candidate.checksum) {
+      if (!checksum) continue;
+      if (!isPoolString(candidate.checksum, poolSet)) continue;
+      if (
+        !isChecksumValid({
+          body: candidate.body,
+          checksum: candidate.checksum,
+          pool,
+        })
+      ) {
+        continue;
+      }
+    }
+
+    // Leading segments are, in order, an optional prefix, the issuer when one is
+    // expected, and an optional environment
+    const lead = [...candidate.lead];
+    if (prefix && lead[0] === prefix) lead.shift();
+    if (issuer) {
+      if (lead[0] !== issuer) continue;
+      lead.shift();
+    }
+    if (lead.length === 0) return true;
+    if (lead.length > 1) continue;
+
+    // A single unclaimed segment is the environment. With an issuer the layout
+    // is unambiguous, so any environment is accepted outside production and
+    // rejected within it. Without an issuer the segment is indistinguishable
+    // from an issuer, so it must match the environment being validated against
+    if (issuer) {
+      if (!production) return true;
+      environmentMismatch = true;
+      continue;
+    }
+    if (resolvedEnvironment && lead[0] === resolvedEnvironment) return true;
   }
 
-  for (const prefixStr of prefixCandidates) {
-    if (!key.startsWith(prefixStr)) continue;
-
-    const remainder = key.slice(prefixStr.length);
-    if (remainder.length < length) continue;
-
-    const body = remainder.slice(0, length);
-
-    // Validate all body chars are in pool
-    let bodyValid = true;
-    for (const char of body) {
-      if (!poolSet.has(char)) {
-        bodyValid = false;
-        break;
-      }
-    }
-    if (!bodyValid) continue;
-
-    const tail = remainder.slice(length);
-
-    // No tail — valid (checksum not required)
-    if (tail.length === 0) return true;
-
-    // If checksum is disabled, extra chars means invalid for this interpretation
-    if (checksum <= 0) continue;
-
-    // Try: separator + checksum
-    if (tail.length === 1 + checksum && (tail[0] === "_" || tail[0] === "-")) {
-      const checksumStr = tail.slice(1);
-      if (checksumStr === computeChecksum(body, pool, checksum)) {
-        return true;
-      }
-    }
-
-    // Try: checksum directly (no separator)
-    if (tail.length === checksum) {
-      if (tail === computeChecksum(body, pool, checksum)) {
-        return true;
-      }
-    }
+  if (environmentMismatch) {
+    throw new UnauthorizedError(MESSAGE.NON_PRODUCTION_KEY);
   }
 
   return false;
@@ -222,4 +425,9 @@ function validateJaypieKey(
 //
 
 export { generateJaypieKey, hashJaypieKey, jaypieApiKeyId, validateJaypieKey };
-export type { ApiKeyIdOptions, HashOptions, JaypieKeyOptions };
+export type {
+  ApiKeyIdOptions,
+  HashOptions,
+  JaypieKeyOptions,
+  JaypieKeyVersion,
+};

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.126",
+  "version": "0.8.127",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/jaypie/1.2.80.md
+++ b/packages/mcp/release-notes/jaypie/1.2.80.md
@@ -1,0 +1,13 @@
+---
+version: 1.2.80
+date: 2026-08-04
+summary: Track @jaypie/kit 1.2.16, adding the API key environment segment
+---
+
+## Changes
+
+- Update the `@jaypie/kit` range to `^1.2.16`, which adds the `environment`
+  segment to `generateJaypieKey`, moves to a five-character checksum that
+  catches transpositions, and logs a caught 4xx Jaypie error at `log.debug`
+- Every key minted before `@jaypie/kit` 1.2.16 still validates; re-deriving a
+  seeded key requires `version: 1`

--- a/packages/mcp/release-notes/kit/1.2.16.md
+++ b/packages/mcp/release-notes/kit/1.2.16.md
@@ -1,0 +1,49 @@
+---
+version: 1.2.16
+date: 2026-08-04
+summary: Environment segment in API keys, five-character checksum, and 4xx handler errors at debug
+---
+
+## Changes
+
+### Handler log level
+
+- `jaypieHandler` logs a caught 4xx Jaypie error at `log.debug`. A client
+  mistake is part of normal operation and no longer raises the warn count or
+  reaches monitors filtering on warn.
+- 500-class errors continue to log at `log.error`.
+- Scrubbing is unchanged: every caught Jaypie error still emits
+  `log.var({ jaypieError: { detail, status, title } })`, 500-class detail and
+  title are replaced with the generic strings for the status, and 4xx keeps its
+  detail as thrown unless `scrub` says otherwise.
+
+### API keys
+
+- `generateJaypieKey` accepts `environment`, defaulting to `PROJECT_ENV` and
+  placed between the issuer and the body: `sk_issuer_environment_body_checksum`.
+  The segment is omitted in production, when `PROJECT_ENV` is unset, and when
+  `environment` is `false` or `null`. Characters outside `0-9A-Za-z` are
+  stripped so an environment such as `pr-123` cannot read as two segments.
+- `validateJaypieKey` never requires the environment segment. Outside
+  production a key validates with or without it. In production a key carrying
+  one throws `UnauthorizedError` with "The provided key matches a
+  non-production environment", which requires `issuer` since an unclaimed
+  segment is otherwise indistinguishable from an issuer.
+- The checksum is five characters from a position-weighted rolling hash and is
+  no longer configurable by length. The previous four-character sum was
+  order-insensitive, so a transposed pair passed; the new checksum catches it.
+- Random key bodies use rejection sampling. 256 is not a multiple of 62, so the
+  previous modulo favored the first eight base62 characters.
+- Seeded derivation reads HMAC blocks in counter mode under a version-tagged
+  message. A `length` above 32 now derives real bytes instead of running off the
+  end of a single digest.
+
+### Key compatibility
+
+- Every key minted before this version still validates. Validation reads the
+  checksum length and dispatches four characters to the original sum and five to
+  the current algorithm. There is no transition window.
+- Re-deriving a seeded key minted before this version requires `version: 1`,
+  which reproduces the old derivation and four-character checksum byte for byte.
+  This is the only caller-visible break, and it affects the site that re-derives
+  a bootstrap key from `PROJECT_ADMIN_SEED`.

--- a/packages/mcp/release-notes/mcp/0.8.127.md
+++ b/packages/mcp/release-notes/mcp/0.8.127.md
@@ -1,0 +1,12 @@
+---
+version: 0.8.127
+date: 2026-08-04
+summary: Document the API key environment segment and 4xx errors logging at debug
+---
+
+## Changes
+
+- `skill("apikey")` covers the `environment` segment, the five-character
+  checksum, the production `UnauthorizedError`, and what `version: 1` reproduces
+- `skill("logs")` and `skill("handlers")` describe a caught 4xx Jaypie error as
+  logging at `log.debug`

--- a/packages/mcp/release-notes/testkit/1.2.64.md
+++ b/packages/mcp/release-notes/testkit/1.2.64.md
@@ -1,0 +1,10 @@
+---
+version: 1.2.64
+date: 2026-08-04
+summary: Mock generateJaypieKey returns a five-character checksum
+---
+
+## Changes
+
+- `generateJaypieKey` mock returns `sk_MOCK00000000000000000000000000_abcde`,
+  matching the five-character checksum `@jaypie/kit` 1.2.16 emits

--- a/packages/mcp/skills/apikey.md
+++ b/packages/mcp/skills/apikey.md
@@ -13,8 +13,8 @@ Jaypie provides four functions for working with API keys: `generateJaypieKey`, `
 import { generateJaypieKey } from "jaypie";
 
 const key = generateJaypieKey();
-// "sk_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6_Xq7R"
-//  ^^ prefix    ^^ 32-char base62 body   ^^ 4-char checksum
+// "sk_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6_Xq7Rt"
+//  ^^ prefix    ^^ 32-char base62 body   ^^ 5-char checksum
 ```
 
 ### With Issuer
@@ -23,23 +23,43 @@ Use `issuer` to namespace keys by application or service. Prefer explicit naming
 
 ```typescript
 const key = generateJaypieKey({ issuer: "jaypie" });
-// "sk_jaypie_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6_Xq7R"
+// "sk_jaypie_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6_Xq7Rt"
 ```
+
+### With Environment
+
+> **Version note:** `environment` requires `jaypie >= 1.2.80` / `@jaypie/kit >= 1.2.16`.
+
+A key minted outside production carries the environment between the issuer and the body, so a key is recognizable on sight as non-production:
+
+```typescript
+// PROJECT_ENV=sandbox
+generateJaypieKey({ issuer: "jaypie" });
+// "sk_jaypie_sandbox_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6_Xq7Rt"
+
+// PROJECT_ENV=production
+generateJaypieKey({ issuer: "jaypie" });
+// "sk_jaypie_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6_Xq7Rt"
+```
+
+The segment defaults to `PROJECT_ENV` and is omitted in production, when `PROJECT_ENV` is unset, and when `environment` is `false` or `null`. Characters outside `0-9A-Za-z` are stripped, so an environment such as `pr-123` becomes `pr123` and cannot read as two segments.
 
 ### Without Prefix or Checksum
 
-Prefix and checksum are optional. Pass `prefix: ""` or `checksum: 0` to omit:
+Prefix and checksum are optional. Pass `prefix: ""` or `checksum: false` to omit:
 
 ```typescript
 generateJaypieKey({ prefix: "" });
-// "A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6_Xq7R"
+// "A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6_Xq7Rt"
 
-generateJaypieKey({ prefix: "", checksum: 0 });
+generateJaypieKey({ prefix: "", checksum: false });
 // "A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6"
 
 generateJaypieKey({ prefix: "", issuer: "jaypie" });
-// "jaypie_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6_Xq7R"
+// "jaypie_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6_Xq7Rt"
 ```
+
+Checksum length is not configurable. `checksum` is read for truthiness only and always emits five characters.
 
 ### With Seed
 
@@ -62,19 +82,30 @@ generateJaypieKey({ seed: "my-seed", issuer: "beta" });
 
 This is useful for bootstrapping an initial owner key from a shared secret without requiring database access.
 
+Derivation reads bytes in counter mode, so `length` above 32 keeps deriving real bytes instead of running off the end of a single digest, and the counter message carries a version tag so a version 2 derivation can never collide with a version 1 digest for the same seed and issuer.
+
+A key derived from a seed before `@jaypie/kit` 1.2.16 is reproduced with `version: 1`:
+
+```typescript
+generateJaypieKey({ seed: process.env.PROJECT_ADMIN_SEED, issuer: "jaypie", version: 1 });
+// Byte-for-byte the key the old algorithm derived
+```
+
 ### Options
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `checksum` | `4` | Checksum character count (0 to omit) |
+| `checksum` | `true` | Emit the five-character checksum (`false` to omit) |
+| `environment` | `PROJECT_ENV` | Segment between issuer and body (`false` to omit) |
 | `issuer` | (none) | Namespace segment after prefix |
 | `length` | `32` | Random body length |
 | `pool` | base62 (`0-9A-Za-z`) | Character pool for body |
 | `prefix` | `"sk"` | Key prefix (`""` to omit) |
 | `seed` | (none) | Derive key deterministically via HMAC-SHA256 |
 | `separator` | `"_"` | Delimiter between segments |
+| `version` | `2` | `1` reproduces a key minted before the five-character checksum |
 
-All options are optional. Zero-param call produces `sk_<32 base62>_<4 checksum>`.
+All options are optional. Zero-param call produces `sk_<environment>_<32 base62>_<5 checksum>`, dropping the environment segment in production.
 
 ### Valid Formats
 
@@ -82,11 +113,12 @@ All of the following are valid key formats:
 
 | Format | Example |
 |--------|---------|
-| `sk_issuer_body_checksum` | `sk_jaypie_A1b2...p6_Xq7R` |
-| `sk_issuer_bodychecksum` | `sk_jaypie_A1b2...p6Xq7R` |
-| `sk_body_checksum` | `sk_A1b2...p6_Xq7R` |
-| `issuer_bodychecksum` | `jaypie_A1b2...p6Xq7R` |
-| `body_checksum` | `A1b2...p6_Xq7R` |
+| `sk_issuer_environment_body_checksum` | `sk_jaypie_sandbox_A1b2...p6_Xq7Rt` |
+| `sk_issuer_body_checksum` | `sk_jaypie_A1b2...p6_Xq7Rt` |
+| `sk_issuer_bodychecksum` | `sk_jaypie_A1b2...p6Xq7Rt` |
+| `sk_body_checksum` | `sk_A1b2...p6_Xq7Rt` |
+| `issuer_bodychecksum` | `jaypie_A1b2...p6Xq7Rt` |
+| `body_checksum` | `A1b2...p6_Xq7Rt` |
 | `body` | `A1b2...p6` |
 
 Both `_` and `-` are accepted as separators in prefix matter.
@@ -114,13 +146,52 @@ validateJaypieKey(bare);  // true — prefix is not required
 Keys without checksum validate with default options:
 
 ```typescript
-const noCheck = generateJaypieKey({ checksum: 0 });
+const noCheck = generateJaypieKey({ checksum: false });
 validateJaypieKey(noCheck);  // true — checksum is not required
 ```
 
 Checksum separator is also optional — `body_checksum` and `bodychecksum` both validate.
 
 Validation does **not** check revocation or authorization — only structural validity.
+
+### Environment
+
+The environment segment is never required. Outside production a key validates with or without it, whatever environment it names:
+
+```typescript
+// PROJECT_ENV=sandbox
+validateJaypieKey("sk_jaypie_sandbox_A1b2...p6_Xq7Rt", { issuer: "jaypie" });  // true
+validateJaypieKey("sk_jaypie_local_A1b2...p6_Xq7Rt", { issuer: "jaypie" });    // true
+validateJaypieKey("sk_jaypie_A1b2...p6_Xq7Rt", { issuer: "jaypie" });          // true
+```
+
+In production a key carrying an environment segment throws `UnauthorizedError`:
+
+```typescript
+// PROJECT_ENV=production
+validateJaypieKey("sk_jaypie_sandbox_A1b2...p6_Xq7Rt", { issuer: "jaypie" });
+// throws UnauthorizedError("The provided key matches a non-production environment")
+```
+
+The throw requires `issuer`. Without it, an extra segment is indistinguishable from an issuer, so it validates only when it matches the environment being validated against and returns `false` otherwise. Pass `issuer` wherever the production rejection matters.
+
+Production is `isProductionEnv()`: `PROJECT_ENV=production` or `PROJECT_PRODUCTION=true`.
+
+## Compatibility
+
+Every key minted before `@jaypie/kit` 1.2.16 still validates. Validation reads the checksum length and dispatches: four characters to the original order-insensitive sum, five to the current algorithm. Nothing was invalidated and there is no transition window.
+
+Three things changed for keys minted going forward:
+
+| Change | Effect on existing keys |
+|--------|------------------------|
+| Checksum is five characters from a rolling hash | None. Four-character checksums still validate |
+| Random bodies use rejection sampling | None. Validation never inspected how bytes were drawn |
+| Seeded derivation is versioned and reads in counter mode | Re-derivation needs `version: 1` to reproduce the old key |
+
+The last one is the only caller-visible break: a bootstrap key derived from `PROJECT_ADMIN_SEED` is re-derived at comparison time, and the default derivation is now version 2. Pass `version: 1` at that call site, or mint a version 2 key and store its hash.
+
+The five-character checksum exists because the original summed character codes, which is order-insensitive: transposing two characters produced the same checksum. The rolling hash weights position, so a transposed pair is caught.
 
 ## Hash
 
@@ -200,7 +271,7 @@ Mocked in `@jaypie/testkit`:
 import { generateJaypieKey, hashJaypieKey, validateJaypieKey } from "@jaypie/testkit/mock";
 ```
 
-- `generateJaypieKey` returns `"sk_MOCK00000000000000000000000000_abcd"`
+- `generateJaypieKey` returns `"sk_MOCK00000000000000000000000000_abcde"`
 - `hashJaypieKey` returns `"0".repeat(64)` (64 zeroes)
 - `validateJaypieKey` returns `true`
 

--- a/packages/mcp/skills/handlers.md
+++ b/packages/mcp/skills/handlers.md
@@ -155,7 +155,7 @@ fabricMcp({ service: greetService, server });
 
 All handlers catch errors and format responses:
 
-- **Jaypie errors under 500** (`isProjectError: true`): Return error body, log at warn level
+- **Jaypie errors under 500** (`isProjectError: true`): Return error body, log at debug level
 - **Jaypie errors 500 and above**: Return error body, log at error level
 - **Unhandled errors**: Wrap in `UnhandledError`, log at fatal level
 - **With `throw: true`**: Re-throw instead of formatting (for custom handling)

--- a/packages/mcp/skills/logs.md
+++ b/packages/mcp/skills/logs.md
@@ -67,9 +67,9 @@ Log any important, even scalar, data and filter with `var` in Datadog
 
 ## Caught Jaypie Errors
 
-The handler lifecycle picks the level from the error's status, so an outage is visible to monitors filtering on error status without the application logging anything itself:
+The handler lifecycle picks the level from the error's status, so an outage is visible to monitors filtering on error status without the application logging anything itself. A 4xx is part of normal operation and stays at debug, so client mistakes do not raise the warn count:
 
-- **4xx** (`BadRequestError`, `NotFoundError`, …) → `log.warn("[handler] Caught Jaypie error")`
+- **4xx** (`BadRequestError`, `NotFoundError`, …) → `log.debug("[handler] Caught Jaypie error")`
 - **500-class** (`ConfigurationError`, `InternalError`, `BadGatewayError`, `GatewayTimeoutError`, `UnavailableError`, …) → `log.error("[handler] Caught Jaypie error")`
 
 Either way the handler emits `log.var({ jaypieError: { detail, status, title } })` carrying the error as thrown. The same applies to errors thrown during `validate` and `teardown`. Non-Jaypie errors remain `log.fatal` plus `log.error`.

--- a/packages/testkit/package.json
+++ b/packages/testkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/testkit",
-  "version": "1.2.63",
+  "version": "1.2.64",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/finlaysonstudio/jaypie.git"

--- a/packages/testkit/src/mock/core.ts
+++ b/packages/testkit/src/mock/core.ts
@@ -147,7 +147,7 @@ export const formatError = createMockWrappedFunction(
 );
 
 export const generateJaypieKey = createMockReturnedFunction(
-  `sk_MOCK00000000000000000000000000_abcd`,
+  `sk_MOCK00000000000000000000000000_abcde`,
 );
 
 export const hashJaypieKey = createMockReturnedFunction("0".repeat(64));

--- a/workspaces/documentation/src/content/docs/docs/core/handler-lifecycle.md
+++ b/workspaces/documentation/src/content/docs/docs/core/handler-lifecycle.md
@@ -123,13 +123,14 @@ A caught Jaypie error is logged by status and then scrubbed:
 
 | Error | Log level | Response `detail` and `title` |
 |-------|-----------|-------------------------------|
-| 4xx (`BadRequestError`, `NotFoundError`, …) | `log.warn` | Generic strings for the status |
+| 4xx (`BadRequestError`, `NotFoundError`, …) | `log.debug` | Detail as thrown, unless `scrub` |
 | 500-class (`ConfigurationError`, `InternalError`, …) | `log.error` | Generic strings for the status |
 | Non-Jaypie error | `log.fatal` | `UnhandledError` |
 
 Either way the handler emits `log.var({ jaypieError: { detail, status, title } })`
-carrying the error as thrown, then replaces `detail` and `title` with the generic
-strings for the status. `status`, `message`, and `stack` are untouched.
+carrying the error as thrown, then replaces `detail` and `title` of a 500-class
+error with the generic strings for the status. `status`, `message`, and `stack`
+are untouched.
 
 ```typescript
 throw new ConfigurationError("Fabric model chat is not registered");

--- a/workspaces/documentation/src/content/docs/docs/packages/kit.md
+++ b/workspaces/documentation/src/content/docs/docs/packages/kit.md
@@ -189,22 +189,35 @@ Generate API keys with base62 body and optional checksum:
 import { generateJaypieKey } from "jaypie";
 
 const key = generateJaypieKey();
-// "sk_<32 base62 chars>_<4 char checksum>"
+// "sk_<32 base62 chars>_<5 char checksum>"
 
 const custom = generateJaypieKey({
   issuer: "jaypie",
   prefix: "pk",
   length: 16,
 });
-// "pk_jaypie_<16 base62 chars>_<4 char checksum>"
+// "pk_jaypie_<16 base62 chars>_<5 char checksum>"
 ```
 
-Prefix and checksum are optional:
+Outside production the key carries the environment between the issuer and the body:
 
 ```typescript
-generateJaypieKey({ prefix: "" });           // "<body>_<checksum>"
-generateJaypieKey({ checksum: 0 });          // "sk_<body>"
-generateJaypieKey({ prefix: "", checksum: 0 }); // "<body>"
+// PROJECT_ENV=sandbox
+generateJaypieKey({ issuer: "jaypie" });
+// "sk_jaypie_sandbox_<body>_<checksum>"
+
+// PROJECT_ENV=production
+generateJaypieKey({ issuer: "jaypie" });
+// "sk_jaypie_<body>_<checksum>"
+```
+
+Prefix, environment, and checksum are optional:
+
+```typescript
+generateJaypieKey({ prefix: "" });                  // "<body>_<checksum>"
+generateJaypieKey({ checksum: false });             // "sk_<body>"
+generateJaypieKey({ environment: false });          // no environment segment
+generateJaypieKey({ prefix: "", checksum: false }); // "<body>"
 ```
 
 Derive a deterministic key from a seed:
@@ -216,17 +229,23 @@ const key = generateJaypieKey({ seed: process.env.PROJECT_ADMIN_SEED, issuer: "j
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `checksum` | `number` | `4` | Checksum character count (0 to omit) |
+| `checksum` | `boolean` | `true` | Emit the five-character checksum (`false` to omit) |
+| `environment` | `string \| false` | `PROJECT_ENV` | Segment between issuer and body, omitted in production |
 | `issuer` | `string` | `undefined` | Namespace segment after prefix |
 | `length` | `number` | `32` | Random body character length |
 | `pool` | `string` | base62 | Character pool |
 | `prefix` | `string` | `"sk"` | Key prefix (`""` to omit) |
 | `seed` | `string` | `undefined` | Derive key deterministically via HMAC-SHA256 |
 | `separator` | `string` | `"_"` | Delimiter between segments |
+| `version` | `1 \| 2` | `2` | `1` reproduces a key minted before the five-character checksum |
+
+:::note
+Keys minted before `@jaypie/kit` 1.2.16 carry a four-character checksum and still validate. Only re-deriving a seeded key needs `version: 1`.
+:::
 
 ### validateJaypieKey
 
-Validate key format and checksum. Prefix and checksum are **not required** — keys without them are still valid. Both `_` and `-` are accepted as separators:
+Validate key format and checksum. Prefix, environment, and checksum are **not required** — keys without them are still valid. Both `_` and `-` are accepted as separators:
 
 ```typescript
 import { validateJaypieKey } from "jaypie";
@@ -235,6 +254,8 @@ validateJaypieKey(key);                          // true
 validateJaypieKey(key, { issuer: "jaypie" });     // true (if generated with issuer)
 validateJaypieKey("tampered" + key);              // false
 ```
+
+In production, a key carrying an environment segment throws `UnauthorizedError` with the message "The provided key matches a non-production environment". The throw requires `issuer`, since an unclaimed segment is otherwise indistinguishable from an issuer.
 
 ### hashJaypieKey
 


### PR DESCRIPTION
## Log level

A caught 4xx Jaypie error logs at `log.debug` again. A client mistake is part of normal operation and no longer raises the warn count or reaches monitors filtering on warn. 500-class errors continue to log at `log.error`, and scrubbing is unchanged.

The handler-lifecycle page also described 4xx responses as carrying the generic strings, which stopped being true when `scrub` landed.

## API keys

- `generateJaypieKey` accepts `environment`, defaulting to `PROJECT_ENV` and placed between the issuer and the body: `sk_issuer_environment_body_checksum`. Omitted in production, when `PROJECT_ENV` is unset, and when `environment` is `false` or `null`. Non-alphanumeric characters are stripped so `pr-123` cannot read as two segments.
- `validateJaypieKey` never requires the segment. Outside production a key validates with or without it. In production a key carrying one throws `UnauthorizedError("The provided key matches a non-production environment")`, which requires `issuer` since an unclaimed segment is otherwise indistinguishable from an issuer.
- The checksum is five characters from a polynomial rolling hash and is no longer configurable by length. The previous four-character sum was order-insensitive, so a transposed pair produced the same checksum.
- Random bodies use rejection sampling. 256 is not a multiple of 62, so the previous modulo favored the first eight base62 characters.
- Seeded bodies read HMAC blocks in counter mode under a version-tagged message, so `length` above 32 derives real bytes instead of concatenating the literal `"undefined"` past the end of a single digest.

## Compatibility

No existing key was invalidated. Validation dispatches on checksum length: four characters to the legacy sum, five to the current algorithm. Three keys minted by the old algorithm are pinned as fixtures and asserted to validate, including in production.

Re-deriving a seeded key requires `version: 1`, which reproduces the old derivation byte for byte. This is the only caller-visible break and affects the site that re-derives a bootstrap key from `PROJECT_ADMIN_SEED`.

## Versions

`@jaypie/kit` 1.2.16, `@jaypie/testkit` 1.2.64, `@jaypie/mcp` 0.8.127, `jaypie` 1.2.80.

## Testing

4388 tests pass, typecheck clean, no new lint warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5CdZ4JxG5NDv2jyTgijbH