### PR TITLE
feat(constructs): defaultBehavior override and spa rewrite for JaypieWebDeploymentBucket (#487)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14955,7 +14955,7 @@
     },
     "packages/constructs": {
       "name": "@jaypie/constructs",
-      "version": "1.2.77",
+      "version": "1.2.78",
       "license": "MIT",
       "dependencies": {
         "@jaypie/errors": "*",
@@ -15567,7 +15567,7 @@
     },
     "packages/mcp": {
       "name": "@jaypie/mcp",
-      "version": "0.8.127",
+      "version": "0.8.128",
       "license": "MIT",
       "dependencies": {
         "@jaypie/fabric": "^0.3.3",

--- a/packages/constructs/CLAUDE.md
+++ b/packages/constructs/CLAUDE.md
@@ -413,6 +413,26 @@ Production edge caching rides on the default behavior (`CACHING_OPTIMIZED`;
 rank ahead of anything added later and shadow it — paths registered with
 `distribution.addBehavior("/app/*", origin)` match in every environment.
 
+`defaultBehavior?: Partial<cloudfront.BehaviorOptions>` merges over that
+computed behavior (caller keys win; explicit `undefined` is ignored). Merge
+rather than replace, unlike `JaypieDistribution`, because the S3 website origin
+is created internally — a full replacement would force the caller to rebuild it.
+
+`spa: true` attaches a viewer-request CloudFront Function rewriting
+extension-less URIs to `/index.html`, exposed as `.spaFunction` and named
+`constructEnvName("<component>-spa")`. It exists because the bucket's
+`websiteErrorDocument` renders an SPA deep link but answers 404 — correct HTML,
+wrong status for crawlers, uptime checks, and `res.ok` branching. It rides the
+default behavior, so a Lambda surface sharing the distribution via `addBehavior`
+keeps its genuine 404s; a distribution-wide `errorResponses` 404→`/index.html`
+mapping cannot make that distinction. `spa` plus a caller-supplied
+viewer-request association throws `ConfigurationError` at synth, since
+CloudFront permits one function per event type.
+
+```typescript
+new JaypieWebDeploymentBucket(this, "App", { component: "app", host, spa: true, zone });
+```
+
 ### Streaming Lambda
 
 For streaming responses, use `createLambdaStreamHandler` from `@jaypie/express` with `JaypieDistribution`:

--- a/packages/constructs/package.json
+++ b/packages/constructs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/constructs",
-  "version": "1.2.77",
+  "version": "1.2.78",
   "description": "CDK constructs for Jaypie applications",
   "repository": {
     "type": "git",

--- a/packages/constructs/src/JaypieWebDeploymentBucket.ts
+++ b/packages/constructs/src/JaypieWebDeploymentBucket.ts
@@ -53,6 +53,33 @@ const DEFAULT_MANAGED_RULES = [
 ];
 
 /**
+ * Drop explicitly-undefined keys so an override object never erases a
+ * construct default it did not mean to set.
+ */
+function omitUndefined<T extends object>(value: T | undefined): Partial<T> {
+  if (!value) return {};
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined),
+  ) as Partial<T>;
+}
+
+/**
+ * Viewer-request rewrite for a single-page app: any URI whose last segment
+ * carries no file extension is a client route, so serve the shell from its
+ * real key. The website error document renders the same HTML but answers 404,
+ * which breaks crawlers, uptime checks, and any client branching on `res.ok`.
+ */
+const SPA_REWRITE_CODE = `function handler(event) {
+  var request = event.request;
+  var uri = request.uri;
+  var segment = uri.substring(uri.lastIndexOf("/") + 1);
+  if (segment.indexOf(".") === -1) {
+    request.uri = "/index.html";
+  }
+  return request;
+}`;
+
+/**
  * WAF configuration for JaypieWebDeploymentBucket. Same shape as
  * JaypieDistribution's JaypieWafConfig, but `name` is optional — when omitted,
  * the construct id is used to namespace the WebACL and WAF log bucket.
@@ -81,6 +108,23 @@ export interface JaypieWebDeploymentBucketProps extends s3.BucketProps {
    * @default "web"
    */
   component?: string;
+  /**
+   * Overrides merged over the distribution's default behavior. Keys given here
+   * win; keys omitted keep the construct's defaults (S3 website origin,
+   * environment-aware cache policy, response headers policy, HTTPS redirect).
+   *
+   * The default behavior is the right scope for a single-page app rewrite: a
+   * function attached here never sees paths registered later with
+   * `distribution.addBehavior(...)`, so their genuine 404s stay 404s.
+   *
+   * @example
+   * defaultBehavior: {
+   *   functionAssociations: [
+   *     { eventType: cloudfront.FunctionEventType.VIEWER_REQUEST, function: fn },
+   *   ],
+   * }
+   */
+  defaultBehavior?: Partial<cloudfront.BehaviorOptions>;
   /**
    * Log destination configuration for CloudFront access logs.
    * - LambdaDestination: Use a specific Lambda destination for S3 notifications
@@ -140,6 +184,22 @@ export interface JaypieWebDeploymentBucketProps extends s3.BucketProps {
    */
   securityHeaders?: boolean | SecurityHeadersOverrides;
   /**
+   * Serve the bucket as a single-page app. Creates a viewer-request CloudFront
+   * Function on the default behavior that rewrites extension-less URIs to
+   * `/index.html`, so a deep link answers 200 from the real index key instead
+   * of 404 from the website error document.
+   *
+   * Scoped to the default behavior, so paths registered with
+   * `distribution.addBehavior(...)` keep their own 404s. Requires a
+   * distribution: without `host` and `zone` no function is created.
+   *
+   * Throws when `defaultBehavior.functionAssociations` already carries a
+   * viewer-request function, which CloudFront permits only one of.
+   *
+   * @default false
+   */
+  spa?: boolean;
+  /**
    * WAF WebACL configuration for the CloudFront distribution.
    * - true: create and attach a WebACL with sensible defaults; the construct
    *   id is used to namespace the WebACL and WAF log bucket
@@ -175,6 +235,7 @@ export class JaypieWebDeploymentBucket extends Construct implements s3.IBucket {
   public readonly distribution?: cloudfront.Distribution;
   public readonly logBucket?: s3.IBucket;
   public readonly responseHeadersPolicy?: cloudfront.IResponseHeadersPolicy;
+  public readonly spaFunction?: cloudfront.Function;
   public readonly wafLogBucket?: s3.IBucket;
   public readonly webAcl?: wafv2.CfnWebACL;
 
@@ -188,6 +249,7 @@ export class JaypieWebDeploymentBucket extends Construct implements s3.IBucket {
     const {
       certificate: certificateProp,
       component: componentProp = "web",
+      defaultBehavior: defaultBehaviorProp,
       destination: destinationProp = true,
       host: propsHost,
       logBucket: logBucketProp,
@@ -195,6 +257,7 @@ export class JaypieWebDeploymentBucket extends Construct implements s3.IBucket {
       responseHeadersPolicy: responseHeadersPolicyProp,
       roleTag: roleTagProp,
       securityHeaders: securityHeadersProp,
+      spa: spaProp = false,
       waf: wafProp = false,
       zone: propsZone,
       ...bucketProps
@@ -517,6 +580,44 @@ export class JaypieWebDeploymentBucket extends Construct implements s3.IBucket {
 
       this.logBucket = accessLogBucket;
 
+      // Resolve function associations. The SPA rewrite appends to whatever the
+      // caller supplied; CloudFront allows one function per event type, so a
+      // caller-supplied viewer-request function is a synth-time conflict rather
+      // than a deploy-time rejection.
+      const callerFunctionAssociations =
+        defaultBehaviorProp?.functionAssociations ?? [];
+      let functionAssociations = callerFunctionAssociations;
+
+      if (spaProp) {
+        if (
+          callerFunctionAssociations.some(
+            (association) =>
+              association.eventType ===
+              cloudfront.FunctionEventType.VIEWER_REQUEST,
+          )
+        ) {
+          throw new ConfigurationError(
+            "spa cannot be combined with a viewer-request function in defaultBehavior.functionAssociations",
+          );
+        }
+
+        const spaFunction = new cloudfront.Function(this, "SpaRewrite", {
+          code: cloudfront.FunctionCode.fromInline(SPA_REWRITE_CODE),
+          comment: "Rewrite single-page app routes to /index.html",
+          functionName: constructEnvName(`${componentProp}-spa`),
+          runtime: cloudfront.FunctionRuntime.JS_2_0,
+        });
+        this.spaFunction = spaFunction;
+
+        functionAssociations = [
+          ...callerFunctionAssociations,
+          {
+            eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
+            function: spaFunction,
+          },
+        ];
+      }
+
       // Create CloudFront distribution. Production caches at the edge; the
       // policy rides on the default behavior rather than a `/*` behavior so
       // paths registered later with addBehavior still match (#479).
@@ -531,6 +632,8 @@ export class JaypieWebDeploymentBucket extends Construct implements s3.IBucket {
             : {}),
           viewerProtocolPolicy:
             cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+          ...omitUndefined(defaultBehaviorProp),
+          ...(functionAssociations.length ? { functionAssociations } : {}),
         },
         certificate: this.certificate,
         domainNames: [host],

--- a/packages/constructs/src/__tests__/JaypieWebDeploymentBucket.spec.ts
+++ b/packages/constructs/src/__tests__/JaypieWebDeploymentBucket.spec.ts
@@ -240,6 +240,259 @@ describe("JaypieWebDeploymentBucket", () => {
     });
   });
 
+  describe("Default Behavior Override", () => {
+    it("attaches functionAssociations to the default behavior", () => {
+      const { stack, zone } = makeStack();
+      const rewrite = new cloudfront.Function(stack, "Rewrite", {
+        code: cloudfront.FunctionCode.fromInline(
+          "function handler(event) { return event.request; }",
+        ),
+      });
+
+      new JaypieWebDeploymentBucket(stack, "Web", {
+        defaultBehavior: {
+          functionAssociations: [
+            {
+              eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
+              function: rewrite,
+            },
+          ],
+        },
+        host: "app.example.com",
+        zone,
+      });
+      const template = Template.fromStack(stack);
+      const config = findDistribution(template).Properties.DistributionConfig;
+
+      expect(config.DefaultCacheBehavior.FunctionAssociations).toEqual([
+        {
+          EventType: "viewer-request",
+          FunctionARN: {
+            "Fn::GetAtt": [expect.any(String), "FunctionARN"],
+          },
+        },
+      ]);
+      expect(config.CacheBehaviors).toBeUndefined();
+    });
+
+    it("keeps construct defaults the override does not name", () => {
+      process.env.PROJECT_ENV = "production";
+      const { stack, zone } = makeStack();
+
+      new JaypieWebDeploymentBucket(stack, "Web", {
+        defaultBehavior: {
+          allowedMethods: cloudfront.AllowedMethods.ALLOW_ALL,
+        },
+        host: "app.example.com",
+        zone,
+      });
+      const template = Template.fromStack(stack);
+      const config = findDistribution(template).Properties.DistributionConfig;
+
+      expect(config.DefaultCacheBehavior.CachePolicyId).toBe(
+        cloudfront.CachePolicy.CACHING_OPTIMIZED.cachePolicyId,
+      );
+      expect(config.DefaultCacheBehavior.ResponseHeadersPolicyId).toBeDefined();
+      expect(config.DefaultCacheBehavior.AllowedMethods).toEqual(
+        cloudfront.AllowedMethods.ALLOW_ALL.methods,
+      );
+    });
+
+    it("lets the override win over a construct default", () => {
+      process.env.PROJECT_ENV = "production";
+      const { stack, zone } = makeStack();
+
+      new JaypieWebDeploymentBucket(stack, "Web", {
+        defaultBehavior: {
+          cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
+        },
+        host: "app.example.com",
+        zone,
+      });
+      const template = Template.fromStack(stack);
+      const config = findDistribution(template).Properties.DistributionConfig;
+
+      expect(config.DefaultCacheBehavior.CachePolicyId).toBe(
+        cloudfront.CachePolicy.CACHING_DISABLED.cachePolicyId,
+      );
+    });
+
+    it("accepts an origin override", () => {
+      const { stack, zone } = makeStack();
+
+      new JaypieWebDeploymentBucket(stack, "Web", {
+        defaultBehavior: {
+          origin: new origins.HttpOrigin("origin.example.com"),
+        },
+        host: "app.example.com",
+        zone,
+      });
+      const template = Template.fromStack(stack);
+      const config = findDistribution(template).Properties.DistributionConfig;
+
+      const domains = (config.Origins as Array<{ DomainName: unknown }>).map(
+        (origin) => origin.DomainName,
+      );
+      expect(domains).toEqual(["origin.example.com"]);
+    });
+  });
+
+  describe("SPA", () => {
+    it("creates no CloudFront Function by default", () => {
+      const { stack, zone } = makeStack();
+
+      const construct = new JaypieWebDeploymentBucket(stack, "Web", {
+        host: "app.example.com",
+        zone,
+      });
+      const template = Template.fromStack(stack);
+
+      expect(construct.spaFunction).toBeUndefined();
+      template.resourceCountIs("AWS::CloudFront::Function", 0);
+    });
+
+    it("attaches a viewer-request rewrite to the default behavior", () => {
+      const { stack, zone } = makeStack();
+
+      const construct = new JaypieWebDeploymentBucket(stack, "Web", {
+        host: "app.example.com",
+        spa: true,
+        zone,
+      });
+      const template = Template.fromStack(stack);
+      const config = findDistribution(template).Properties.DistributionConfig;
+
+      expect(construct.spaFunction).toBeDefined();
+      template.resourceCountIs("AWS::CloudFront::Function", 1);
+      expect(config.DefaultCacheBehavior.FunctionAssociations).toEqual([
+        {
+          EventType: "viewer-request",
+          FunctionARN: {
+            "Fn::GetAtt": [expect.any(String), "FunctionARN"],
+          },
+        },
+      ]);
+      expect(config.CacheBehaviors).toBeUndefined();
+    });
+
+    it("names the function from component", () => {
+      process.env.PROJECT_ENV = "sandbox";
+      process.env.PROJECT_KEY = "cloudagent";
+      process.env.PROJECT_NONCE = "ckujet";
+      const { stack, zone } = makeStack();
+
+      new JaypieWebDeploymentBucket(stack, "App", {
+        component: "app",
+        host: "app.example.com",
+        spa: true,
+        zone,
+      });
+      const template = Template.fromStack(stack);
+
+      expect(() =>
+        template.hasResourceProperties("AWS::CloudFront::Function", {
+          Name: "sandbox-cloudagent-app-spa-ckujet",
+        }),
+      ).not.toThrow();
+    });
+
+    it("rewrites extensionless paths to index.html", () => {
+      const { stack, zone } = makeStack();
+
+      new JaypieWebDeploymentBucket(stack, "Web", {
+        host: "app.example.com",
+        spa: true,
+        zone,
+      });
+      const template = Template.fromStack(stack);
+      const functions = template.findResources("AWS::CloudFront::Function");
+      const code = Object.values(functions)[0].Properties.FunctionCode;
+
+      const handler = new Function(`${code}; return handler;`)();
+      const rewrite = (uri: string) =>
+        handler({ request: { uri } }).uri as string;
+
+      expect(rewrite("/")).toBe("/index.html");
+      expect(rewrite("/jobs")).toBe("/index.html");
+      expect(rewrite("/jobs/")).toBe("/index.html");
+      expect(rewrite("/jobs/42")).toBe("/index.html");
+      expect(rewrite("/assets/index-a1b2c3.js")).toBe(
+        "/assets/index-a1b2c3.js",
+      );
+      expect(rewrite("/favicon.ico")).toBe("/favicon.ico");
+      expect(rewrite("/index.html")).toBe("/index.html");
+    });
+
+    it("appends the rewrite after caller functionAssociations", () => {
+      const { stack, zone } = makeStack();
+      const custom = new cloudfront.Function(stack, "Custom", {
+        code: cloudfront.FunctionCode.fromInline(
+          "function handler(event) { return event.response; }",
+        ),
+      });
+
+      new JaypieWebDeploymentBucket(stack, "Web", {
+        defaultBehavior: {
+          functionAssociations: [
+            {
+              eventType: cloudfront.FunctionEventType.VIEWER_RESPONSE,
+              function: custom,
+            },
+          ],
+        },
+        host: "app.example.com",
+        spa: true,
+        zone,
+      });
+      const template = Template.fromStack(stack);
+      const config = findDistribution(template).Properties.DistributionConfig;
+
+      const eventTypes = (
+        config.DefaultCacheBehavior.FunctionAssociations as Array<{
+          EventType: string;
+        }>
+      ).map((association) => association.EventType);
+      expect(eventTypes).toEqual(["viewer-response", "viewer-request"]);
+    });
+
+    it("throws when the caller already associates a viewer-request function", () => {
+      const { stack, zone } = makeStack();
+      const custom = new cloudfront.Function(stack, "Custom", {
+        code: cloudfront.FunctionCode.fromInline(
+          "function handler(event) { return event.request; }",
+        ),
+      });
+
+      expect(() => {
+        new JaypieWebDeploymentBucket(stack, "Web", {
+          defaultBehavior: {
+            functionAssociations: [
+              {
+                eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
+                function: custom,
+              },
+            ],
+          },
+          host: "app.example.com",
+          spa: true,
+          zone,
+        });
+      }).toThrow(ConfigurationError);
+    });
+
+    it("creates no function without a distribution", () => {
+      const stack = new Stack();
+
+      const construct = new JaypieWebDeploymentBucket(stack, "Web", {
+        spa: true,
+      });
+      const template = Template.fromStack(stack);
+
+      expect(construct.spaFunction).toBeUndefined();
+      template.resourceCountIs("AWS::CloudFront::Function", 0);
+    });
+  });
+
   describe("Security Headers", () => {
     it("attaches default ResponseHeadersPolicy to default behavior", () => {
       const { stack, zone } = makeStack();

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaypie/mcp",
-  "version": "0.8.127",
+  "version": "0.8.128",
   "description": "Jaypie MCP",
   "repository": {
     "type": "git",

--- a/packages/mcp/release-notes/constructs/1.2.78.md
+++ b/packages/mcp/release-notes/constructs/1.2.78.md
@@ -1,0 +1,57 @@
+---
+version: 1.2.78
+date: 2026-08-04
+summary: JaypieWebDeploymentBucket accepts a defaultBehavior override and an spa prop
+---
+
+## Changes
+
+- `defaultBehavior` overrides the distribution's default behavior. Values
+  merge over the construct's defaults rather than replacing them, so an
+  override names only what it changes and the internally created S3 website
+  origin stays wired up. Covers `functionAssociations`, `edgeLambdas`,
+  `allowedMethods`, `originRequestPolicy`, and `origin` (#487).
+- `spa: true` attaches a viewer-request CloudFront Function to the default
+  behavior that rewrites any URI whose last segment carries no file extension
+  to `/index.html`. The bucket's `websiteErrorDocument` renders an SPA deep
+  link but answers 404, which is correct HTML with the wrong status for
+  crawlers, uptime checks, and clients branching on `res.ok`. The rewrite
+  serves the real index key, so the response is 200. Exposed as
+  `.spaFunction`, named `constructEnvName("<component>-spa")`.
+
+## Notes
+
+The rewrite rides the default behavior alone, so a Lambda surface sharing the
+distribution through `distribution.addBehavior("/app/*", origin)` keeps its
+genuine 404s. A distribution-wide `errorResponses` mapping of 404 to
+`/index.html` cannot make that distinction and would serve the app shell with a
+200 for every miss on those paths.
+
+`spa: true` combined with a caller-supplied viewer-request entry in
+`defaultBehavior.functionAssociations` throws `ConfigurationError` at synth,
+since CloudFront permits one function per event type. Other event types
+compose, with the rewrite appended last.
+
+Both props are opt-in and change nothing for existing stacks.
+
+```typescript
+new JaypieWebDeploymentBucket(this, "App", {
+  component: "app",
+  host: appHost,
+  spa: true,
+  zone,
+});
+
+new JaypieWebDeploymentBucket(this, "Web", {
+  defaultBehavior: {
+    functionAssociations: [
+      {
+        eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
+        function: myFunction,
+      },
+    ],
+  },
+  host: webHost,
+  zone,
+});
+```

--- a/packages/mcp/release-notes/mcp/0.8.128.md
+++ b/packages/mcp/release-notes/mcp/0.8.128.md
@@ -1,0 +1,13 @@
+---
+version: 0.8.128
+date: 2026-08-04
+summary: Document the JaypieWebDeploymentBucket defaultBehavior override and spa prop
+---
+
+## Changes
+
+- `skill("web")` documents `defaultBehavior` as a merged partial override of
+  the distribution's default behavior
+- `skill("web")` adds a Single-Page App section covering `spa: true`, why the
+  website error document answers 404, why the rewrite is scoped to the default
+  behavior, and the viewer-request conflict that throws at synth

--- a/packages/mcp/skills/web.md
+++ b/packages/mcp/skills/web.md
@@ -39,15 +39,17 @@ new JaypieWebDeploymentBucket(this, "Web", {
 | `zone` | `string \| IHostedZone \| JaypieHostedZone` | `CDK_ENV_WEB_HOSTED_ZONE \|\| CDK_ENV_HOSTED_ZONE` |
 | `certificate` | `boolean \| ICertificate` | `true` (creates via `resolveCertificate`) |
 | `component` | `string` | `"web"` — name component for the default bucket name |
+| `defaultBehavior` | `Partial<BehaviorOptions>` | undefined — merged over the construct's default behavior; keys given win |
 | `destination` | `LambdaDestination \| boolean` | `true` (Datadog forwarder for access-log bucket notifications) |
 | `logBucket` | `IBucket \| string \| { exportName } \| true` | undefined — creates a new bucket if `destination !== false` |
 | `name` | `string` | `constructEnvName(component)` |
 | `responseHeadersPolicy` | `IResponseHeadersPolicy` | undefined — full override; bypasses default security headers |
 | `roleTag` | `string` | `CDK.ROLE.HOSTING` |
 | `securityHeaders` | `boolean \| SecurityHeadersOverrides` | `true` |
+| `spa` | `boolean` | `false` — viewer-request rewrite of extension-less URIs to `/index.html` |
 | `waf` | `boolean \| JaypieWebDeploymentBucketWafConfig` | `false` (when enabled, WAF name defaults to construct id) |
 
-Also accepts all `s3.BucketProps` — the bucket defaults to `autoDeleteObjects: true`, `publicReadAccess: true`, `websiteIndexDocument: "index.html"`, `websiteErrorDocument: "index.html"` (SPA-friendly).
+Also accepts all `s3.BucketProps` — the bucket defaults to `autoDeleteObjects: true`, `publicReadAccess: true`, `websiteIndexDocument: "index.html"`, `websiteErrorDocument: "index.html"` — which renders an SPA deep link but answers 404; see [Single-Page App](#single-page-app).
 
 ### Bucket Name
 
@@ -70,6 +72,40 @@ Changing `component` or `name` on a deployed stack renames the bucket, which rep
 const web = new JaypieWebDeploymentBucket(this, "Web", { host, zone });
 web.distribution!.addBehavior("/app/*", new origins.FunctionUrlOrigin(api.functionUrl));
 ```
+
+`defaultBehavior` merges over those defaults instead of replacing them, so an override names only what it changes and the S3 website origin stays wired up. Keys the override omits keep the construct's value; an explicit `undefined` is ignored rather than erasing a default.
+
+```typescript
+new JaypieWebDeploymentBucket(this, "Web", {
+  host, zone,
+  defaultBehavior: {
+    allowedMethods: cloudfront.AllowedMethods.ALLOW_ALL,
+    functionAssociations: [
+      { eventType: cloudfront.FunctionEventType.VIEWER_REQUEST, function: myFunction },
+    ],
+  },
+});
+```
+
+### Single-Page App
+
+An SPA has one `index.html`, so a deep link like `/jobs` has no S3 key behind it. The website error document renders the shell correctly but answers **404** — invisible to a human, wrong for crawlers, uptime checks pointed at a deep link, and any client branching on `res.ok`.
+
+`spa: true` attaches a viewer-request CloudFront Function that rewrites any URI whose last segment has no file extension to `/index.html`, so S3 serves the real index key and returns 200.
+
+```typescript
+new JaypieWebDeploymentBucket(this, "App", {
+  component: "app",
+  host: appHost,
+  spa: true,
+  zone,
+});
+```
+
+- Scoped to the **default behavior** only. Paths registered with `addBehavior("/app/*", ...)` never reach the function, so a Lambda surface sharing the distribution keeps its genuine 404s. This is why a distribution-wide `errorResponses` 404→`/index.html` mapping is the wrong tool on a shared distribution: it would rewrite those into 200s serving the app shell.
+- The function is named `constructEnvName("<component>-spa")`, so `component` disambiguates two instances in one account exactly as it does the bucket name.
+- Exposed as `.spaFunction`. No distribution (no `host`/`zone`) means no function.
+- Combining `spa: true` with a caller-supplied **viewer-request** association throws `ConfigurationError` at synth; CloudFront permits one function per event type. Other event types (for example viewer-response) compose, with the rewrite appended last.
 
 ### Security Headers
 

--- a/workspaces/documentation/src/content/docs/docs/packages/constructs.md
+++ b/workspaces/documentation/src/content/docs/docs/packages/constructs.md
@@ -247,6 +247,38 @@ const web = new JaypieWebDeploymentBucket(this, "Web", { host, zone });
 web.distribution!.addBehavior("/app/*", new origins.FunctionUrlOrigin(api.functionUrl));
 ```
 
+Pass `defaultBehavior` to override the default behavior. It merges over the construct's values rather than replacing them, so an override names only what it changes and the S3 website origin stays wired up:
+
+```typescript
+new JaypieWebDeploymentBucket(this, "Web", {
+  host, zone,
+  defaultBehavior: {
+    functionAssociations: [
+      { eventType: cloudfront.FunctionEventType.VIEWER_REQUEST, function: myFunction },
+    ],
+  },
+});
+```
+
+### Single-Page App
+
+A single-page app has one `index.html`, so a deep link like `/jobs` has no S3 key behind it. The website error document renders the shell correctly but the response carries a **404** status — invisible to a human, wrong for crawlers, uptime checks, and any client branching on `res.ok`.
+
+`spa: true` attaches a viewer-request CloudFront Function that rewrites any URI whose last segment has no file extension to `/index.html`, so S3 serves the real index key and returns 200:
+
+```typescript
+new JaypieWebDeploymentBucket(this, "App", {
+  component: "app",
+  host: appHost,
+  spa: true,
+  zone,
+});
+```
+
+The function is scoped to the default behavior, so paths registered with `addBehavior` keep their genuine 404s. This is why a distribution-wide `errorResponses` mapping is the wrong tool when a Lambda surface shares the distribution: it would rewrite those 404s into 200s serving the app shell.
+
+Combining `spa: true` with a caller-supplied viewer-request association throws `ConfigurationError` at synth, since CloudFront permits one function per event type. Other event types compose, with the rewrite appended last.
+
 ### Stable Outputs for cdk-outputs.json
 
 Call `exportOutputs()` to emit stack-level `CfnOutput`s with hash-free logical IDs (`DestinationBucketName`, `DestinationBucketDeployRoleArn`, `DistributionId`, `CertificateArn`):


### PR DESCRIPTION
Closes #487.

## Problem

`JaypieWebDeploymentBucket` built its default behavior inline with no caller input, so there was no supported way to attach a CloudFront Function to it. The only route was an L1 `addPropertyOverride` escape hatch.

The default behavior is the right scope for an SPA route rewrite. Since #479 the distribution can carry `/app/*` and `/auth/*` behaviors alongside the static site, so a distribution-wide `errorResponses` mapping of 404 to `/index.html` would rewrite those surfaces' genuine 404s into 200s serving the app shell. A function on the default behavior alone never sees those paths.

Without a rewrite, every SPA deep link answers **404** with correct HTML — invisible to a human, wrong for crawlers, uptime checks pointed at a deep link, and any client branching on `res.ok`.

## Changes

**`defaultBehavior?: Partial<cloudfront.BehaviorOptions>`** merges over the computed default behavior. Caller keys win; keys omitted keep the construct's values (S3 website origin, environment-aware cache policy, response headers policy, HTTPS redirect). Explicitly-undefined keys are stripped so an override never erases a default it did not name.

Merge rather than replace — unlike `JaypieDistribution`, where `defaultBehavior` is a full replacement — because the S3 website origin is created internally and a replacement would force the caller to rebuild it.

**`spa?: boolean`** attaches a viewer-request CloudFront Function (`JS_2_0`) rewriting any URI whose last segment carries no file extension to `/index.html`, so S3 serves the real index key and returns 200. Named `constructEnvName("<component>-spa")` and exposed as `.spaFunction`. No distribution (no `host`/`zone`) means no function.

`spa: true` combined with a caller-supplied **viewer-request** association throws `ConfigurationError` at synth, since CloudFront permits one function per event type. Other event types compose, with the rewrite appended last.

```typescript
new JaypieWebDeploymentBucket(this, "App", {
  component: "app",
  host: appHost,
  spa: true,
  zone,
});
```

## Tests

12 cases added, written first and confirmed failing (9 red) before implementation. The rewrite test evaluates the synthesized function source directly:

| URI | Result |
|-----|--------|
| `/`, `/jobs`, `/jobs/`, `/jobs/42` | `/index.html` |
| `/assets/index-a1b2c3.js`, `/favicon.ico`, `/index.html` | unchanged |

Full suite: 4399 passed, typecheck clean, format clean.

## Compatibility

Both props are opt-in; existing stacks synthesize unchanged.

## Docs and versioning

`skill("web")`, `packages/constructs/CLAUDE.md`, and the jaypie.net constructs page. `@jaypie/constructs` 1.2.78 and `@jaypie/mcp` 0.8.128 with release notes; `jaypie` depends on neither, so no umbrella range sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5CdZ4JxG5NDv2jyTgijbH